### PR TITLE
⬆️ Upgrade: Modernize CI and align with Apertix build infrastructure

### DIFF
--- a/.github/workflows/api-compile.yml
+++ b/.github/workflows/api-compile.yml
@@ -4,20 +4,20 @@ on:
   push:
     branches:
       - master
-    paths: 
+    paths:
       - 'API/src/**'
-  
+
 jobs:
   build:
 
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
-    - name: Set up JDK 11
-      uses: actions/setup-java@v2
+    - uses: actions/checkout@v4
+    - name: Set up JDK 17
+      uses: actions/setup-java@v4
       with:
-        java-version: '11'
-        distribution: 'adopt'
+        java-version: '17'
+        distribution: 'temurin'
     - name: Build with Maven
       run: mvn -B -pl API compile | egrep -v "^\[INFO\].*?Download.*?http"

--- a/.github/workflows/api-snapshot.yml
+++ b/.github/workflows/api-snapshot.yml
@@ -4,20 +4,20 @@ on:
   push:
     branches:
       - master
-    paths: 
+    paths:
       - 'API/pom*'
-      
+
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
-      - name: Set up JDK 11
-        uses: actions/setup-java@v2
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
         with:
-          java-version: '11'
-          distribution: 'adopt'
+          java-version: '17'
+          distribution: 'temurin'
           server-id: ossrh
           server-username: MAVEN_USERNAME
           server-password: MAVEN_PASSWORD

--- a/.github/workflows/eval.yml
+++ b/.github/workflows/eval.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: New File
         run: |

--- a/.github/workflows/ide-compile.yml
+++ b/.github/workflows/ide-compile.yml
@@ -1,23 +1,23 @@
 name: Compile IDE
 
-on: 
-  push: 
+on:
+  push:
     branches:
       - master
     paths:
       - 'IDE/src/**'
-  
+
 jobs:
   build:
 
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
-    - name: Set up JDK 11
-      uses: actions/setup-java@v2
+    - uses: actions/checkout@v4
+    - name: Set up JDK 17
+      uses: actions/setup-java@v4
       with:
-        java-version: '11'
-        distribution: 'adopt'
+        java-version: '17'
+        distribution: 'temurin'
     - name: Build with Maven
       run: mvn -B compile | egrep -v "^\[INFO\].*?Download.*?http"

--- a/.github/workflows/ide-snapshot.yml
+++ b/.github/workflows/ide-snapshot.yml
@@ -6,20 +6,20 @@ on:
       - master
     paths:
       - 'IDE/pom*'
-  
+
 jobs:
   build:
 
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
-    
-    - name: Set up JDK 11
-      uses: actions/setup-java@v2
+    - uses: actions/checkout@v4
+
+    - name: Set up JDK 17
+      uses: actions/setup-java@v4
       with:
-        java-version: '11'
-        distribution: 'adopt'
+        java-version: '17'
+        distribution: 'temurin'
         server-id: ossrh
         server-username: MAVEN_USERNAME
         server-password: MAVEN_PASSWORD
@@ -43,10 +43,10 @@ jobs:
 # --------------------------------------- macOS
     - name: macOS Build with Maven
       run: mvn -B -pl IDE -P complete-mac-jar clean package | egrep -v "^\[INFO\].*?Download.*?http"
-      
+
     - name: Remove thin jar
       run: rm ${{ github.workspace }}/IDE/target/sikulixide-2.1.0-SNAPSHOT.jar
-      
+
     - name: Rename fat jar
       run: mv ${{ github.workspace }}/IDE/target/sikulixide-2.1.0-SNAPSHOT-complete-mac.jar ${{ github.workspace }}/IDE/target/sikulixmac-2.1.0-SNAPSHOT.jar
 

--- a/API/pom.xml
+++ b/API/pom.xml
@@ -55,7 +55,7 @@
     <timestamp>${maven.build.timestamp}</timestamp>
     <maven.build.timestamp.format>yyyy-MM-dd_HH:mm</maven.build.timestamp.format>
     <!--suppress UnresolvedMavenProperty -->
-    <buildnumber>${env.TRAVIS_BUILD_NUMBER}</buildnumber>
+    <buildnumber>${env.GITHUB_RUN_NUMBER}</buildnumber>
   </properties>
 
   <dependencies>
@@ -101,7 +101,7 @@
     <dependency>
       <groupId>net.java.dev.jna</groupId>
       <artifactId>jna-platform</artifactId>
-      <version>5.6.0</version>
+      <version>5.14.0</version>
       <!--License LGPL, version 2.1 - Apache License v2.0-->
     </dependency>
     <dependency>
@@ -154,7 +154,7 @@
         <plugins>
           <plugin>
             <artifactId>maven-assembly-plugin</artifactId>
-            <version>3.1.1</version>
+            <version>3.7.1</version>
             <configuration>
               <archive>
                 <manifest>
@@ -188,7 +188,7 @@
         <plugins>
           <plugin>
             <artifactId>maven-assembly-plugin</artifactId>
-            <version>3.1.1</version>
+            <version>3.7.1</version>
             <configuration>
               <archive>
                 <manifest>
@@ -222,7 +222,7 @@
         <plugins>
           <plugin>
             <artifactId>maven-assembly-plugin</artifactId>
-            <version>3.1.1</version>
+            <version>3.7.1</version>
             <configuration>
               <archive>
                 <manifest>
@@ -256,7 +256,7 @@
         <plugins>
           <plugin>
             <artifactId>maven-assembly-plugin</artifactId>
-            <version>3.1.1</version>
+            <version>3.7.1</version>
             <configuration>
               <archive>
                 <manifest>
@@ -291,7 +291,7 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-gpg-plugin</artifactId>
-            <version>1.6</version>
+            <version>3.2.8</version>
             <executions>
               <execution>
                 <id>sign-artifacts</id>
@@ -316,7 +316,7 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-source-plugin</artifactId>
-            <version>3.1.0</version>
+            <version>3.4.0</version>
             <configuration>
               <excludeResources>true</excludeResources>
             </configuration>
@@ -343,10 +343,10 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-javadoc-plugin</artifactId>
-            <version>3.1.1</version>
+            <version>3.12.0</version>
             <configuration>
               <use>false</use>
-              <source>1.8</source>
+              <source>17</source>
               <excludePackageNames>
                 org.opencv:jxgrabkey:com.tulskiy.keymaster:se.vidstige.jadb
               </excludePackageNames>
@@ -377,7 +377,7 @@
           <plugin>
             <groupId>org.sonatype.plugins</groupId>
             <artifactId>nexus-staging-maven-plugin</artifactId>
-            <version>1.6.8</version>
+            <version>1.7.0</version>
             <extensions>true</extensions>
             <configuration>
               <serverId>ossrh</serverId>
@@ -410,15 +410,15 @@
     <plugins>
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.8.1</version>
+        <version>3.14.0</version>
         <configuration>
-          <source>1.8</source>
-          <target>1.8</target>
+          <source>17</source>
+          <target>17</target>
         </configuration>
       </plugin>
       <plugin>
         <artifactId>maven-jar-plugin</artifactId>
-        <version>3.1.2</version>
+        <version>3.4.2</version>
         <configuration>
           <archive>
             <manifest>


### PR DESCRIPTION
![Upgrade](https://img.shields.io/badge/type-upgrade-blue?style=for-the-badge)
![Java 17](https://img.shields.io/badge/Java-17-orange?style=for-the-badge&logo=openjdk)
![CI/CD](https://img.shields.io/badge/CI%2FCD-GitHub%20Actions-black?style=for-the-badge&logo=github-actions)
![Merged](https://img.shields.io/badge/status-merged-purple?style=for-the-badge)

---

> [!IMPORTANT]
> **Mandatory upgrade.** Apertix 4.10.0-0 (our OpenCV dependency) is compiled with Java 17. Running it on Java 11 causes `UnsupportedClassVersionError`. This PR aligns all CI and build config with the new requirement.

---

## Summary

Modernize all GitHub Actions workflows and `API/pom.xml` to match the infrastructure validated through [24 PRs on Apertix](https://github.com/julienmerconsulting/Apertix/pulls?q=is%3Apr+is%3Aclosed).

### Workflows (5 files)

| Component | Before | After |
|-----------|--------|-------|
| `actions/checkout` | `v2` | `v4` |
| `actions/setup-java` | `v2` | `v4` |
| `java-version` | `11` | `17` |
| `distribution` | `adopt` (EOL) | `temurin` |

### API/pom.xml

| Component | Before | After | Reason |
|-----------|--------|-------|--------|
| Compiler source/target | `1.8` | `17` | Apertix 4.10.0-0 requires Java 17 |
| Javadoc source | `1.8` | `17` | Align with compiler |
| `jna-platform` | `5.6.0` | `5.14.0` | Match Apertix (glibc + Apple Silicon) |
| `maven-compiler-plugin` | `3.8.1` | `3.14.0` | — |
| `maven-assembly-plugin` | `3.1.1` | `3.7.1` | — |
| `maven-jar-plugin` | `3.1.2` | `3.4.2` | — |
| `maven-gpg-plugin` | `1.6` | `3.2.8` | — |
| `maven-source-plugin` | `3.1.0` | `3.4.0` | — |
| `maven-javadoc-plugin` | `3.1.1` | `3.12.0` | — |
| `nexus-staging-maven-plugin` | `1.6.8` | `1.7.0` | — |
| Build number env var | `TRAVIS_BUILD_NUMBER` | `GITHUB_RUN_NUMBER` | Travis CI → GitHub Actions |

### Not changed (intentionally)

- `IDE/pom.xml` — follow-up scope
- Runtime deps (commons-cli, tess4j, jython) — no bumps needed
- `jaxb-api 2.3.1` — already declared, required for Java 11+

### Scale

```
+47 / -47 across 6 files (1 commit)
```