### PR TITLE
✨ Enhancement: Fix OpenCV native loading + DPI-aware multi-resolution matching pipeline

### DIFF
--- a/API/src/main/java/org/opencv/core/Core.java
+++ b/API/src/main/java/org/opencv/core/Core.java
@@ -16,11 +16,11 @@ import org.opencv.utils.Converters;
 
 public class Core {
     // these constants are wrapped inside functions to prevent inlining
-    private static String getVersion() { return "4.5.4"; }
-    private static String getNativeLibraryName() { return "opencv_java454"; }
+    private static String getVersion() { return "4.10.0"; }
+    private static String getNativeLibraryName() { return "opencv_java4100"; }
     private static int getVersionMajorJ() { return 4; }
-    private static int getVersionMinorJ() { return 5; }
-    private static int getVersionRevisionJ() { return 4; }
+    private static int getVersionMinorJ() { return 10; }
+    private static int getVersionRevisionJ() { return 0; }
     private static String getVersionStatusJ() { return ""; }
 
     public static final String VERSION = getVersion();

--- a/API/src/main/java/org/sikuli/script/Finder.java
+++ b/API/src/main/java/org/sikuli/script/Finder.java
@@ -686,9 +686,16 @@ public class Finder implements Iterator<Match> {
      */
     private static int getSystemDpi() {
       try {
-        return Toolkit.getDefaultToolkit().getScreenResolution();
+        java.awt.GraphicsDevice gd = java.awt.GraphicsEnvironment.getLocalGraphicsEnvironment()
+            .getDefaultScreenDevice();
+        double scale = gd.getDefaultConfiguration().getDefaultTransform().getScaleX();
+        return (int) Math.round(96 * scale);
       } catch (Exception e) {
-        return 96; // valeur par defaut
+        try {
+          return Toolkit.getDefaultToolkit().getScreenResolution();
+        } catch (Exception e2) {
+          return 96; // valeur par defaut
+        }
       }
     }
 
@@ -697,12 +704,25 @@ public class Finder implements Iterator<Match> {
      * Retourne 1.0 si pas de difference ou si les DPI ne sont pas disponibles.
      */
     private static double getDpiRatio(FindInput2 findInput) {
-      Image targetImg = findInput.getTargetImage();
-      int templateDpi = getDpiFromImage(targetImg);
-      if (templateDpi <= 0) {
-        return 1.0;
-      }
       int screenDpi = getSystemDpi();
+      int templateDpi = -1;
+
+      // 1. In-memory DPI from Image object (set at capture time)
+      Image targetImg = findInput.getTargetImage();
+      if (targetImg != null && targetImg.getCaptureDpi() > 0) {
+        templateDpi = targetImg.getCaptureDpi();
+      }
+
+      // 2. Fallback: read DPI from PNG metadata (pHYs chunk)
+      if (templateDpi <= 0) {
+        templateDpi = getDpiFromImage(targetImg);
+      }
+
+      // 3. Fallback: assume 96 DPI (legacy templates, 100% scaling)
+      if (templateDpi <= 0) {
+        templateDpi = 96;
+      }
+
       if (screenDpi == templateDpi) {
         return 1.0;
       }
@@ -885,6 +905,7 @@ public class Finder implements Iterator<Match> {
       }
 
       // --- MODE 3 : tolerant match (flou gaussien) ---
+      double originalScore = findInput.getScore();
       if (findResult == null && !findInput.isFindAll() && !findInput.hasMask()) {
         begin_lap = new Date().getTime();
         Mat whatBlur = new Mat();
@@ -893,8 +914,9 @@ public class Finder implements Iterator<Match> {
         Imgproc.GaussianBlur(findWhere, whereBlur, new Size(3, 3), 0);
         mResult = doFindMatch(whatBlur, whereBlur, findInput);
         mMinMax = Core.minMaxLoc(mResult);
-        double tolerantScore = findInput.getScore() * 0.9;
+        double tolerantScore = originalScore * 0.9;
         if (mMinMax.maxVal > tolerantScore) {
+          findInput.setSimilarity(tolerantScore);
           findResult = new FindResult2(mResult, findInput);
           log.trace("OculiX Mode 3 tolerant: match %%%.4f (seuil=%%%.4f) %d msec",
               mMinMax.maxVal * 100, tolerantScore * 100, new Date().getTime() - begin_lap);
@@ -914,8 +936,9 @@ public class Finder implements Iterator<Match> {
           Mat mResultGray = Commons.getNewMat();
           Imgproc.matchTemplate(whereGray, whatGray, mResultGray, Imgproc.TM_CCOEFF_NORMED);
           mMinMax = Core.minMaxLoc(mResultGray);
-          double smartScore = findInput.getScore() * 0.85;
+          double smartScore = originalScore * 0.85;
           if (mMinMax.maxVal > smartScore) {
+            findInput.setSimilarity(smartScore);
             findResult = new FindResult2(mResultGray, findInput);
             log.trace("OculiX Mode 4 smart: match %%%.4f (seuil=%%%.4f) %d msec",
                 mMinMax.maxVal * 100, smartScore * 100, new Date().getTime() - begin_lap);
@@ -925,6 +948,37 @@ public class Finder implements Iterator<Match> {
         }
         whatGray.release();
         whereGray.release();
+      }
+      // --- MODE 5 : multi-scale brute-force (dernier recours) ---
+      if (findResult == null && !findInput.isFindAll() && !findInput.hasMask()) {
+        double[] commonScales = {1.25, 1.5, 1.75, 2.0, 0.8, 0.67, 0.5};
+        double multiScaleScore = originalScore * 0.9;
+        begin_lap = new Date().getTime();
+        for (double scale : commonScales) {
+          Mat mScaled = new Mat();
+          Imgproc.resize(findInput.getTarget(), mScaled, new Size(),
+              scale, scale, Imgproc.INTER_LINEAR);
+          if (mScaled.width() > findWhere.width() || mScaled.height() > findWhere.height()) {
+            mScaled.release();
+            continue;
+          }
+          mResult = doFindMatch(mScaled, findWhere, findInput);
+          mMinMax = Core.minMaxLoc(mResult);
+          if (mMinMax.maxVal > multiScaleScore) {
+            findInput.setSimilarity(multiScaleScore);
+            findResult = new FindResult2(mResult, findInput);
+            log.trace("OculiX Mode 5 multi-scale: match %%%.4f (scale=%.2f) %d msec",
+                mMinMax.maxVal * 100, scale, new Date().getTime() - begin_lap);
+            mScaled.release();
+            break;
+          }
+          mScaled.release();
+        }
+      }
+
+      // Restaurer le seuil original si aucun mode degrade n'a matche
+      if (findResult == null) {
+        findInput.setSimilarity(originalScore);
       }
 
       // ========================================================

--- a/API/src/main/java/org/sikuli/script/Finder.java
+++ b/API/src/main/java/org/sikuli/script/Finder.java
@@ -12,9 +12,17 @@ import org.sikuli.support.devices.IScreen;
 
 import java.awt.Color;
 import java.awt.Rectangle;
+import java.awt.Toolkit;
 import java.awt.image.BufferedImage;
+import java.io.File;
 import java.util.*;
 import java.util.regex.Matcher;
+import javax.imageio.ImageIO;
+import javax.imageio.ImageReader;
+import javax.imageio.metadata.IIOMetadata;
+import javax.imageio.stream.ImageInputStream;
+import org.w3c.dom.Node;
+import org.w3c.dom.NamedNodeMap;
 
 public class Finder implements Iterator<Match> {
 
@@ -188,6 +196,7 @@ public class Finder implements Iterator<Match> {
       }
       _image = aPtn.getImage();
       _findInput.setTarget(possibleImageResizeOrCallback(_image, aPtn.getResize()));
+      _findInput.setTargetImage(_image);
       _findInput.setSimilarity(aPtn.getSimilar());
       _findInput.setIsPattern();
       _results = Finder2.find(_findInput);
@@ -213,6 +222,7 @@ public class Finder implements Iterator<Match> {
     if (img.isValid()) {
       _image = img;
       _findInput.setTarget(possibleImageResizeOrCallback(img));
+      _findInput.setTargetImage(img);
       _findInput.setSimilarity(Settings.MinSimilarity);
       _results = Finder2.find(_findInput);
       currentMatchIndex = 0;
@@ -295,6 +305,7 @@ public class Finder implements Iterator<Match> {
       _pattern = aPtn;
       _image = aPtn.getImage();
       _findInput.setTarget(possibleImageResizeOrCallback(_image, aPtn.getResize()));
+      _findInput.setTargetImage(_image);
       _findInput.setSimilarity(aPtn.getSimilar());
       _findInput.setIsPattern();
       _findInput.setFindAll();
@@ -326,6 +337,7 @@ public class Finder implements Iterator<Match> {
     if (img.isValid()) {
       _image = img;
       _findInput.setTarget(possibleImageResizeOrCallback(img));
+      _findInput.setTargetImage(img);
       _findInput.setSimilarity(Settings.MinSimilarity);
       _findInput.setFindAll();
       Debug timing = Debug.startTimer("Finder.findAll");
@@ -573,6 +585,136 @@ public class Finder implements Iterator<Match> {
 
     private FindInput2 fInput = null;
 
+    // ========================================================
+    // OculiX : lecture DPI depuis les metadonnees PNG
+    // ========================================================
+
+    /**
+     * Lit le DPI horizontal embarque dans les metadonnees d'une image PNG.
+     * Retourne -1 si non disponible.
+     */
+    private static int getDpiFromImage(Image img) {
+      if (img == null || img.getFilename() == null) {
+        return -1;
+      }
+      try {
+        File file = new File(img.getFilename());
+        if (!file.exists()) {
+          return -1;
+        }
+        ImageInputStream iis = ImageIO.createImageInputStream(file);
+        if (iis == null) {
+          return -1;
+        }
+        Iterator<ImageReader> readers = ImageIO.getImageReaders(iis);
+        if (!readers.hasNext()) {
+          iis.close();
+          return -1;
+        }
+        ImageReader reader = readers.next();
+        reader.setInput(iis);
+        IIOMetadata metadata = reader.getImageMetadata(0);
+        if (metadata == null) {
+          iis.close();
+          return -1;
+        }
+        // Parcourir les metadonnees standard pour trouver le DPI
+        String[] formatNames = metadata.getMetadataFormatNames();
+        for (String formatName : formatNames) {
+          Node root = metadata.getAsTree(formatName);
+          int dpi = searchDpiInNode(root);
+          if (dpi > 0) {
+            iis.close();
+            return dpi;
+          }
+        }
+        iis.close();
+      } catch (Exception e) {
+        log.trace("getDpiFromImage: erreur lecture DPI: %s", e.getMessage());
+      }
+      return -1;
+    }
+
+    /**
+     * Parcourt recursivement les noeuds XML des metadonnees
+     * pour trouver la resolution horizontale (DPI).
+     */
+    private static int searchDpiInNode(Node node) {
+      if (node == null) {
+        return -1;
+      }
+      // Chercher dans les noeuds pHYs (PNG) ou HorizontalPixelSize
+      String nodeName = node.getNodeName();
+      if ("pHYs".equals(nodeName)) {
+        NamedNodeMap attrs = node.getAttributes();
+        if (attrs != null) {
+          Node ppux = attrs.getNamedItem("pixelsPerUnitXAxis");
+          Node unit = attrs.getNamedItem("unitSpecifier");
+          if (ppux != null && unit != null && "meter".equals(unit.getNodeValue())) {
+            int ppu = Integer.parseInt(ppux.getNodeValue());
+            return (int) Math.round(ppu / 39.3701); // metres vers pouces
+          }
+        }
+      }
+      if ("HorizontalPixelSize".equals(nodeName)) {
+        NamedNodeMap attrs = node.getAttributes();
+        if (attrs != null) {
+          Node val = attrs.getNamedItem("value");
+          if (val != null) {
+            double mmPerPixel = Double.parseDouble(val.getNodeValue());
+            if (mmPerPixel > 0) {
+              return (int) Math.round(25.4 / mmPerPixel);
+            }
+          }
+        }
+      }
+      // Parcours recursif des enfants
+      Node child = node.getFirstChild();
+      while (child != null) {
+        int dpi = searchDpiInNode(child);
+        if (dpi > 0) {
+          return dpi;
+        }
+        child = child.getNextSibling();
+      }
+      return -1;
+    }
+
+    /**
+     * Recupere le DPI systeme courant.
+     * 96 = scaling 100%, 120 = 125%, 144 = 150%, etc.
+     */
+    private static int getSystemDpi() {
+      try {
+        return Toolkit.getDefaultToolkit().getScreenResolution();
+      } catch (Exception e) {
+        return 96; // valeur par defaut
+      }
+    }
+
+    /**
+     * Calcule le ratio DPI entre l'ecran courant et l'image template.
+     * Retourne 1.0 si pas de difference ou si les DPI ne sont pas disponibles.
+     */
+    private static double getDpiRatio(FindInput2 findInput) {
+      Image targetImg = findInput.getTargetImage();
+      int templateDpi = getDpiFromImage(targetImg);
+      if (templateDpi <= 0) {
+        return 1.0;
+      }
+      int screenDpi = getSystemDpi();
+      if (screenDpi == templateDpi) {
+        return 1.0;
+      }
+      double ratio = (double) screenDpi / templateDpi;
+      log.trace("OculiX DPI-aware: template=%d dpi, ecran=%d dpi, ratio=%.4f", templateDpi, screenDpi, ratio);
+      return ratio;
+    }
+
+    // ========================================================
+    // Fin OculiX DPI
+    // ========================================================
+
     protected static FindResult2 find(FindInput2 findInput) {
       findInput.setAttributes();
       Finder2 finder2 = new Finder2();
@@ -710,6 +852,84 @@ public class Finder implements Iterator<Match> {
           findResult = new FindResult2(mResult, findInput);
         }
       }
+
+      // ========================================================
+      // OculiX : pipeline cascade multi-mode
+      // Mode 1 (ci-dessus) = match exact standard
+      // Mode 2 = DPI-aware scale
+      // Mode 3 = tolerant match (GaussianBlur)
+      // Mode 4 = smart match (grayscale)
+      // Mode 5 = relative search (gere au niveau Region/Pattern)
+      // ========================================================
+
+      // --- MODE 2 : DPI-aware scale ---
+      if (findResult == null && !findInput.isFindAll()) {
+        double dpiRatio = getDpiRatio(findInput);
+        if (dpiRatio != 1.0) {
+          begin_lap = new Date().getTime();
+          Mat scaledTarget = new Mat();
+          Imgproc.resize(findInput.getTarget(), scaledTarget, new Size(),
+              dpiRatio, dpiRatio, Imgproc.INTER_LINEAR);
+          // Verifier que le template redimensionne tient dans la source
+          if (scaledTarget.width() <= findWhere.width() && scaledTarget.height() <= findWhere.height()) {
+            mResult = doFindMatch(scaledTarget, findWhere, findInput);
+            mMinMax = Core.minMaxLoc(mResult);
+            if (mMinMax.maxVal > findInput.getScore()) {
+              findResult = new FindResult2(mResult, findInput);
+              log.trace("OculiX Mode 2 DPI-aware: match %%%.4f (ratio=%.4f) %d msec",
+                  mMinMax.maxVal * 100, dpiRatio, new Date().getTime() - begin_lap);
+            }
+          }
+          scaledTarget.release();
+        }
+      }
+
+      // --- MODE 3 : tolerant match (flou gaussien) ---
+      if (findResult == null && !findInput.isFindAll() && !findInput.hasMask()) {
+        begin_lap = new Date().getTime();
+        Mat whatBlur = new Mat();
+        Mat whereBlur = new Mat();
+        Imgproc.GaussianBlur(findInput.getTarget(), whatBlur, new Size(3, 3), 0);
+        Imgproc.GaussianBlur(findWhere, whereBlur, new Size(3, 3), 0);
+        mResult = doFindMatch(whatBlur, whereBlur, findInput);
+        mMinMax = Core.minMaxLoc(mResult);
+        double tolerantScore = findInput.getScore() * 0.9;
+        if (mMinMax.maxVal > tolerantScore) {
+          findResult = new FindResult2(mResult, findInput);
+          log.trace("OculiX Mode 3 tolerant: match %%%.4f (seuil=%%%.4f) %d msec",
+              mMinMax.maxVal * 100, tolerantScore * 100, new Date().getTime() - begin_lap);
+        }
+        whatBlur.release();
+        whereBlur.release();
+      }
+
+      // --- MODE 4 : smart match (grayscale) ---
+      if (findResult == null && !findInput.isFindAll() && !findInput.isGray() && !findInput.hasMask()) {
+        begin_lap = new Date().getTime();
+        Mat whatGray = new Mat();
+        Mat whereGray = new Mat();
+        try {
+          Imgproc.cvtColor(findInput.getTarget(), whatGray, Imgproc.COLOR_BGR2GRAY);
+          Imgproc.cvtColor(findWhere, whereGray, Imgproc.COLOR_BGR2GRAY);
+          Mat mResultGray = Commons.getNewMat();
+          Imgproc.matchTemplate(whereGray, whatGray, mResultGray, Imgproc.TM_CCOEFF_NORMED);
+          mMinMax = Core.minMaxLoc(mResultGray);
+          double smartScore = findInput.getScore() * 0.85;
+          if (mMinMax.maxVal > smartScore) {
+            findResult = new FindResult2(mResultGray, findInput);
+            log.trace("OculiX Mode 4 smart: match %%%.4f (seuil=%%%.4f) %d msec",
+                mMinMax.maxVal * 100, smartScore * 100, new Date().getTime() - begin_lap);
+          }
+        } catch (Exception e) {
+          log.trace("OculiX Mode 4 smart: erreur conversion grayscale: %s", e.getMessage());
+        }
+        whatGray.release();
+        whereGray.release();
+      }
+
+      // ========================================================
+      // Fin OculiX pipeline cascade
+      // ========================================================
       log.trace("doFindImage: end %d msec", new Date().getTime() - begin_find);
       return findResult;
     }
@@ -1053,6 +1273,18 @@ public class Finder implements Iterator<Match> {
     }
 
     private Image image = null;
+
+    // --- OculiX : reference vers l'Image source pour lecture DPI ---
+    private Image targetImage = null;
+
+    public void setTargetImage(Image img) {
+      this.targetImage = img;
+    }
+
+    public Image getTargetImage() {
+      return targetImage;
+    }
+    // --- fin OculiX ---
 
     private double similarity = 0.7;
 

--- a/API/src/main/java/org/sikuli/script/Image.java
+++ b/API/src/main/java/org/sikuli/script/Image.java
@@ -170,6 +170,7 @@ public class Image extends Element {
    */
   public Image(ScreenImage img) {
     this(img.getImage(), null);
+    injectSystemDpi();
   }
 
   /**
@@ -182,6 +183,22 @@ public class Image extends Element {
    */
   public Image(ScreenImage img, String name) {
     this(img.getImage(), name);
+    injectSystemDpi();
+  }
+
+  private void injectSystemDpi() {
+    try {
+      java.awt.GraphicsDevice gd = java.awt.GraphicsEnvironment.getLocalGraphicsEnvironment()
+          .getDefaultScreenDevice();
+      double scale = gd.getDefaultConfiguration().getDefaultTransform().getScaleX();
+      this.captureDpi = (int) Math.round(96 * scale);
+    } catch (Exception e) {
+      try {
+        this.captureDpi = java.awt.Toolkit.getDefaultToolkit().getScreenResolution();
+      } catch (Exception e2) {
+        this.captureDpi = 96;
+      }
+    }
   }
 
   /**
@@ -332,6 +349,17 @@ public class Image extends Element {
 
   private BufferedImage bimg = null;
   private int bsize = 0;
+
+  // OculiX: DPI at which this image was captured (-1 = unknown)
+  private int captureDpi = -1;
+
+  public int getCaptureDpi() {
+    return captureDpi;
+  }
+
+  public void setCaptureDpi(int dpi) {
+    this.captureDpi = dpi;
+  }
 
   public static BufferedImage getSubimage(BufferedImage bimg, Rectangle rect) {
     return bimg.getSubimage(rect.x, rect.y, (int) rect.getWidth(), (int) rect.getHeight());
@@ -1088,7 +1116,7 @@ public class Image extends Element {
   public String save(String name, String path) {
     File fImg = new File(path, name);
     try {
-      ImageIO.write(get(), "png", fImg);
+      FileManager.writePngWithDpi(get(), fImg);
       Debug.log(3, "Image::save: %s", fImg);
     } catch (IOException e) {
       Debug.error("Image::save: %s did not work (%s)", fImg, e.getMessage());
@@ -1098,7 +1126,7 @@ public class Image extends Element {
 
   public void save(File imgFile) {
     try {
-      ImageIO.write(get(), "png", imgFile);
+      FileManager.writePngWithDpi(get(), imgFile);
       Debug.log(3, "Image(%s)::save: %s", getName(), imgFile);
     } catch (IOException e) {
       Debug.error("Image(%s)::save: %s did not work (%s)", getName(), imgFile, e.getMessage());

--- a/API/src/main/java/org/sikuli/script/ScreenImage.java
+++ b/API/src/main/java/org/sikuli/script/ScreenImage.java
@@ -205,7 +205,7 @@ public class ScreenImage {
 	private void storeImage(File image) throws IOException {
 		String filename = image.getAbsolutePath();
 		if (!filename.equals(this.filename) || image.getName().startsWith("_")) {
-			ImageIO.write(bimg, "png", image);
+			FileManager.writePngWithDpi(bimg, image);
 			this.filename = filename;
 		}
 	}
@@ -236,7 +236,7 @@ public class ScreenImage {
 
   public void saveLastScreenImage(File fPath) {
     try {
-  		ImageIO.write(bimg, "png", new File(fPath, "LastScreenImage.png"));
+  		FileManager.writePngWithDpi(bimg, new File(fPath, "LastScreenImage.png"));
     } catch (Exception ex) {}
   }
 
@@ -293,7 +293,7 @@ public class ScreenImage {
 	public String saveInto(File path) {
 		File fImage = new File(path, String.format("%s-%d.png", "sikuliximage", new Date().getTime()));
 		try {
-			ImageIO.write(bimg, FilenameUtils.getExtension(fImage.getName()), fImage);
+			FileManager.writePngWithDpi(bimg, fImage);
 			Debug.log(3, "ScreenImage::saveImage: %s", fImage);
 		} catch (Exception ex) {
 			Debug.error("ScreenImage::saveInto: did not work: %s (%s)", fImage, ex.getMessage());

--- a/API/src/main/java/org/sikuli/support/Commons.java
+++ b/API/src/main/java/org/sikuli/support/Commons.java
@@ -1104,41 +1104,76 @@ public class Commons {
   private static boolean libOpenCVloaded = false;
 
 public static void loadOpenCV() {
-    if (!libOpenCVloaded) {
-        try {
-            // Extraire et charger la DLL depuis le jar (win32-x86-64/)
-            String libName = Core.NATIVE_LIBRARY_NAME;
-            System.loadLibrary(libName);
-            Debug.log(3, "OpenCV: loaded via System.loadLibrary: %s", libName);
-        } catch (Throwable e) {
-            try {
-                // Fallback : extraction manuelle depuis le jar
-                String resource = "win32-x86-64/" + Core.NATIVE_LIBRARY_NAME + ".dll";
-                java.io.InputStream is = Commons.class.getClassLoader().getResourceAsStream(resource);
-                if (is != null) {
-                    File tempDir = getTempFolder();
-                    if (tempDir == null) {
-                        tempDir = new File(System.getProperty("java.io.tmpdir"));
-                    }
-                    File tempLib = new File(tempDir, Core.NATIVE_LIBRARY_NAME + ".dll");
-                    java.io.FileOutputStream fos = new java.io.FileOutputStream(tempLib);
-                    byte[] buf = new byte[8192];
-                    int len;
-                    while ((len = is.read(buf)) > 0) {
-                        fos.write(buf, 0, len);
-                    }
-                    fos.close();
-                    is.close();
-                    System.load(tempLib.getAbsolutePath());
-                    Debug.log(3, "OpenCV: loaded from jar resource: %s", tempLib);
-                }
-            } catch (Throwable e2) {
-                Debug.log(-1, "OpenCV: FAILED to load: %s", e2.getMessage());
-            }
-        }
-        libOpenCVloaded = true;
+    if (libOpenCVloaded) {
+      return;
     }
-}
+    String libName = Core.NATIVE_LIBRARY_NAME;
+
+    // 1. Apertix (nu.pattern.OpenCV) — preferred method
+    try {
+      Class<?> opencvClass = Class.forName(libOpenCVclassref);
+      java.lang.reflect.Method loadLocally = opencvClass.getMethod("loadLocally");
+      loadLocally.invoke(null);
+      libOpenCVloaded = true;
+      Debug.log(3, "OpenCV: loaded via Apertix (%s)", libOpenCVclassref);
+      return;
+    } catch (Throwable e) {
+      Debug.log(3, "OpenCV: Apertix load failed: %s", e.getMessage());
+    }
+
+    // 2. System.loadLibrary (lib already on java.library.path)
+    try {
+      System.loadLibrary(libName);
+      libOpenCVloaded = true;
+      Debug.log(3, "OpenCV: loaded via System.loadLibrary: %s", libName);
+      return;
+    } catch (Throwable e) {
+      Debug.log(3, "OpenCV: System.loadLibrary failed: %s", e.getMessage());
+    }
+
+    // 3. Fallback: extract native lib from jar and load manually
+    try {
+      String resource = null;
+      String fileName = null;
+      if (runningWindows()) {
+        resource = "win32-x86-64/" + libName + ".dll";
+        fileName = libName + ".dll";
+      } else if (runningMac()) {
+        resource = "darwin-x86-64/lib" + libName + ".dylib";
+        fileName = "lib" + libName + ".dylib";
+      } else if (runningLinux()) {
+        resource = "linux-x86-64/lib" + libName + ".so";
+        fileName = "lib" + libName + ".so";
+      }
+      if (resource != null) {
+        java.io.InputStream is = Commons.class.getClassLoader().getResourceAsStream(resource);
+        if (is != null) {
+          File tempDir = getTempFolder();
+          if (tempDir == null) {
+            tempDir = new File(System.getProperty("java.io.tmpdir"));
+          }
+          File tempLib = new File(tempDir, fileName);
+          try (java.io.FileOutputStream fos = new java.io.FileOutputStream(tempLib)) {
+            byte[] buf = new byte[8192];
+            int len;
+            while ((len = is.read(buf)) > 0) {
+              fos.write(buf, 0, len);
+            }
+          } finally {
+            is.close();
+          }
+          System.load(tempLib.getAbsolutePath());
+          libOpenCVloaded = true;
+          Debug.log(3, "OpenCV: loaded from jar resource: %s", tempLib);
+          return;
+        }
+      }
+    } catch (Throwable e) {
+      Debug.log(3, "OpenCV: jar extraction failed: %s", e.getMessage());
+    }
+
+    Debug.log(-1, "OpenCV: FAILED to load native library '%s'", libName);
+  }
 
   private static final String jarLibsPath = "/sikulixlibs/";
   private static List<String> libsLoaded = new ArrayList<>();

--- a/API/src/main/java/org/sikuli/support/Commons.java
+++ b/API/src/main/java/org/sikuli/support/Commons.java
@@ -1104,8 +1104,40 @@ public class Commons {
   private static boolean libOpenCVloaded = false;
 
 public static void loadOpenCV() {
-    // opencv géré par Apertix/JNA
-    libOpenCVloaded = true;
+    if (!libOpenCVloaded) {
+        try {
+            // Extraire et charger la DLL depuis le jar (win32-x86-64/)
+            String libName = Core.NATIVE_LIBRARY_NAME;
+            System.loadLibrary(libName);
+            Debug.log(3, "OpenCV: loaded via System.loadLibrary: %s", libName);
+        } catch (Throwable e) {
+            try {
+                // Fallback : extraction manuelle depuis le jar
+                String resource = "win32-x86-64/" + Core.NATIVE_LIBRARY_NAME + ".dll";
+                java.io.InputStream is = Commons.class.getClassLoader().getResourceAsStream(resource);
+                if (is != null) {
+                    File tempDir = getTempFolder();
+                    if (tempDir == null) {
+                        tempDir = new File(System.getProperty("java.io.tmpdir"));
+                    }
+                    File tempLib = new File(tempDir, Core.NATIVE_LIBRARY_NAME + ".dll");
+                    java.io.FileOutputStream fos = new java.io.FileOutputStream(tempLib);
+                    byte[] buf = new byte[8192];
+                    int len;
+                    while ((len = is.read(buf)) > 0) {
+                        fos.write(buf, 0, len);
+                    }
+                    fos.close();
+                    is.close();
+                    System.load(tempLib.getAbsolutePath());
+                    Debug.log(3, "OpenCV: loaded from jar resource: %s", tempLib);
+                }
+            } catch (Throwable e2) {
+                Debug.log(-1, "OpenCV: FAILED to load: %s", e2.getMessage());
+            }
+        }
+        libOpenCVloaded = true;
+    }
 }
 
   private static final String jarLibsPath = "/sikulixlibs/";

--- a/API/src/main/java/org/sikuli/support/FileManager.java
+++ b/API/src/main/java/org/sikuli/support/FileManager.java
@@ -529,7 +529,7 @@ public class FileManager {
     }
     ImageWriter writer = writers.next();
     ImageWriteParam writeParam = writer.getDefaultWriteParam();
-    ImageTypeSpecifier typeSpec = ImageTypeSpecifier.createFromBufferedImage(img);
+    ImageTypeSpecifier typeSpec = ImageTypeSpecifier.createFromRenderedImage(img);
     IIOMetadata metadata = writer.getDefaultImageMetadata(typeSpec, writeParam);
 
     int dpi;

--- a/API/src/main/java/org/sikuli/support/FileManager.java
+++ b/API/src/main/java/org/sikuli/support/FileManager.java
@@ -9,6 +9,13 @@ import org.sikuli.basics.Settings;
 import org.sikuli.support.gui.SXDialog;
 
 import javax.imageio.ImageIO;
+import javax.imageio.ImageTypeSpecifier;
+import javax.imageio.ImageWriteParam;
+import javax.imageio.ImageWriter;
+import javax.imageio.metadata.IIOMetadata;
+import javax.imageio.metadata.IIOMetadataNode;
+import javax.imageio.stream.ImageOutputStream;
+import javax.imageio.IIOImage;
 import javax.swing.*;
 import java.awt.*;
 import java.awt.image.BufferedImage;
@@ -510,6 +517,59 @@ public class FileManager {
     }
   }
 
+  /**
+   * OculiX: Write a PNG file with DPI metadata (pHYs chunk).
+   * Uses the current system screen resolution as DPI value.
+   */
+  public static void writePngWithDpi(BufferedImage img, File file) throws IOException {
+    Iterator<ImageWriter> writers = ImageIO.getImageWritersByFormatName("png");
+    if (!writers.hasNext()) {
+      ImageIO.write(img, "png", file);
+      return;
+    }
+    ImageWriter writer = writers.next();
+    ImageWriteParam writeParam = writer.getDefaultWriteParam();
+    ImageTypeSpecifier typeSpec = ImageTypeSpecifier.createFromBufferedImage(img);
+    IIOMetadata metadata = writer.getDefaultImageMetadata(typeSpec, writeParam);
+
+    int dpi;
+    try {
+      java.awt.GraphicsDevice gd = java.awt.GraphicsEnvironment.getLocalGraphicsEnvironment()
+          .getDefaultScreenDevice();
+      double scale = gd.getDefaultConfiguration().getDefaultTransform().getScaleX();
+      dpi = (int) Math.round(96 * scale);
+    } catch (Exception e) {
+      try {
+        dpi = Toolkit.getDefaultToolkit().getScreenResolution();
+      } catch (Exception e2) {
+        dpi = 96;
+      }
+    }
+
+    String metaFormat = "javax_imageio_png_1.0";
+    try {
+      IIOMetadataNode root = (IIOMetadataNode) metadata.getAsTree(metaFormat);
+      IIOMetadataNode phys = new IIOMetadataNode("pHYs");
+      int ppu = (int) Math.round(dpi * 39.3701); // DPI to pixels per meter
+      phys.setAttribute("pixelsPerUnitXAxis", String.valueOf(ppu));
+      phys.setAttribute("pixelsPerUnitYAxis", String.valueOf(ppu));
+      phys.setAttribute("unitSpecifier", "meter");
+      root.appendChild(phys);
+      metadata.mergeTree(metaFormat, root);
+    } catch (Exception e) {
+      log(-1, "writePngWithDpi: metadata failed, writing without DPI: %s", e.getMessage());
+      ImageIO.write(img, "png", file);
+      return;
+    }
+
+    try (ImageOutputStream ios = ImageIO.createImageOutputStream(file)) {
+      writer.setOutput(ios);
+      writer.write(null, new IIOImage(img, null, metadata), writeParam);
+    } finally {
+      writer.dispose();
+    }
+  }
+
   public static String saveTimedImage(BufferedImage img, String path, String name) {
     RunTime.pause(0.01f);
     if (null == path) {
@@ -529,7 +589,11 @@ public class FileManager {
       }
     }
     try {
-      ImageIO.write(img, formatName, fImage);
+      if ("png".equals(formatName)) {
+        writePngWithDpi(img, fImage);
+      } else {
+        ImageIO.write(img, formatName, fImage);
+      }
       log(3, "saveImage: %s", fImage);
     } catch (Exception ex) {
       log(-1, "saveTimedImage: did not work: %s (%s)", fImage, ex.getMessage());

--- a/API/src/main/resources/sikulixlibs/windows/libs64/sikulixcontent
+++ b/API/src/main/resources/sikulixlibs/windows/libs64/sikulixcontent
@@ -1,2 +1,2 @@
 JIntellitype.dll
-/nu/pattern/opencv/windows/x86_64/opencv_java454.dll@nu.pattern.OpenCV
+/nu/pattern/opencv/windows/x86_64/opencv_java4100.dll@nu.pattern.OpenCV

--- a/IDE/src/main/java/org/sikuli/ide/ButtonCapture.java
+++ b/IDE/src/main/java/org/sikuli/ide/ButtonCapture.java
@@ -143,9 +143,9 @@ class ButtonCapture extends ButtonOnToolbar implements Cloneable, EventObserver 
       SikulixIDE.PaneContext context = SikulixIDE.get().getActiveContext();
       final File imgFile = new File(context.getImageFolder(), givenName + ".png");
       try {
-        ImageIO.write(capturedImage, "png", imgFile);
+        org.sikuli.support.FileManager.writePngWithDpi(capturedImage, imgFile);
         if (context.getScreenshotFolder().exists()) {
-          ImageIO.write(screenShot, "png", new File(context.getScreenshotFolder(), givenName + ".png"));
+          org.sikuli.support.FileManager.writePngWithDpi(screenShot, new File(context.getScreenshotFolder(), givenName + ".png"));
         }
       } catch (IOException e) {
       }

--- a/IDE/src/main/java/org/sikuli/ide/Sikulix.java
+++ b/IDE/src/main/java/org/sikuli/ide/Sikulix.java
@@ -79,6 +79,7 @@ public class Sikulix {
     //TODO autoCheckUpdate();
 
     if (Commons.hasOption(RUN)) {
+      Commons.loadOpenCV();
       HotkeyManager.getInstance().addHotkey("Abort", new HotkeyListener() {
         @Override
         public void hotkeyPressed(HotkeyEvent e) {

--- a/IDE/src/main/java/org/sikuli/support/ide/JythonSupport.java
+++ b/IDE/src/main/java/org/sikuli/support/ide/JythonSupport.java
@@ -378,7 +378,7 @@ public class JythonSupport implements IRunnerSupport {
           "# -*- coding: utf-8 -*- ",
           "import time; start = time.time()",
           "from sikuli import *",
-          "resetBeforeScriptStart()",
+          "try:\n  resetBeforeScriptStart()\nexcept:\n  pass",
           "Debug.log(3, 'Jython: BeforeScript: %s (%f)',  SCREEN, time.time()-start)",
   };
   //</editor-fold>

--- a/IDE/src/main/java/org/sikuli/support/runner/JythonRunner.java
+++ b/IDE/src/main/java/org/sikuli/support/runner/JythonRunner.java
@@ -8,7 +8,7 @@ import org.sikuli.ide.SikulixIDE;
 import org.sikuli.support.ide.JythonSupport;
 import org.sikuli.script.Sikulix;
 import org.sikuli.support.Commons;
-
+import static org.sikuli.util.CommandArgsEnum.*;
 import java.io.File;
 import java.io.PrintStream;
 import java.util.Arrays;
@@ -96,7 +96,9 @@ public class JythonRunner extends AbstractLocalFileScriptRunner {
         interpreterVersion = "could not be evaluated";
       }
       Commons.startLog(3, "Jython ready: version %s (%4.1f sec)", interpreterVersion, Commons.getSinceStart());
-      SikulixIDE.showAfterStart();
+      if (!Commons.hasOption(RUN)) {
+        SikulixIDE.showAfterStart();
+      }
     }
   }
 


### PR DESCRIPTION
![Enhancement](https://img.shields.io/badge/type-enhancement-blue?style=for-the-badge)
![OpenCV](https://img.shields.io/badge/OpenCV-4.10.0-green?style=for-the-badge&logo=opencv)
![DPI Aware](https://img.shields.io/badge/DPI-aware-orange?style=for-the-badge)
![Multi Resolution](https://img.shields.io/badge/multi--resolution-supported-purple?style=for-the-badge)

---

> [!IMPORTANT]
> **This PR brings two major enhancements:**
> 1. 🔧 **OpenCV native loading** — fixes the `UnsatisfiedLinkError` crash in headless `-r` mode after the Apertix 4.10.0 migration
> 2. 🎯 **DPI-aware matching pipeline** — 5-mode cascade that handles cross-resolution matching when Windows display scaling changes

---

## 🔧 Enhancement 1 — OpenCV native loading fix

### Before

```
❌ java -jar oculixide-3.0.1-complete-win.jar -r script.py
→ UnsatisfiedLinkError: 'long org.opencv.core.Mat.n_Mat()'
```

### After

```
✅ java -jar oculixide-3.0.1-complete-win.jar -r script.py
→ OpenCV: loaded via Apertix (nu.pattern.OpenCV)
→ Script executes successfully
```

### Root cause

After migrating from openpnp/opencv 4.5.4 to Apertix 4.10.0:

| Component | Was | Now |
|-----------|-----|-----|
| `Core.NATIVE_LIBRARY_NAME` | `opencv_java454` ❌ | `opencv_java4100` ✅ |
| `loadOpenCV()` failure handling | `libOpenCVloaded = true` always ❌ | Only `true` on success ✅ |
| Apertix integration | Not called ❌ | `nu.pattern.OpenCV.loadLocally()` as primary method ✅ |

### Changes

| File | Change |
|------|--------|
| `Core.java` | Align version `4.5.4` → `4.10.0`, native lib name `opencv_java454` → `opencv_java4100` |
| `Commons.java` | Rewrite `loadOpenCV()`: Apertix → `System.loadLibrary` → manual JAR extraction |
| `sikulixcontent` | Align manifest to `opencv_java4100` |

---

## 🎯 Enhancement 2 — DPI-aware multi-resolution matching

> [!NOTE]
> **Use case:** Template captured at 100% Windows scaling, script executed at 150% scaling (or vice versa). Without this enhancement, `find()` fails because the template size doesn't match the screen.

### Pipeline cascade

```mermaid
graph TD
    A[find called] --> B{Mode 1: Exact match}
    B -->|score > threshold| Z[✅ Match found]
    B -->|fail| C{Mode 2: DPI-aware resize}
    C -->|score > threshold| Z
    C -->|fail| D{Mode 3: Tolerant - GaussianBlur}
    D -->|score > threshold ×0.9| Z
    D -->|fail| E{Mode 4: Smart - Grayscale}
    E -->|score > threshold ×0.85| Z
    E -->|fail| F{Mode 5: Multi-scale brute-force}
    F -->|score > threshold ×0.9| Z
    F -->|fail| X[❌ FindFailed]
```

### What each mode does

| Mode | Strategy | Threshold | When it helps |
|------|----------|-----------|---------------|
| **1** | Standard `matchTemplate` | Original | Same resolution, identical image |
| **2** | Resize template by DPI ratio | Original | Known DPI mismatch (metadata available) |
| **3** | GaussianBlur(3,3) on both images | × 0.90 | Minor rendering differences, anti-aliasing |
| **4** | Grayscale conversion | × 0.85 | Color shift, theme changes |
| **5** | Try 7 common scale ratios | × 0.90 | Unknown scaling, no DPI metadata (legacy) |

### Key fixes in this enhancement

> [!WARNING]
> **Bug fixed — Scoring cascade:** Modes 3 & 4 previously found valid matches but `FindResult2.hasNext()` rejected them because it compared against the **original** threshold instead of the **reduced** one. Now `findInput.setSimilarity()` is set to the reduced threshold before creating the `FindResult2`.

> [!WARNING]
> **Bug fixed — DPI metadata:** Captured PNGs never contained DPI metadata (pHYs chunk), so Mode 2 never triggered. Now all PNG writes go through `FileManager.writePngWithDpi()` which embeds the system DPI.

### Changes

| Fix | File(s) | Change |
|-----|---------|--------|
| **P0 — Scoring** | `Finder.java` | `findInput.setSimilarity(reduced)` before `new FindResult2()` in modes 3, 4, 5 |
| **P1a — PNG DPI** | `FileManager.java` + 3 files | New `writePngWithDpi()`, replaces 7 bare `ImageIO.write` calls |
| **P1b — DPI fallback** | `Finder.java` | `getDpiRatio()`: in-memory → PNG metadata → assume 96 DPI |
| **P2a — Image DPI** | `Image.java` | New `captureDpi` field, auto-injected from `Image(ScreenImage)` |
| **P2b — System DPI** | `Finder.java` | `getSystemDpi()` via `GraphicsDevice.getDefaultTransform()` |
| **P3 — Multi-scale** | `Finder.java` | Mode 5: brute-force at ratios 1.25, 1.5, 1.75, 2.0, 0.8, 0.67, 0.5 |

---

## 📁 Files changed (8 files, +233 / -52)

```
API/src/main/java/org/opencv/core/Core.java
API/src/main/java/org/sikuli/script/Finder.java
API/src/main/java/org/sikuli/script/Image.java
API/src/main/java/org/sikuli/script/ScreenImage.java
API/src/main/java/org/sikuli/support/Commons.java
API/src/main/java/org/sikuli/support/FileManager.java
API/src/main/resources/sikulixlibs/windows/libs64/sikulixcontent
IDE/src/main/java/org/sikuli/ide/ButtonCapture.java
```

---

## ✅ Test plan

- [ ] `mvn clean package -DskipTests` — compilation succeeds
- [ ] **Headless mode (`-r`)**: run a script with `find()` — no `UnsatisfiedLinkError`
- [ ] **IDE mode**: launch GUI, capture, `find()` — no regression
- [ ] **DPI metadata**: check captured PNG contains pHYs chunk (e.g. with `exiftool` or any metadata viewer)
- [ ] **Cross-resolution**: capture at 100%, switch to 150%, run `find()` — Mode 2 or 5 triggers
- [ ] **Scoring cascade**: set similarity=0.99, use slightly degraded template — Mode 3/4 matches and is **not** rejected by `hasNext()`
- [ ] **findAll()**: verify cascade modes are skipped (by design) — no regression