### PR TITLE
Claude/ide refactoring

### DIFF
--- a/API/src/main/java/org/sikuli/script/Sikulix.java
+++ b/API/src/main/java/org/sikuli/script/Sikulix.java
@@ -21,7 +21,23 @@ import java.io.File;
 
 public class Sikulix {
 
-  public static void main(String[] args) throws FindFailed {
+public static void main(String[] args) throws FindFailed {
+    // Mode serveur: java -jar oculixapi.jar -s
+    // Demarre le ServerRunner legacy sur le port 50001
+    for (String arg : args) {
+      if ("-s".equals(arg)) {
+        try {
+          Class<?> cServer = Class.forName("org.sikuli.script.runners.ServerRunner");
+          cServer.getMethod("run").invoke(null);
+          System.exit(0);
+        } catch (Exception e) {
+          System.err.println("[ERROR] Failed to start ServerRunner: " + e.getMessage());
+          e.printStackTrace();
+          System.exit(1);
+        }
+      }
+    }
+
     if (args.length == 1 && "buildDate".equals(args[0])) {
       System.out.println(Commons.getSxBuildStamp());
       System.exit(0);
@@ -29,7 +45,7 @@ public class Sikulix {
 
     System.out.println("SikuliX API: nothing to do");
     System.exit(0);
-  }
+}
 
   //<editor-fold desc="00 log">
   private static int lvl = 3;

--- a/API/src/main/java/org/sikuli/util/SikulixFileChooser.java
+++ b/API/src/main/java/org/sikuli/util/SikulixFileChooser.java
@@ -58,12 +58,13 @@ public class SikulixFileChooser {
     File selectedFile;
     if (isBundle)
       selectedFile = show("Save as .sikuli, folder or file", SAVE, DIRSANDFILES
+            , new SXFilter("as folder.sikuli", SXFilter.SIKULI)
             , new SXFilter("as file", extension)
             , new SXFilter("as plain folder", SXFilter.FOLDER)
-            , new SXFilter("as folder.sikuli", SXFilter.SIKULI)
              );
     else {
       selectedFile = show("Save as .sikuli, folder or file", SAVE, DIRSANDFILES
+          , new SXFilter("as folder.sikuli", SXFilter.SIKULI)
           , new SXFilter("as file", extension)
       );
     }

--- a/IDE/pom.xml
+++ b/IDE/pom.xml
@@ -96,6 +96,30 @@
       <artifactId>commons-io</artifactId>
       <version>2.8.0</version>
     </dependency>
+    <!-- FlatLaf modern Look & Feel -->
+    <dependency>
+      <groupId>com.formdev</groupId>
+      <artifactId>flatlaf</artifactId>
+      <version>3.7.1</version>
+    </dependency>
+    <!-- DJ-Raven : modal dialogs, toasts, animations -->
+    <dependency>
+      <groupId>io.github.dj-raven</groupId>
+      <artifactId>modal-dialog</artifactId>
+      <version>2.6.1</version>
+    </dependency>
+    <!-- DJ-Raven : modern swing components -->
+    <dependency>
+      <groupId>io.github.dj-raven</groupId>
+      <artifactId>swing-pack</artifactId>
+      <version>1.0.1</version>
+    </dependency>
+    <!-- MigLayout : modern layout manager -->
+    <dependency>
+      <groupId>com.miglayout</groupId>
+      <artifactId>miglayout-swing</artifactId>
+      <version>11.4.3</version>
+    </dependency>
   </dependencies>
 
   <profiles>

--- a/IDE/src/main/java/org/sikuli/ide/ButtonOnToolbar.java
+++ b/IDE/src/main/java/org/sikuli/ide/ButtonOnToolbar.java
@@ -3,8 +3,6 @@
  */
 package org.sikuli.ide;
 
-import com.explodingpixels.macwidgets.plaf.UnifiedToolbarButtonUI;
-
 import javax.swing.*;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
@@ -18,8 +16,7 @@ public class ButtonOnToolbar extends JButton implements ActionListener {
 
    public ButtonOnToolbar(){
       setBorderPainted(false);
-      putClientProperty("JButton.buttonType", "textured");
-      setUI(new UnifiedToolbarButtonUI());
+      putClientProperty("JButton.buttonType", "toolBarButton");
       setBorder(BorderFactory.createEmptyBorder(3,10,3,10));
    }
 

--- a/IDE/src/main/java/org/sikuli/ide/EditorConsolePane.java
+++ b/IDE/src/main/java/org/sikuli/ide/EditorConsolePane.java
@@ -242,11 +242,11 @@ public class EditorConsolePane extends JPanel implements Runnable {
   static final String lineSep = System.getProperty("line.separator");
 
   public final static String CSS_Colors =
-      ".normal{ color: black; }"
-          + ".debug { color:#505000; }"
-          + ".info  { color: blue; }"
-          + ".log   { color: #09806A; }"
-          + ".error { color: red; }";
+      ".normal{ color: #BBBBBB; }"
+          + ".debug { color:#C0A000; }"
+          + ".info  { color: #6CB6FF; }"
+          + ".log   { color: #3DDBA4; }"
+          + ".error { color: #FF6B6B; }";
 
   private String htmlize(String msg) {
     StringBuilder sb = new StringBuilder();
@@ -255,16 +255,16 @@ public class EditorConsolePane extends JPanel implements Runnable {
         .replace("<", "&lt;")
         .replace(">", "&gt;");
 
-    String color = "color: black;";
+    String color = "color: #BBBBBB;";
 
     for (String line : msg.split(lineSep)) {
       Matcher m = patMsgCat.matcher(line);
       if (m.matches()) {
         String logType = m.group(1).toLowerCase();
-        if (logType.contains("error")) color = "color: red;";
-        else if (logType.contains("debug")) color = "color: #505000;";
-        else if (logType.contains("log")) color = "color: #09806A;";
-        else if (logType.contains("info")) color = "color: blue;";
+        if (logType.contains("error")) color = "color: #FF6B6B;";
+        else if (logType.contains("debug")) color = "color: #C0A000;";
+        else if (logType.contains("log")) color = "color: #3DDBA4;";
+        else if (logType.contains("info")) color = "color: #6CB6FF;";
       }
       String font = "font-family:monospace; font-size: medium;";
       int margin = 0;

--- a/IDE/src/main/java/org/sikuli/ide/EditorImageButton.java
+++ b/IDE/src/main/java/org/sikuli/ide/EditorImageButton.java
@@ -40,7 +40,15 @@ public class EditorImageButton extends JButton implements ActionListener, Serial
     return ((File) options.get(IButton.FILE)).getAbsolutePath();
   }
 
-  int MAXHEIGHT = PreferencesUser.get().getDefaultThumbHeight();
+  int MAXHEIGHT = getThumbHeight();
+
+  private static int getThumbHeight() {
+    try {
+      return PreferencesUser.get().getDefaultThumbHeight();
+    } catch (Exception e) {
+      return 50; // fallback
+    }
+  }
 
   BufferedImage thumbnail;
 

--- a/IDE/src/main/java/org/sikuli/ide/EditorImageButton.java
+++ b/IDE/src/main/java/org/sikuli/ide/EditorImageButton.java
@@ -4,6 +4,7 @@
 package org.sikuli.ide;
 
 import org.apache.commons.io.FilenameUtils;
+import org.sikuli.basics.PreferencesUser;
 import org.sikuli.support.ide.IButton;
 import org.sikuli.script.Location;
 import org.sikuli.script.Pattern;
@@ -39,7 +40,7 @@ public class EditorImageButton extends JButton implements ActionListener, Serial
     return ((File) options.get(IButton.FILE)).getAbsolutePath();
   }
 
-  int MAXHEIGHT = 20;
+  int MAXHEIGHT = PreferencesUser.get().getDefaultThumbHeight();
 
   BufferedImage thumbnail;
 

--- a/IDE/src/main/java/org/sikuli/ide/SikuliIDEStatusBar.java
+++ b/IDE/src/main/java/org/sikuli/ide/SikuliIDEStatusBar.java
@@ -1,11 +1,12 @@
 /*
- * Copyright (c) 2010-2020, sikuli.org, sikulix.com - MIT license
+ * Copyright (c) 2010-2026, sikuli.org, sikulix.com, oculix-org - MIT license
  */
 package org.sikuli.ide;
 
 import java.awt.*;
 import javax.swing.*;
 
+import net.miginfocom.swing.MigLayout;
 import org.sikuli.support.Commons;
 
 import java.util.Date;
@@ -14,25 +15,33 @@ class SikuliIDEStatusBar extends JPanel {
 
   private JLabel _lblMsg;
   private JLabel _lblCaretPos;
+  private JLabel _lblOcrStatus;
   private String currentContentType = "???";
   private int currentRow;
   private int currentCol;
   private long starting;
 
   public SikuliIDEStatusBar() {
-    setLayout(new BorderLayout());
-    setPreferredSize(new Dimension(10, 20));
+    setLayout(new MigLayout("insets 2 8 2 8, fill", "[]push[]12[]12[]", "[]"));
+    setPreferredSize(new Dimension(10, 22));
 
     _lblMsg = new JLabel();
-    _lblMsg.setPreferredSize(new Dimension(500, 20));
     _lblMsg.setFont(UIManager.getFont("Label.font").deriveFont(11.0f));
+
+    _lblOcrStatus = new JLabel();
+    _lblOcrStatus.setFont(UIManager.getFont("Label.font").deriveFont(11.0f));
+    checkOcrStatus();
+
     _lblCaretPos = new JLabel();
-    _lblCaretPos.setBorder(BorderFactory.createEmptyBorder(0, 0, 0, 15));
     _lblCaretPos.setFont(UIManager.getFont("Label.font").deriveFont(11.0f));
+
     setCaretPosition(1, 1);
     resetMessage();
-    add(_lblMsg, BorderLayout.WEST);
-    add(_lblCaretPos, BorderLayout.LINE_END);
+
+    add(_lblMsg);
+    add(_lblOcrStatus);
+    add(new JSeparator(SwingConstants.VERTICAL), "growy");
+    add(_lblCaretPos);
   }
 
   public void setType(String contentType) {
@@ -51,32 +60,43 @@ class SikuliIDEStatusBar extends JPanel {
       currentRow = row;
       currentCol = col;
     }
-    _lblCaretPos.setText(String.format("(%s) | R: %d | C: %d", currentContentType, currentRow, currentCol));
+    _lblCaretPos.setText(String.format("[%s]  R: %d  C: %d", currentContentType, currentRow, currentCol));
     if (starting > 0 && new Date().getTime() - starting > 3000) {
       resetMessage();
     }
   }
 
   public void setMessage(String text) {
-    _lblMsg.setText("   " + text);
+    _lblMsg.setText(text);
     repaint();
     starting = new Date().getTime();
   }
 
   public void resetMessage() {
-    String message = Commons.getSXVersionIDE();
-    message += " --- Java " + Commons.getJavaVersion();
+    String message = "OculiX " + Commons.getSXVersionShort() + "  \u2502  Java " + Commons.getJavaVersion();
     setMessage(message);
     starting = 0;
   }
-//  @Override
-//  protected void paintComponent(Graphics g) {
-//    super.paintComponent(g);
-//    int y = 0;
-//    g.setColor(new Color(156, 154, 140));
-//    g.drawLine(0, y, getWidth(), y);
-//    y++;
-//    g.setColor(new Color(196, 194, 183));
-//    g.drawLine(0, y, getWidth(), y);
-//  }
+
+  private void checkOcrStatus() {
+    try {
+      Class<?> engineClass = Class.forName("com.sikulix.ocr.PaddleOCREngine");
+      Object engine = engineClass.getDeclaredConstructor().newInstance();
+      boolean available = (boolean) engineClass.getMethod("isAvailable").invoke(engine);
+      if (available) {
+        _lblOcrStatus.setText("\u2B24 PaddleOCR");
+        _lblOcrStatus.setForeground(new Color(0x3D, 0xDB, 0xA4)); // green
+      } else {
+        _lblOcrStatus.setText("\u2B24 PaddleOCR");
+        _lblOcrStatus.setForeground(new Color(0xFF, 0x6B, 0x6B)); // red
+      }
+    } catch (Exception e) {
+      _lblOcrStatus.setText("\u2B24 PaddleOCR");
+      _lblOcrStatus.setForeground(UIManager.getColor("Label.disabledForeground"));
+    }
+  }
+
+  public void refreshOcrStatus() {
+    checkOcrStatus();
+  }
 }

--- a/IDE/src/main/java/org/sikuli/ide/SikuliIDEStatusBar.java
+++ b/IDE/src/main/java/org/sikuli/ide/SikuliIDEStatusBar.java
@@ -6,7 +6,6 @@ package org.sikuli.ide;
 import java.awt.*;
 import javax.swing.*;
 
-import com.explodingpixels.macwidgets.plaf.EmphasizedLabelUI;
 import org.sikuli.support.Commons;
 
 import java.util.Date;
@@ -24,21 +23,16 @@ class SikuliIDEStatusBar extends JPanel {
     setLayout(new BorderLayout());
     setPreferredSize(new Dimension(10, 20));
 
-    JPanel rightPanel = new JPanel(new BorderLayout());
-    rightPanel.setOpaque(false);
     _lblMsg = new JLabel();
     _lblMsg.setPreferredSize(new Dimension(500, 20));
-    _lblMsg.setUI(new EmphasizedLabelUI());
-    _lblMsg.setFont(new Font("Monaco", Font.TRUETYPE_FONT, 11));
+    _lblMsg.setFont(UIManager.getFont("Label.font").deriveFont(11.0f));
     _lblCaretPos = new JLabel();
     _lblCaretPos.setBorder(BorderFactory.createEmptyBorder(0, 0, 0, 15));
-    _lblCaretPos.setUI(new EmphasizedLabelUI());
-    _lblCaretPos.setFont(UIManager.getFont("Button.font").deriveFont(11.0f));
+    _lblCaretPos.setFont(UIManager.getFont("Label.font").deriveFont(11.0f));
     setCaretPosition(1, 1);
     resetMessage();
     add(_lblMsg, BorderLayout.WEST);
     add(_lblCaretPos, BorderLayout.LINE_END);
-//    add(rightPanel, BorderLayout.EAST);
   }
 
   public void setType(String contentType) {

--- a/IDE/src/main/java/org/sikuli/ide/Sikulix.java
+++ b/IDE/src/main/java/org/sikuli/ide/Sikulix.java
@@ -16,6 +16,7 @@ import org.sikuli.support.gui.SXDialog;
 import org.sikuli.support.ide.SikuliIDEI18N;
 
 import com.formdev.flatlaf.FlatDarkLaf;
+import com.formdev.flatlaf.FlatLaf;
 
 import java.io.File;
 import java.io.FileOutputStream;
@@ -108,6 +109,9 @@ public class Sikulix {
     //endregion
 
     // FlatLaf must be initialized before any Swing component creation
+    // Use modern system fonts: Segoe UI (Win), SF Pro (Mac), Inter/Cantarell (Linux)
+    FlatLaf.setPreferredFontFamily("Segoe UI");
+    FlatLaf.setPreferredMonospacedFontFamily("Cascadia Code");
     FlatDarkLaf.setup();
 
     ideSplash = new SXDialog("sxidestartup", SikulixIDE.getWindowTop(), SXDialog.POSITION.TOP);

--- a/IDE/src/main/java/org/sikuli/ide/Sikulix.java
+++ b/IDE/src/main/java/org/sikuli/ide/Sikulix.java
@@ -15,6 +15,8 @@ import org.sikuli.support.RunTime;
 import org.sikuli.support.gui.SXDialog;
 import org.sikuli.support.ide.SikuliIDEI18N;
 
+import com.formdev.flatlaf.FlatDarkLaf;
+
 import java.io.File;
 import java.io.FileOutputStream;
 import java.lang.reflect.Method;
@@ -105,6 +107,9 @@ public class Sikulix {
     Commons.startLog(1, "IDE starting (%4.1f)", Commons.getSinceStart());
     //endregion
 
+    // FlatLaf must be initialized before any Swing component creation
+    FlatDarkLaf.setup();
+
     ideSplash = new SXDialog("sxidestartup", SikulixIDE.getWindowTop(), SXDialog.POSITION.TOP);
     ideSplash.run();
 
@@ -170,12 +175,7 @@ public class Sikulix {
     Commons.setIDETemp(ideTemp);
     //endregion
 
-    if (Commons.runningMac()) {
-      try {
-        System.setProperty("apple.laf.useScreenMenuBar", "true");
-      } catch (Exception e) {
-      }
-    }
+    // apple.laf.useScreenMenuBar removed — FlatLaf handles macOS menu integration natively
 
     SikulixIDE.start();
 

--- a/IDE/src/main/java/org/sikuli/ide/SikulixIDE.java
+++ b/IDE/src/main/java/org/sikuli/ide/SikulixIDE.java
@@ -302,6 +302,7 @@ public class SikulixIDE extends JFrame {
     initSidebarNavigation();
     sidebar.initFooter(Commons.getSXVersionShort(), null);
     ideContainer.add(sidebar, BorderLayout.WEST);
+    updateScriptDependentItems(); // grey out Run/Capture/Record until a script is open
     Debug.log("IDE: Putting all together - after sidebar");
 
     // Phase 1a: migrate accelerators from JMenuBar to rootPane
@@ -470,28 +471,31 @@ public class SikulixIDE extends JFrame {
     sidebar.initNavigation(fileSub, editSub, runSub, toolsSub, helpSub);
   }
 
+  // Items that require an open script to be functional
+  private java.util.List<JMenuItem> scriptDependentItems = new ArrayList<>();
+
   private SidebarSubmenu buildRunSubmenu() {
     SidebarSubmenu sub = new SidebarSubmenu();
     int scMask = Toolkit.getDefaultToolkit().getMenuShortcutKeyMaskEx();
-    sub.addItem("\u25B6  " + _I("menuRunRun"),
+    scriptDependentItems.add(sub.addItem("\u25B6  " + _I("menuRunRun"),
         KeyStroke.getKeyStroke(java.awt.event.KeyEvent.VK_R, scMask),
-        e -> btnRun.runCurrentScript());
-    sub.addItem("\u25B6  " + _I("menuRunRunAndShowActions"),
+        e -> btnRun.runCurrentScript()));
+    scriptDependentItems.add(sub.addItem("\u25B6  " + _I("menuRunRunAndShowActions"),
         KeyStroke.getKeyStroke(java.awt.event.KeyEvent.VK_R, InputEvent.ALT_DOWN_MASK | scMask),
-        e -> btnRunSlow.runCurrentScript());
+        e -> btnRunSlow.runCurrentScript()));
     sub.addSeparator();
-    sub.addItem("\u25B6  Run selection",
+    scriptDependentItems.add(sub.addItem("\u25B6  Run selection",
         KeyStroke.getKeyStroke(java.awt.event.KeyEvent.VK_R, InputEvent.SHIFT_DOWN_MASK | scMask),
-        e -> getCurrentCodePane().runSelection());
+        e -> getCurrentCodePane().runSelection()));
     return sub;
   }
 
   private SidebarSubmenu buildToolsSubmenu() {
     SidebarSubmenu sub = new SidebarSubmenu();
-    sub.addItem("\uD83D\uDCF7  Capture", null,
-        e -> btnCapture.captureWithAutoDelay());
-    sub.addItem("\uD83D\uDD34  Record", null,
-        e -> btnRecord.actionPerformed(e));
+    scriptDependentItems.add(sub.addItem("\uD83D\uDCF7  Capture", null,
+        e -> btnCapture.captureWithAutoDelay()));
+    scriptDependentItems.add(sub.addItem("\uD83D\uDD34  Record", null,
+        e -> btnRecord.actionPerformed(e)));
     sub.addSeparator();
     // Add items from the existing _toolMenu (Extensions, etc.)
     if (_toolMenu != null) {
@@ -505,6 +509,13 @@ public class SikulixIDE extends JFrame {
       }
     }
     return sub;
+  }
+
+  private void updateScriptDependentItems() {
+    boolean hasScript = !contexts.isEmpty();
+    for (JMenuItem item : scriptDependentItems) {
+      item.setEnabled(hasScript);
+    }
   }
 
   private SidebarSubmenu buildSubmenuFrom(JMenu sourceMenu) {
@@ -595,6 +606,7 @@ public class SikulixIDE extends JFrame {
       }
       tabs.addTab("Welcome", welcomeTab);
       welcomeShowing = true;
+      updateScriptDependentItems();
     }
   }
 
@@ -605,6 +617,7 @@ public class SikulixIDE extends JFrame {
         tabs.removeTabAt(idx);
       }
       welcomeShowing = false;
+      updateScriptDependentItems();
     }
   }
   //</editor-fold>

--- a/IDE/src/main/java/org/sikuli/ide/SikulixIDE.java
+++ b/IDE/src/main/java/org/sikuli/ide/SikulixIDE.java
@@ -2011,6 +2011,14 @@ public class SikulixIDE extends JFrame {
     return createMenuItem(item, shortcut, listener);
   }
 
+  /** Creates a disabled menu item used as a section header label. */
+  JMenuItem createSectionLabel(String text) {
+    JMenuItem label = new JMenuItem("── " + text + " ──");
+    label.setEnabled(false);
+    label.setFont(UIManager.getFont("defaultFont").deriveFont(Font.BOLD, 11f));
+    return label;
+  }
+
   class MenuAction implements ActionListener {
 
     Method actMethod = null;
@@ -2072,29 +2080,30 @@ public class SikulixIDE extends JFrame {
       _fileMenu.addSeparator();
     }
 
-    // New submenu: Script / Workspace
-    JMenu newMenu = new JMenu(_I("menuFileNew"));
-    newMenu.add(createMenuItem("Script",
+    // ── Nouveau ──
+    _fileMenu.add(createSectionLabel(_I("menuFileNew")));
+    _fileMenu.add(createMenuItem("\uD83D\uDCC4  Script",
             KeyStroke.getKeyStroke(java.awt.event.KeyEvent.VK_N, scMask),
             new FileAction(FileAction.NEW)));
-    newMenu.add(createMenuItem("Workspace",
+    _fileMenu.add(createMenuItem("\uD83D\uDCC1  Workspace",
             null,
             e -> openNewWorkspaceDialog()));
-    _fileMenu.add(newMenu);
 
-    // Open submenu: Script / Workspace
-    JMenu openMenu = new JMenu(_I("menuFileOpen"));
-    openMenu.add(createMenuItem("Script",
+    // ── Ouvrir ──
+    _fileMenu.add(createSectionLabel(_I("menuFileOpen")));
+    _fileMenu.add(createMenuItem("\uD83D\uDCC4  Script",
             KeyStroke.getKeyStroke(java.awt.event.KeyEvent.VK_O, scMask),
             new FileAction(FileAction.OPEN)));
-    openMenu.add(createMenuItem("Workspace",
+    _fileMenu.add(createMenuItem("\uD83D\uDCC1  Workspace",
             null,
             e -> openExistingWorkspace()));
-    _fileMenu.add(openMenu);
 
     recentMenu = new JMenu(_I("menuRecent"));
     _fileMenu.add(recentMenu);
 
+    _fileMenu.addSeparator();
+
+    // ── Enregistrer ──
     jmi = _fileMenu.add(createMenuItem(_I("menuFileSave"),
             KeyStroke.getKeyStroke(java.awt.event.KeyEvent.VK_S, scMask),
             new FileAction(FileAction.SAVE)));
@@ -2110,6 +2119,8 @@ public class SikulixIDE extends JFrame {
             KeyStroke.getKeyStroke(java.awt.event.KeyEvent.VK_E,
                     InputEvent.SHIFT_DOWN_MASK | scMask),
             new FileAction(FileAction.EXPORT)));
+
+    _fileMenu.addSeparator();
 
     jmi = _fileMenu.add(createMenuItem(_I("menuFileCloseTab"),
             KeyStroke.getKeyStroke(java.awt.event.KeyEvent.VK_W, scMask),

--- a/IDE/src/main/java/org/sikuli/ide/SikulixIDE.java
+++ b/IDE/src/main/java/org/sikuli/ide/SikulixIDE.java
@@ -1073,8 +1073,9 @@ public class SikulixIDE extends JFrame {
         if (_ext.isEmpty() || _ext.equals("sikuli")) {
           _file.mkdirs();
           _folder = _file;
-          _file = new File(_folder, _name);
-          _ext = "";
+          String scriptExt = IDESupport.getDefaultRunner().getDefaultExtension();
+          _file = new File(_folder, _name + "." + scriptExt);
+          _ext = scriptExt;
         } else {
           _folder = _file.getParentFile();
           _folder.mkdirs();

--- a/IDE/src/main/java/org/sikuli/ide/SikulixIDE.java
+++ b/IDE/src/main/java/org/sikuli/ide/SikulixIDE.java
@@ -30,6 +30,7 @@ import org.sikuli.support.gui.SXDialog;
 import org.sikuli.support.recorder.actions.IRecordedAction;
 import org.sikuli.util.*;
 import org.sikuli.ide.ui.OculixSidebar;
+import org.sikuli.ide.ui.ScriptExplorer;
 import org.sikuli.ide.ui.SidebarSubmenu;
 import org.sikuli.ide.ui.WelcomeTab;
 
@@ -268,24 +269,33 @@ public class SikulixIDE extends JFrame {
       initMessageArea();
     }
     Debug.log("IDE: creating combined work window");
-    JPanel codePane = new JPanel(new BorderLayout(10, 10));
-    codePane.setBorder(BorderFactory.createEmptyBorder(0, 8, 0, 0));
+    JPanel codePane = new JPanel(new BorderLayout(0, 0));
+    codePane.setBorder(BorderFactory.createEmptyBorder(0, 0, 0, 0));
     codePane.add(tabs, BorderLayout.CENTER);
+
+    // Script file explorer (left of editor)
+    Debug.log("IDE: creating file explorer");
+    explorer = new ScriptExplorer();
+
+    // Explorer + Editor in a horizontal split
+    JSplitPane editorSplit = new JSplitPane(JSplitPane.HORIZONTAL_SPLIT, explorer, codePane);
+    editorSplit.setDividerLocation(180);
+    editorSplit.setResizeWeight(0.0); // editor gets all extra space
+    editorSplit.setBorder(BorderFactory.createEmptyBorder(0, 0, 0, 0));
+    editorSplit.setOneTouchExpandable(true);
 
     Debug.log("IDE: Putting all together");
     JPanel editPane = new JPanel(new BorderLayout(0, 0));
     mainPane = null;
     if (messageArea != null) {
-      if (prefs.getPrefMoreMessage() == PreferencesUser.VERTICAL) {
-        mainPane = new JSplitPane(JSplitPane.HORIZONTAL_SPLIT, codePane, messageArea);
-      } else {
-        mainPane = new JSplitPane(JSplitPane.VERTICAL_SPLIT, codePane, messageArea);
-      }
-      mainPane.setResizeWeight(0.6);
+      // Console always at the bottom (Eclipse-style)
+      mainPane = new JSplitPane(JSplitPane.VERTICAL_SPLIT, editorSplit, messageArea);
+      mainPane.setResizeWeight(0.75);
       mainPane.setBorder(BorderFactory.createEmptyBorder(0, 0, 0, 0));
+      mainPane.setOneTouchExpandable(true);
       editPane.add(mainPane, BorderLayout.CENTER);
     } else {
-      editPane.add(codePane, BorderLayout.CENTER);
+      editPane.add(editorSplit, BorderLayout.CENTER);
     }
 
     ideContainer.add(editPane, BorderLayout.CENTER);
@@ -564,6 +574,7 @@ public class SikulixIDE extends JFrame {
 
   private SikuliIDEStatusBar _status;
   private OculixSidebar sidebar;
+  private ScriptExplorer explorer;
 
   private JSplitPane mainPane;
 
@@ -610,6 +621,9 @@ public class SikulixIDE extends JFrame {
       updateScriptDependentItems();
       if (sidebar != null) {
         sidebar.updateProjectInfo(null, null);
+      }
+      if (explorer != null) {
+        explorer.setScriptDirectory(null);
       }
     }
   }
@@ -690,9 +704,12 @@ public class SikulixIDE extends JFrame {
       uncollapseMessageArea();
     }
 
-    // Update sidebar project info
+    // Update sidebar project info and explorer
     if (sidebar != null) {
       sidebar.updateProjectInfo(context.getFileName(), context.getFolder());
+    }
+    if (explorer != null) {
+      explorer.setScriptDirectory(context.getFolder());
     }
   }
 

--- a/IDE/src/main/java/org/sikuli/ide/SikulixIDE.java
+++ b/IDE/src/main/java/org/sikuli/ide/SikulixIDE.java
@@ -673,9 +673,11 @@ public class SikulixIDE extends JFrame {
         (java.util.function.BiConsumer<JTabbedPane, Integer>) (tabbedPane, tabIndex) -> {
           // Check if this is the welcome tab (not a script context)
           Component comp = tabbedPane.getComponentAt(tabIndex);
-          if (comp instanceof WelcomeTab) return; // welcome tab is not closable
-          if (tabIndex >= 0 && tabIndex < contexts.size()) {
-            getContextAt(tabIndex).close();
+          if (comp instanceof WelcomeTab) return;
+          // Account for welcome tab offset
+          int contextIndex = welcomeShowing ? tabIndex - 1 : tabIndex;
+          if (contextIndex >= 0 && contextIndex < contexts.size()) {
+            getContextAt(contextIndex).close();
           }
         });
     tabs.addChangeListener(e -> {
@@ -743,6 +745,9 @@ public class SikulixIDE extends JFrame {
   }
 
   PaneContext setActiveContext(int pos) {
+    if (pos < 0 || pos >= contexts.size()) {
+      return null;
+    }
     tabs.setSelectedIndex(pos);
     PaneContext context = contexts.get(pos);
     showContext(context);
@@ -750,6 +755,9 @@ public class SikulixIDE extends JFrame {
   }
 
   PaneContext getContextAt(int ix) {
+    if (ix < 0 || ix >= contexts.size()) {
+      return null;
+    }
     return contexts.get(ix);
   }
 
@@ -757,11 +765,12 @@ public class SikulixIDE extends JFrame {
     if (ix < 0 || contexts.isEmpty()) {
       return;
     }
-    if (ix >= contexts.size()) {
-      // Welcome tab or invalid index — ignore silently
+    // Account for welcome tab offset
+    int contextIx = welcomeShowing ? ix - 1 : ix;
+    if (contextIx < 0 || contextIx >= contexts.size()) {
       return;
     }
-    PaneContext context = contexts.get(ix);
+    PaneContext context = contexts.get(contextIx);
     PaneContext previous = lastContext;
     lastContext = context;
 
@@ -1600,7 +1609,8 @@ public class SikulixIDE extends JFrame {
   }
 
   EditorPane getPaneAtIndex(int index) {
-    return getContextAt(index).getPane();
+    PaneContext ctx = getContextAt(index);
+    return ctx != null ? ctx.getPane() : null;
   }
 
   private void convertSrcToHtml(String bundle) {
@@ -1922,7 +1932,10 @@ public class SikulixIDE extends JFrame {
       }
       // Close the initial empty script if it was created before session restore
       if (contexts.size() > filesToLoad.size()) {
-        getContextAt(0).closeSilent();
+        PaneContext firstCtx = getContextAt(0);
+        if (firstCtx != null) {
+          firstCtx.closeSilent();
+        }
       }
       tempIndex = 1;
     }

--- a/IDE/src/main/java/org/sikuli/ide/SikulixIDE.java
+++ b/IDE/src/main/java/org/sikuli/ide/SikulixIDE.java
@@ -600,7 +600,7 @@ public class SikulixIDE extends JFrame {
       if (welcomeTab == null) {
         welcomeTab = new WelcomeTab(
             e -> { hideWelcomeTab(); createEmptyScriptContext(); },
-            e -> { hideWelcomeTab(); File f = selectFileToOpen(); if (f != null) createFileContext(f); }
+            e -> { File f = selectFileToOpen(); if (f != null) createFileContext(f); }
         );
         welcomeTab.putClientProperty("isClosable", false);
       }

--- a/IDE/src/main/java/org/sikuli/ide/SikulixIDE.java
+++ b/IDE/src/main/java/org/sikuli/ide/SikulixIDE.java
@@ -470,29 +470,37 @@ public class SikulixIDE extends JFrame {
   private SidebarSubmenu buildSubmenuFrom(JMenu sourceMenu) {
     SidebarSubmenu sub = new SidebarSubmenu();
     if (sourceMenu == null) return sub;
+    boolean lastWasSeparator = true; // avoid leading separator
     for (int i = 0; i < sourceMenu.getItemCount(); i++) {
       JMenuItem item = sourceMenu.getItem(i);
       if (item == null) {
-        sub.addSeparator();
+        // separator — skip duplicates
+        if (!lastWasSeparator) {
+          sub.addSeparator();
+          lastWasSeparator = true;
+        }
       } else if (item instanceof JMenu) {
-        // Nested menu (e.g., Find submenu) — flatten into submenu
+        // Nested menu (e.g., Find submenu, Recent) — flatten into submenu
         JMenu nested = (JMenu) item;
-        sub.addSeparator();
+        if (nested.getItemCount() == 0) continue; // skip empty menus like Recent
+        if (!lastWasSeparator) {
+          sub.addSeparator();
+          lastWasSeparator = true;
+        }
         for (int j = 0; j < nested.getItemCount(); j++) {
           JMenuItem nestedItem = nested.getItem(j);
-          if (nestedItem == null) {
-            sub.addSeparator();
-          } else {
+          if (nestedItem != null) {
             ActionListener[] listeners = nestedItem.getActionListeners();
             sub.addItem(nestedItem.getText(), nestedItem.getAccelerator(),
                 listeners.length > 0 ? listeners[0] : null);
+            lastWasSeparator = false;
           }
         }
-        sub.addSeparator();
       } else {
         ActionListener[] listeners = item.getActionListeners();
         sub.addItem(item.getText(), item.getAccelerator(),
             listeners.length > 0 ? listeners[0] : null);
+        lastWasSeparator = false;
       }
     }
     return sub;
@@ -509,16 +517,18 @@ public class SikulixIDE extends JFrame {
 
   private void initTabs() {
     tabs = new CloseableTabbedPane();
-    // Phase 1c: Use FlatLaf native closeable tabs instead of custom MetalTabbedPaneUI
+    // Phase 1c: Use FlatLaf native closeable tabs
     tabs.putClientProperty("JTabbedPane.tabClosable", true);
+    tabs.putClientProperty("JTabbedPane.tabCloseToolTipText", "Close");
     tabs.putClientProperty("JTabbedPane.tabCloseCallback",
         (java.util.function.BiConsumer<JTabbedPane, Integer>) (tabbedPane, tabIndex) -> {
-          getContextAt(tabIndex).close();
+          // Check if this is the welcome tab (not a script context)
+          Component comp = tabbedPane.getComponentAt(tabIndex);
+          if (comp instanceof WelcomeTab) return; // welcome tab is not closable
+          if (tabIndex >= 0 && tabIndex < contexts.size()) {
+            getContextAt(tabIndex).close();
+          }
         });
-    tabs.addCloseableTabbedPaneListener(tabIndexToClose -> {
-      getContextAt(tabIndexToClose).close();
-      return false;
-    });
     tabs.addChangeListener(e -> {
       JTabbedPane tab = (JTabbedPane) e.getSource();
       int ix = tab.getSelectedIndex();
@@ -1027,7 +1037,7 @@ public class SikulixIDE extends JFrame {
         }
       } else {
         if (resetPos() == 0) {
-          createEmptyScriptContext();
+          showWelcomeTab();
         } else {
           setActiveContext(Math.min(closedPos, contexts.size() - 1));
         }

--- a/IDE/src/main/java/org/sikuli/ide/SikulixIDE.java
+++ b/IDE/src/main/java/org/sikuli/ide/SikulixIDE.java
@@ -343,8 +343,13 @@ public class SikulixIDE extends JFrame {
       messages.initRedirect();
     }
     Debug.log("IDE: Putting all together - Restore last Session");
-    List<File> restored = restoreSession();
-    if (restored.isEmpty()) {
+    try {
+      List<File> restored = restoreSession();
+      if (restored.isEmpty() || tabs.getTabCount() == 0) {
+        showWelcomeTab();
+      }
+    } catch (Exception e) {
+      log("Session restore failed: %s", e.getMessage());
       showWelcomeTab();
     }
 

--- a/IDE/src/main/java/org/sikuli/ide/SikulixIDE.java
+++ b/IDE/src/main/java/org/sikuli/ide/SikulixIDE.java
@@ -578,6 +578,13 @@ public class SikulixIDE extends JFrame {
             lastWasSeparator = false;
           }
         }
+      } else if (!item.isEnabled()) {
+        // Section header label (disabled bold item) — reproduce in submenu
+        JMenuItem header = new JMenuItem(item.getText());
+        header.setEnabled(false);
+        header.setFont(UIManager.getFont("defaultFont").deriveFont(Font.BOLD, 11f));
+        sub.add(header);
+        lastWasSeparator = true; // treat as separator to avoid doubles
       } else {
         ActionListener[] listeners = item.getActionListeners();
         sub.addItem(item.getText(), item.getAccelerator(),

--- a/IDE/src/main/java/org/sikuli/ide/SikulixIDE.java
+++ b/IDE/src/main/java/org/sikuli/ide/SikulixIDE.java
@@ -31,6 +31,7 @@ import org.sikuli.support.recorder.actions.IRecordedAction;
 import org.sikuli.util.*;
 import org.sikuli.ide.ui.OculixSidebar;
 import org.sikuli.ide.ui.SidebarSubmenu;
+import org.sikuli.ide.ui.WelcomeTab;
 
 import javax.swing.*;
 import javax.swing.text.BadLocationException;
@@ -338,12 +339,14 @@ public class SikulixIDE extends JFrame {
     });
     ToolTipManager.sharedInstance().setDismissDelay(30000);
 
-    createEmptyScriptContext();
     if (messages != null) {
       messages.initRedirect();
     }
     Debug.log("IDE: Putting all together - Restore last Session");
-    restoreSession();
+    List<File> restored = restoreSession();
+    if (restored.isEmpty()) {
+      showWelcomeTab();
+    }
 
     initShortcutKeys();
     ideIsReady.set(true);
@@ -528,6 +531,32 @@ public class SikulixIDE extends JFrame {
   }
 
   private CloseableTabbedPane tabs;
+  private WelcomeTab welcomeTab;
+  private boolean welcomeShowing = false;
+
+  void showWelcomeTab() {
+    if (!welcomeShowing && tabs.getTabCount() == 0) {
+      if (welcomeTab == null) {
+        welcomeTab = new WelcomeTab(
+            e -> { hideWelcomeTab(); createEmptyScriptContext(); },
+            e -> { hideWelcomeTab(); File f = selectFileToOpen(); if (f != null) createFileContext(f); }
+        );
+        welcomeTab.putClientProperty("isClosable", false);
+      }
+      tabs.addTab("Welcome", welcomeTab);
+      welcomeShowing = true;
+    }
+  }
+
+  void hideWelcomeTab() {
+    if (welcomeShowing && welcomeTab != null) {
+      int idx = tabs.indexOfComponent(welcomeTab);
+      if (idx >= 0) {
+        tabs.removeTabAt(idx);
+      }
+      welcomeShowing = false;
+    }
+  }
   //</editor-fold>
 
   //<editor-fold desc="03 PaneContext">
@@ -1841,10 +1870,7 @@ public class SikulixIDE extends JFrame {
     jmi.setName("OPEN");
 
     recentMenu = new JMenu(_I("menuRecent"));
-
-    if (Settings.experimental) {
-      _fileMenu.add(recentMenu);
-    }
+    _fileMenu.add(recentMenu);
 
     jmi = _fileMenu.add(createMenuItem(_I("menuFileSave"),
             KeyStroke.getKeyStroke(java.awt.event.KeyEvent.VK_S, scMask),
@@ -1862,15 +1888,6 @@ public class SikulixIDE extends JFrame {
                     InputEvent.SHIFT_DOWN_MASK | scMask),
             new FileAction(FileAction.EXPORT)));
 
-    _fileMenu.add(createMenuItem("Export as jar",
-            KeyStroke.getKeyStroke(java.awt.event.KeyEvent.VK_J, scMask),
-            new FileAction(FileAction.ASJAR)));
-
-    _fileMenu.add(createMenuItem("Export as runnable jar",
-            KeyStroke.getKeyStroke(java.awt.event.KeyEvent.VK_J,
-                    InputEvent.SHIFT_DOWN_MASK | scMask),
-            new FileAction(FileAction.ASRUNJAR)));
-
     jmi = _fileMenu.add(createMenuItem(_I("menuFileCloseTab"),
             KeyStroke.getKeyStroke(java.awt.event.KeyEvent.VK_W, scMask),
             new FileAction(FileAction.CLOSE_TAB)));
@@ -1882,19 +1899,6 @@ public class SikulixIDE extends JFrame {
               KeyStroke.getKeyStroke(java.awt.event.KeyEvent.VK_P, scMask),
               new FileAction(FileAction.PREFERENCES)));
     }
-
-    _fileMenu.addSeparator();
-    _fileMenu.add(createMenuItem("Open Special Files",
-            KeyStroke.getKeyStroke(java.awt.event.KeyEvent.VK_O, InputEvent.ALT_DOWN_MASK | scMask),
-            new FileAction(FileAction.OPEN_SPECIAL)));
-
-//TODO restart IDE
-/*
-    _fileMenu.add(createMenuItem("Restart IDE",
-            KeyStroke.getKeyStroke(java.awt.event.KeyEvent.VK_R,
-                    InputEvent.SHIFT_DOWN_MASK | InputEvent.ALT_DOWN_MASK),
-            new FileAction(FileAction.RESTART)));
-*/
     if (IDEDesktopSupport.showQuit) {
       _fileMenu.addSeparator();
       _fileMenu.add(createMenuItem(_I("menuFileQuit"),
@@ -2211,7 +2215,7 @@ public class SikulixIDE extends JFrame {
     }
 
     private boolean _find(String str, int begin, boolean forward) {
-      if (str == "!") {
+      if ("!".equals(str)) {
         return false;
       }
       EditorPane codePane = getCurrentCodePane();
@@ -2446,18 +2450,6 @@ public class SikulixIDE extends JFrame {
     _toolMenu.add(createMenuItem(_I("menuToolExtensions"),
             null,
             new ToolAction(ToolAction.EXTENSIONS)));
-
-    _toolMenu.add(createMenuItem("Pack Jar with Jython",
-            null,
-            new ToolAction(ToolAction.JARWITHJYTHON)));
-
-    _toolMenu.add(createMenuItem("Pack Jar with Jython",
-        null,
-        new ToolAction(ToolAction.JARWITHJYTHON)));
-
-    _toolMenu.add(createMenuItem(_I("menuToolAndroid"),
-            null,
-            new ToolAction(ToolAction.ANDROID)));
   }
 
   class ToolAction extends MenuAction {
@@ -2623,44 +2615,40 @@ public class SikulixIDE extends JFrame {
     _helpMenu.add(createMenuItem(_I("menuHelpBugReport"),
             null, new HelpAction(HelpAction.OPEN_BUG_REPORT)));
 
-//    _helpMenu.add(createMenuItem(_I("menuHelpTranslation"),
-//            null, new HelpAction(HelpAction.OPEN_TRANSLATION)));
     _helpMenu.addSeparator();
     _helpMenu.add(createMenuItem(_I("menuHelpHomepage"),
             null, new HelpAction(HelpAction.OPEN_HOMEPAGE)));
-
-//    _helpMenu.addSeparator();
-//    _helpMenu.add(createMenuItem("SikuliX1 Downloads",
-//        null, new HelpAction(HelpAction.OPEN_DOWNLOADS)));
-//    _helpMenu.add(createMenuItem(_I("menuHelpCheckUpdate"),
-//        null, new HelpAction(HelpAction.CHECK_UPDATE)));
+    _helpMenu.addSeparator();
+    _helpMenu.add(createMenuItem(_I("menuHelpCheckUpdate"),
+            null, new HelpAction(HelpAction.CHECK_UPDATE)));
   }
 
   private void lookUpdate() {
     newBuildAvailable = null;
-    String token = "This version was built at ";
-    String httpDownload = "#https://raiman.github.io/SikuliX1/downloads.html";
-    String pageDownload = FileManager.downloadURLtoString(httpDownload);
-    if (!pageDownload.isEmpty()) {
-      newBuildAvailable = false;
-    }
-    int locStamp = pageDownload.indexOf(token);
-    if (locStamp > 0) {
-      locStamp += token.length();
-      String latestBuildFull = pageDownload.substring(locStamp, locStamp + 16);
-      String latestBuild = latestBuildFull.replaceAll("-", "").replace("_", "").replace(":", "");
-      String actualBuild = Commons.getSxBuildStamp();
-      try {
-        long lb = Long.parseLong(latestBuild);
-        long ab = Long.parseLong(actualBuild);
-        if (lb > ab) {
-          newBuildAvailable = true;
-          newBuildStamp = latestBuildFull;
+    try {
+      String apiUrl = "https://api.github.com/repos/oculix-org/Oculix/releases/latest";
+      String response = FileManager.downloadURLtoString(apiUrl);
+      if (response != null && !response.isEmpty()) {
+        // Parse tag_name from JSON response (simple extraction)
+        int tagIdx = response.indexOf("\"tag_name\"");
+        if (tagIdx > 0) {
+          int valueStart = response.indexOf("\"", tagIdx + 11) + 1;
+          int valueEnd = response.indexOf("\"", valueStart);
+          String latestTag = response.substring(valueStart, valueEnd);
+          // Remove leading 'v' if present
+          String latestVersion = latestTag.startsWith("v") ? latestTag.substring(1) : latestTag;
+          String currentVersion = Commons.getSXVersionShort();
+          log("Check update: latest=%s current=%s", latestVersion, currentVersion);
+          if (!latestVersion.equals(currentVersion)) {
+            newBuildAvailable = true;
+            newBuildStamp = latestVersion;
+          } else {
+            newBuildAvailable = false;
+          }
         }
-        log("latest build: %s this build: %s (newer: %s)", latestBuild, actualBuild, newBuildAvailable);
-      } catch (NumberFormatException e) {
-        log("check for new build: stamps not readable");
       }
+    } catch (Exception e) {
+      log("Check update failed: %s", e.getMessage());
     }
   }
 

--- a/IDE/src/main/java/org/sikuli/ide/SikulixIDE.java
+++ b/IDE/src/main/java/org/sikuli/ide/SikulixIDE.java
@@ -607,6 +607,9 @@ public class SikulixIDE extends JFrame {
       tabs.addTab("Welcome", welcomeTab);
       welcomeShowing = true;
       updateScriptDependentItems();
+      if (sidebar != null) {
+        sidebar.updateProjectInfo(null, null);
+      }
     }
   }
 
@@ -684,6 +687,11 @@ public class SikulixIDE extends JFrame {
       collapseMessageArea();
     } else {
       uncollapseMessageArea();
+    }
+
+    // Update sidebar project info
+    if (sidebar != null) {
+      sidebar.updateProjectInfo(context.getFileName(), context.getFolder());
     }
   }
 
@@ -3281,6 +3289,8 @@ public class SikulixIDE extends JFrame {
           resetErrorMark();
           doBeforeRun();
 
+          long runStart = System.currentTimeMillis();
+
           IRunner.Options runOptions = new IRunner.Options();
           runOptions.setRunningInIDE();
 
@@ -3298,6 +3308,15 @@ public class SikulixIDE extends JFrame {
           } finally {
             Runner.setLastScriptRunReturnCode(exitValue);
           }
+
+          // Update sidebar last run info
+          final int finalExit = exitValue;
+          final long duration = System.currentTimeMillis() - runStart;
+          EventQueue.invokeLater(() -> {
+            if (sidebar != null) {
+              sidebar.updateLastRun(finalExit, duration);
+            }
+          });
 
           log("************** after RunScript");
           addErrorMark(runOptions.getErrorLine());

--- a/IDE/src/main/java/org/sikuli/ide/SikulixIDE.java
+++ b/IDE/src/main/java/org/sikuli/ide/SikulixIDE.java
@@ -367,7 +367,9 @@ public class SikulixIDE extends JFrame {
     if (sikulixIDE.mainPane != null) {
       sikulixIDE.mainPane.setDividerLocation(0.6); //TODO saved value
     }
-    sikulixIDE.getActiveContext().focus();
+    if (!sikulixIDE.contexts.isEmpty()) {
+      sikulixIDE.getActiveContext().focus();
+    }
   }
 
   //TODO initShortcutKey
@@ -635,12 +637,12 @@ public class SikulixIDE extends JFrame {
   }
 
   void switchContext(int ix) {
-    if (ix < 0) {
+    if (ix < 0 || contexts.isEmpty()) {
       return;
     }
     if (ix >= contexts.size()) {
-      RunTime.terminate(999, "IDE: switchPane: invalid tab index: %d (valid: 0 .. %d)",
-              ix, contexts.size() - 1);
+      // Welcome tab or invalid index — ignore silently
+      return;
     }
     PaneContext context = contexts.get(ix);
     PaneContext previous = lastContext;

--- a/IDE/src/main/java/org/sikuli/ide/SikulixIDE.java
+++ b/IDE/src/main/java/org/sikuli/ide/SikulixIDE.java
@@ -276,6 +276,14 @@ public class SikulixIDE extends JFrame {
     // Script file explorer (left of editor)
     Debug.log("IDE: creating file explorer");
     explorer = new ScriptExplorer();
+    explorer.setOnCardSelected(e -> {
+      int cardIndex = e.getID(); // card index passed as event ID
+      // Account for welcome tab offset
+      int tabIndex = welcomeShowing ? cardIndex + 1 : cardIndex;
+      if (tabIndex >= 0 && tabIndex < tabs.getTabCount()) {
+        tabs.setSelectedIndex(tabIndex);
+      }
+    });
 
     // Explorer + Editor in a horizontal split
     JSplitPane editorSplit = new JSplitPane(JSplitPane.HORIZONTAL_SPLIT, explorer, codePane);
@@ -622,9 +630,7 @@ public class SikulixIDE extends JFrame {
       if (sidebar != null) {
         sidebar.updateProjectInfo(null, null);
       }
-      if (explorer != null) {
-        explorer.setScriptDirectory(null);
-      }
+      refreshWorkspace();
     }
   }
 
@@ -704,14 +710,30 @@ public class SikulixIDE extends JFrame {
       uncollapseMessageArea();
     }
 
-    // Update sidebar project info and explorer
+    // Update sidebar project info and workspace explorer
     if (sidebar != null) {
       sidebar.updateProjectInfo(context.getFileName(), context.getFolder());
     }
-    if (explorer != null) {
-      explorer.setScriptDirectory(context.getFolder());
-    }
+    refreshWorkspace();
     updateScriptDependentItems();
+  }
+
+  /**
+   * Rebuilds the workspace explorer cards from the current contexts list.
+   */
+  private void refreshWorkspace() {
+    if (explorer == null) return;
+    List<ScriptExplorer.ScriptInfo> scripts = new ArrayList<>();
+    for (PaneContext ctx : contexts) {
+      scripts.add(ScriptExplorer.ScriptInfo.fromFolder(
+          ctx.getFileName(), ctx.getFolder(), ctx.isTemp()));
+    }
+    int selected = tabs.getSelectedIndex();
+    // If welcome tab is showing, no card is selected
+    if (welcomeShowing && selected == 0) {
+      selected = -1;
+    }
+    explorer.updateScripts(scripts, selected);
   }
 
   void createEmptyScriptContext() {
@@ -720,10 +742,7 @@ public class SikulixIDE extends JFrame {
     context.setRunner(IDESupport.getDefaultRunner());
     context.setFile();
     context.create();
-    // Explicitly update explorer and sidebar for the new script
-    if (explorer != null) {
-      explorer.setScriptDirectory(context.getFolder());
-    }
+    refreshWorkspace();
     if (sidebar != null) {
       sidebar.updateProjectInfo(context.getFileName(), context.getFolder());
     }

--- a/IDE/src/main/java/org/sikuli/ide/SikulixIDE.java
+++ b/IDE/src/main/java/org/sikuli/ide/SikulixIDE.java
@@ -1997,7 +1997,18 @@ public class SikulixIDE extends JFrame {
     File[] sikuliDirs = dir.listFiles(f -> f.isDirectory() && f.getName().endsWith(".sikuli"));
     if (sikuliDirs != null) {
       for (File script : sikuliDirs) {
-        createFileContext(script);
+        try {
+          // Check that the .sikuli bundle contains a script file
+          String baseName = script.getName().replace(".sikuli", "");
+          File pyFile = new File(script, baseName + ".py");
+          if (pyFile.exists()) {
+            createFileContext(script);
+          } else {
+            log("Workspace: skipping %s (no .py file found)", script.getName());
+          }
+        } catch (Exception e) {
+          log("Workspace: error loading %s: %s", script.getName(), e.getMessage());
+        }
       }
     }
 

--- a/IDE/src/main/java/org/sikuli/ide/SikulixIDE.java
+++ b/IDE/src/main/java/org/sikuli/ide/SikulixIDE.java
@@ -635,8 +635,8 @@ public class SikulixIDE extends JFrame {
 
   PaneContext getActiveContext() {
     final int ix = tabs.getSelectedIndex();
-    if (ix < 0) {
-      fatal("PaneContext: no context available"); //TODO possible?
+    if (ix < 0 || ix >= contexts.size()) {
+      return null;
     }
     return contexts.get(ix);
   }
@@ -696,6 +696,7 @@ public class SikulixIDE extends JFrame {
   }
 
   void createEmptyScriptContext() {
+    hideWelcomeTab();
     final PaneContext context = new PaneContext();
     context.setRunner(IDESupport.getDefaultRunner());
     context.setFile();
@@ -703,6 +704,7 @@ public class SikulixIDE extends JFrame {
   }
 
   void createEmptyTextContext() {
+    hideWelcomeTab();
     final PaneContext context = new PaneContext();
     context.setRunner(Runner.getRunner(TextRunner.class));
     context.setFile();
@@ -710,6 +712,7 @@ public class SikulixIDE extends JFrame {
   }
 
   void createFileContext(File file) {
+    hideWelcomeTab();
     final int pos = alreadyOpen(file);
     if (pos >= 0) {
       setActiveContext(pos);
@@ -1444,7 +1447,8 @@ public class SikulixIDE extends JFrame {
   }
 
   EditorPane getCurrentCodePane() {
-    return getActiveContext().getPane();
+    PaneContext ctx = getActiveContext();
+    return ctx != null ? ctx.getPane() : null;
   }
 
   EditorPane getPaneAtIndex(int index) {

--- a/IDE/src/main/java/org/sikuli/ide/SikulixIDE.java
+++ b/IDE/src/main/java/org/sikuli/ide/SikulixIDE.java
@@ -1056,12 +1056,14 @@ public class SikulixIDE extends JFrame {
           if (_file != null) {
             _ext = FilenameUtils.getExtension(_file.getPath());
           } else {
+            // No script file found in bundle — create one with default extension
             _ext = IDESupport.getDefaultRunner().getDefaultExtension();
+            _file = new File(_folder, _name + "." + _ext);
             try {
               _file.createNewFile();
             } catch (IOException e) {
-              fatal("PaneContext: setFile: create not possible: %s", file); //TODO
-              _file = null;
+              log("PaneContext: setFile: create not possible: %s", _file);
+              return false;
             }
           }
         } else {
@@ -1998,10 +2000,9 @@ public class SikulixIDE extends JFrame {
     if (sikuliDirs != null) {
       for (File script : sikuliDirs) {
         try {
-          // Check that the .sikuli bundle contains a script file
-          String baseName = script.getName().replace(".sikuli", "");
-          File pyFile = new File(script, baseName + ".py");
-          if (pyFile.exists()) {
+          // Check that the .sikuli bundle contains at least one .py file
+          File[] pyFiles = script.listFiles((d, name) -> name.endsWith(".py"));
+          if (pyFiles != null && pyFiles.length > 0) {
             createFileContext(script);
           } else {
             log("Workspace: skipping %s (no .py file found)", script.getName());
@@ -2011,6 +2012,8 @@ public class SikulixIDE extends JFrame {
         }
       }
     }
+
+    refreshWorkspace();
 
     log("Workspace loaded: %s (%s)", currentWorkspaceName, dir.getAbsolutePath());
   }

--- a/IDE/src/main/java/org/sikuli/ide/SikulixIDE.java
+++ b/IDE/src/main/java/org/sikuli/ide/SikulixIDE.java
@@ -494,7 +494,7 @@ public class SikulixIDE extends JFrame {
 
   // Phase 1b: build sidebar submenus from existing menu actions
   private void initSidebarNavigation() {
-    SidebarSubmenu fileSub = buildSubmenuFrom(_fileMenu);
+    SidebarSubmenu fileSub = buildFileSubmenu();
     SidebarSubmenu editSub = buildSubmenuFrom(_editMenu);
     SidebarSubmenu runSub = buildRunSubmenu();
     SidebarSubmenu toolsSub = buildToolsSubmenu();
@@ -504,6 +504,65 @@ public class SikulixIDE extends JFrame {
 
   // Items that require an open script to be functional
   private java.util.List<JMenuItem> scriptDependentItems = new ArrayList<>();
+
+  private SidebarSubmenu buildFileSubmenu() {
+    SidebarSubmenu sub = new SidebarSubmenu();
+    int scMask = Toolkit.getDefaultToolkit().getMenuShortcutKeyMaskEx();
+
+    // ── Nouveau ──
+    JMenuItem newHeader = new JMenuItem("\u2500\u2500 " + _I("menuFileNew") + " \u2500\u2500");
+    newHeader.setEnabled(false);
+    newHeader.setFont(UIManager.getFont("defaultFont").deriveFont(Font.BOLD, 11f));
+    sub.add(newHeader);
+    sub.addItem("\uD83D\uDCC4  Script",
+        KeyStroke.getKeyStroke(java.awt.event.KeyEvent.VK_N, scMask),
+        e -> { createEmptyScriptContext(); });
+    sub.addItem("\uD83D\uDCC1  Workspace", null,
+        e -> openNewWorkspaceDialog());
+
+    // ── Ouvrir ──
+    JMenuItem openHeader = new JMenuItem("\u2500\u2500 " + _I("menuFileOpen") + " \u2500\u2500");
+    openHeader.setEnabled(false);
+    openHeader.setFont(UIManager.getFont("defaultFont").deriveFont(Font.BOLD, 11f));
+    sub.add(openHeader);
+    sub.addItem("\uD83D\uDCC4  Script",
+        KeyStroke.getKeyStroke(java.awt.event.KeyEvent.VK_O, scMask),
+        e -> { File f = selectFileToOpen(); if (f != null) createFileContext(f); });
+    sub.addItem("\uD83D\uDCC1  Workspace", null,
+        e -> openExistingWorkspace());
+
+    sub.addSeparator();
+
+    // Enregistrer
+    scriptDependentItems.add(sub.addItem(_I("menuFileSave"),
+        KeyStroke.getKeyStroke(java.awt.event.KeyEvent.VK_S, scMask),
+        e -> { PaneContext ctx = getActiveContext(); if (ctx != null) ctx.save(); }));
+    scriptDependentItems.add(sub.addItem(_I("menuFileSaveAs"),
+        KeyStroke.getKeyStroke(java.awt.event.KeyEvent.VK_S, InputEvent.SHIFT_DOWN_MASK | scMask),
+        e -> { PaneContext ctx = getActiveContext(); if (ctx != null) ctx.saveAs(); }));
+    scriptDependentItems.add(sub.addItem(_I("menuFileExport"),
+        KeyStroke.getKeyStroke(java.awt.event.KeyEvent.VK_E, InputEvent.SHIFT_DOWN_MASK | scMask),
+        e -> { exportAsZip(); }));
+
+    sub.addSeparator();
+
+    scriptDependentItems.add(sub.addItem(_I("menuFileCloseTab"),
+        KeyStroke.getKeyStroke(java.awt.event.KeyEvent.VK_W, scMask),
+        e -> { PaneContext ctx = getActiveContext(); if (ctx != null) ctx.close(); }));
+
+    sub.addSeparator();
+
+    sub.addItem(_I("menuFilePreferences"),
+        KeyStroke.getKeyStroke(java.awt.event.KeyEvent.VK_P, scMask),
+        e -> showPreferencesWindow());
+
+    sub.addSeparator();
+
+    sub.addItem(_I("menuFileQuit"), null,
+        e -> terminate());
+
+    return sub;
+  }
 
   private SidebarSubmenu buildRunSubmenu() {
     SidebarSubmenu sub = new SidebarSubmenu();

--- a/IDE/src/main/java/org/sikuli/ide/SikulixIDE.java
+++ b/IDE/src/main/java/org/sikuli/ide/SikulixIDE.java
@@ -1707,7 +1707,12 @@ public class SikulixIDE extends JFrame {
   //<editor-fold defaultstate="collapsed" desc="04 save / restore session">
   private boolean saveSession(int saveAction) {
     StringBuilder sbuf = new StringBuilder();
-    for (PaneContext context : contexts.toArray(new PaneContext[]{new PaneContext()})) {
+    if (contexts.isEmpty()) {
+      PreferencesUser.get().setIdeSession("");
+      return true;
+    }
+    for (PaneContext context : contexts.toArray(new PaneContext[0])) {
+      if (context == null) continue;
       if (saveAction == DO_SAVE_ALL) {
         if (!context.close()) {
           return false;

--- a/IDE/src/main/java/org/sikuli/ide/SikulixIDE.java
+++ b/IDE/src/main/java/org/sikuli/ide/SikulixIDE.java
@@ -720,6 +720,14 @@ public class SikulixIDE extends JFrame {
     context.setRunner(IDESupport.getDefaultRunner());
     context.setFile();
     context.create();
+    // Explicitly update explorer and sidebar for the new script
+    if (explorer != null) {
+      explorer.setScriptDirectory(context.getFolder());
+    }
+    if (sidebar != null) {
+      sidebar.updateProjectInfo(context.getFileName(), context.getFolder());
+    }
+    updateScriptDependentItems();
   }
 
   void createEmptyTextContext() {

--- a/IDE/src/main/java/org/sikuli/ide/SikulixIDE.java
+++ b/IDE/src/main/java/org/sikuli/ide/SikulixIDE.java
@@ -889,6 +889,12 @@ public class SikulixIDE extends JFrame {
   }
 
   public File selectFileForSave(PaneContext context) {
+    // Set initial directory to workspace or script location
+    if (currentWorkspaceDir != null) {
+      PreferencesUser.get().put("LAST_OPEN_DIR", currentWorkspaceDir.getAbsolutePath());
+    } else if (context.getFolder() != null && context.getFolder().getParentFile() != null) {
+      PreferencesUser.get().put("LAST_OPEN_DIR", context.getFolder().getParentFile().getAbsolutePath());
+    }
     File fileSelected = new SikulixFileChooser(sikulixIDE).saveAs(
             context.getExt(), context.isBundle() || context.isTemp());
     if (fileSelected == null) {
@@ -1394,6 +1400,10 @@ public class SikulixIDE extends JFrame {
         contextsClosed.add(0, this);
         tabs.setTitleAt(pos, newContext.name);
         sikulixIDE.setIDETitle(newContext.file.getAbsolutePath());
+        sikulixIDE.refreshWorkspace();
+        if (sikulixIDE.sidebar != null) {
+          sikulixIDE.sidebar.updateProjectInfo(newContext.getFileName(), newContext.getFolder());
+        }
       }
       return success;
     }

--- a/IDE/src/main/java/org/sikuli/ide/SikulixIDE.java
+++ b/IDE/src/main/java/org/sikuli/ide/SikulixIDE.java
@@ -33,6 +33,7 @@ import org.sikuli.ide.ui.OculixSidebar;
 import org.sikuli.ide.ui.ScriptExplorer;
 import org.sikuli.ide.ui.SidebarSubmenu;
 import org.sikuli.ide.ui.WelcomeTab;
+import org.sikuli.ide.ui.WorkspaceDialog;
 
 import javax.swing.*;
 import javax.swing.text.BadLocationException;
@@ -162,6 +163,7 @@ public class SikulixIDE extends JFrame {
     ideWindow.setVisible(true);
     PaneContext ctx = sikulixIDE.getActiveContext();
     if (ctx != null) ctx.focus();
+    sikulixIDE.refreshWorkspace(); // refresh card image counts after capture
   }
 
   //TODO showAfterStart to be revised
@@ -277,11 +279,21 @@ public class SikulixIDE extends JFrame {
     Debug.log("IDE: creating file explorer");
     explorer = new ScriptExplorer();
     explorer.setOnCardSelected(e -> {
-      int cardIndex = e.getID(); // card index passed as event ID
-      // Account for welcome tab offset
+      int cardIndex = e.getID();
       int tabIndex = welcomeShowing ? cardIndex + 1 : cardIndex;
       if (tabIndex >= 0 && tabIndex < tabs.getTabCount()) {
         tabs.setSelectedIndex(tabIndex);
+      }
+    });
+    explorer.setOnCardRenamed(e -> {
+      int cardIndex = e.getID();
+      String newName = e.getActionCommand();
+      if (cardIndex >= 0 && cardIndex < contexts.size() && newName != null) {
+        // Rename is a save-as with new name — for now just update the tab title
+        PaneContext ctx = contexts.get(cardIndex);
+        int tabIndex = welcomeShowing ? cardIndex + 1 : cardIndex;
+        tabs.setTitleAt(tabIndex, newName);
+        refreshWorkspace();
       }
     });
 
@@ -620,7 +632,9 @@ public class SikulixIDE extends JFrame {
       if (welcomeTab == null) {
         welcomeTab = new WelcomeTab(
             e -> { hideWelcomeTab(); createEmptyScriptContext(); },
-            e -> { File f = selectFileToOpen(); if (f != null) createFileContext(f); }
+            e -> { File f = selectFileToOpen(); if (f != null) createFileContext(f); },
+            e -> openNewWorkspaceDialog(),
+            e -> openExistingWorkspace()
         );
         welcomeTab.putClientProperty("isClosable", false);
       }
@@ -1837,6 +1851,75 @@ public class SikulixIDE extends JFrame {
     return terminate();
   }
 
+  // ── Workspace management ──
+
+  private File currentWorkspaceDir = null;
+  private String currentWorkspaceName = "Workspace";
+
+  private void openNewWorkspaceDialog() {
+    File dir = WorkspaceDialog.showDialog(ideWindow);
+    if (dir != null) {
+      loadWorkspace(dir);
+    }
+  }
+
+  private void openExistingWorkspace() {
+    JFileChooser chooser = new JFileChooser();
+    chooser.setDialogTitle("Open Workspace");
+    chooser.setFileSelectionMode(JFileChooser.DIRECTORIES_ONLY);
+    chooser.setAcceptAllFileFilterUsed(false);
+    int result = chooser.showOpenDialog(ideWindow);
+    if (result == JFileChooser.APPROVE_OPTION) {
+      loadWorkspace(chooser.getSelectedFile());
+    }
+  }
+
+  private void loadWorkspace(File dir) {
+    currentWorkspaceDir = dir;
+
+    // Try to read workspace.json for the name
+    File wsJson = new File(dir, "workspace.json");
+    if (wsJson.exists()) {
+      try {
+        String content = org.sikuli.support.FileManager.readFileToString(wsJson);
+        // Simple JSON name extraction
+        int nameIdx = content.indexOf("\"name\"");
+        if (nameIdx > 0) {
+          int valueStart = content.indexOf("\"", nameIdx + 7) + 1;
+          int valueEnd = content.indexOf("\"", valueStart);
+          currentWorkspaceName = content.substring(valueStart, valueEnd);
+        }
+      } catch (Exception e) {
+        currentWorkspaceName = dir.getName();
+      }
+    } else {
+      currentWorkspaceName = dir.getName();
+    }
+
+    // Update explorer header
+    if (explorer != null) {
+      explorer.setWorkspaceName(currentWorkspaceName);
+    }
+
+    // Load any .sikuli scripts in the workspace directory
+    File[] sikuliDirs = dir.listFiles(f -> f.isDirectory() && f.getName().endsWith(".sikuli"));
+    if (sikuliDirs != null) {
+      for (File script : sikuliDirs) {
+        createFileContext(script);
+      }
+    }
+
+    log("Workspace loaded: %s (%s)", currentWorkspaceName, dir.getAbsolutePath());
+  }
+
+  public File getCurrentWorkspaceDir() {
+    return currentWorkspaceDir;
+  }
+
+  public String getCurrentWorkspaceName() {
+    return currentWorkspaceName;
+  }
+
   public void showPreferencesWindow() {
     PreferencesWin pwin = new PreferencesWin();
     pwin.setAlwaysOnTop(true);
@@ -1989,14 +2072,25 @@ public class SikulixIDE extends JFrame {
       _fileMenu.addSeparator();
     }
 
-    _fileMenu.add(createMenuItem(_I("menuFileNew"),
+    // New submenu: Script / Workspace
+    JMenu newMenu = new JMenu(_I("menuFileNew"));
+    newMenu.add(createMenuItem("Script",
             KeyStroke.getKeyStroke(java.awt.event.KeyEvent.VK_N, scMask),
             new FileAction(FileAction.NEW)));
+    newMenu.add(createMenuItem("Workspace",
+            null,
+            e -> openNewWorkspaceDialog()));
+    _fileMenu.add(newMenu);
 
-    jmi = _fileMenu.add(createMenuItem(_I("menuFileOpen"),
+    // Open submenu: Script / Workspace
+    JMenu openMenu = new JMenu(_I("menuFileOpen"));
+    openMenu.add(createMenuItem("Script",
             KeyStroke.getKeyStroke(java.awt.event.KeyEvent.VK_O, scMask),
             new FileAction(FileAction.OPEN)));
-    jmi.setName("OPEN");
+    openMenu.add(createMenuItem("Workspace",
+            null,
+            e -> openExistingWorkspace()));
+    _fileMenu.add(openMenu);
 
     recentMenu = new JMenu(_I("menuRecent"));
     _fileMenu.add(recentMenu);

--- a/IDE/src/main/java/org/sikuli/ide/SikulixIDE.java
+++ b/IDE/src/main/java/org/sikuli/ide/SikulixIDE.java
@@ -1083,8 +1083,8 @@ public class SikulixIDE extends JFrame {
         try {
           _file.createNewFile();
         } catch (IOException e) {
-          fatal("PaneContext: setFile: create not possible: %s", file); //TODO
-          _file = null;
+          log("PaneContext: setFile: create not possible: %s", _file);
+          return false;
         }
       }
       if (_file == null) {

--- a/IDE/src/main/java/org/sikuli/ide/SikulixIDE.java
+++ b/IDE/src/main/java/org/sikuli/ide/SikulixIDE.java
@@ -29,6 +29,8 @@ import org.sikuli.support.recorder.generators.ICodeGenerator;
 import org.sikuli.support.gui.SXDialog;
 import org.sikuli.support.recorder.actions.IRecordedAction;
 import org.sikuli.util.*;
+import org.sikuli.ide.ui.OculixSidebar;
+import org.sikuli.ide.ui.SidebarSubmenu;
 
 import javax.swing.*;
 import javax.swing.text.BadLocationException;
@@ -287,9 +289,25 @@ public class SikulixIDE extends JFrame {
     ideContainer.add(editPane, BorderLayout.CENTER);
     Debug.log("IDE: Putting all together - after main pane");
 
+    // Phase 1a: init toolbar (actions are still needed) but don't add to layout
     JToolBar tb = initToolbar();
-    ideContainer.add(tb, BorderLayout.NORTH);
-    Debug.log("IDE: Putting all together - after toolbar");
+    // Phase 1b: JToolBar hidden, actions migrated to sidebar
+    tb.setVisible(false);
+
+    // Phase 1b: Create and configure sidebar
+    Debug.log("IDE: Putting all together - init sidebar");
+    sidebar = new OculixSidebar();
+    initSidebarActions();
+    initSidebarNavigation();
+    sidebar.initFooter(Commons.getSXVersionShort(), null);
+    ideContainer.add(sidebar, BorderLayout.WEST);
+    Debug.log("IDE: Putting all together - after sidebar");
+
+    // Phase 1a: migrate accelerators from JMenuBar to rootPane
+    migrateAcceleratorsToRootPane();
+
+    // Phase 1b: hide JMenuBar (kept as safety net, removed in Phase 3)
+    _menuBar.setVisible(false);
 
     _status = new SikuliIDEStatusBar();
     ideContainer.add(_status, BorderLayout.SOUTH);
@@ -388,17 +406,112 @@ public class SikulixIDE extends JFrame {
     }, AWTEvent.KEY_EVENT_MASK);
   }
 
+  // Phase 1a: Migrate all JMenuItem accelerators to rootPane InputMap/ActionMap
+  // This ensures keyboard shortcuts survive the JMenuBar being hidden.
+  private void migrateAcceleratorsToRootPane() {
+    JRootPane root = ideWindow.getRootPane();
+    InputMap im = root.getInputMap(JComponent.WHEN_IN_FOCUSED_WINDOW);
+    ActionMap am = root.getActionMap();
+    migrateMenuAccelerators(_fileMenu, im, am);
+    migrateMenuAccelerators(_editMenu, im, am);
+    migrateMenuAccelerators(_runMenu, im, am);
+    migrateMenuAccelerators(_viewMenu, im, am);
+    migrateMenuAccelerators(_toolMenu, im, am);
+    migrateMenuAccelerators(_helpMenu, im, am);
+    Debug.log("IDE: Accelerators migrated to rootPane");
+  }
+
+  private void migrateMenuAccelerators(JMenu menu, InputMap im, ActionMap am) {
+    if (menu == null) return;
+    for (int i = 0; i < menu.getItemCount(); i++) {
+      JMenuItem item = menu.getItem(i);
+      if (item == null) continue; // separators
+      if (item instanceof JMenu) {
+        migrateMenuAccelerators((JMenu) item, im, am);
+      } else if (item.getAccelerator() != null) {
+        KeyStroke ks = item.getAccelerator();
+        String actionKey = "sidebar_" + menu.getText() + "_" + item.getText();
+        im.put(ks, actionKey);
+        final JMenuItem menuItem = item;
+        am.put(actionKey, new AbstractAction() {
+          @Override
+          public void actionPerformed(ActionEvent e) {
+            for (ActionListener al : menuItem.getActionListeners()) {
+              al.actionPerformed(new ActionEvent(menuItem, ActionEvent.ACTION_PERFORMED, menuItem.getActionCommand()));
+            }
+          }
+        });
+      }
+    }
+  }
+
+  // Phase 1b: wire sidebar action buttons to existing toolbar button logic
+  private void initSidebarActions() {
+    sidebar.initActionButtons(
+        e -> btnRun.runCurrentScript(),
+        e -> btnRunSlow.runCurrentScript(),
+        e -> btnCapture.captureWithAutoDelay(),
+        e -> btnRecord.actionPerformed(e)
+    );
+  }
+
+  // Phase 1b: build sidebar submenus from existing menu actions
+  private void initSidebarNavigation() {
+    SidebarSubmenu fileSub = buildSubmenuFrom(_fileMenu);
+    SidebarSubmenu editSub = buildSubmenuFrom(_editMenu);
+    SidebarSubmenu toolsSub = buildSubmenuFrom(_toolMenu);
+    SidebarSubmenu helpSub = buildSubmenuFrom(_helpMenu);
+    sidebar.initNavigation(fileSub, editSub, toolsSub, helpSub);
+  }
+
+  private SidebarSubmenu buildSubmenuFrom(JMenu sourceMenu) {
+    SidebarSubmenu sub = new SidebarSubmenu();
+    if (sourceMenu == null) return sub;
+    for (int i = 0; i < sourceMenu.getItemCount(); i++) {
+      JMenuItem item = sourceMenu.getItem(i);
+      if (item == null) {
+        sub.addSeparator();
+      } else if (item instanceof JMenu) {
+        // Nested menu (e.g., Find submenu) — flatten into submenu
+        JMenu nested = (JMenu) item;
+        sub.addSeparator();
+        for (int j = 0; j < nested.getItemCount(); j++) {
+          JMenuItem nestedItem = nested.getItem(j);
+          if (nestedItem == null) {
+            sub.addSeparator();
+          } else {
+            ActionListener[] listeners = nestedItem.getActionListeners();
+            sub.addItem(nestedItem.getText(), nestedItem.getAccelerator(),
+                listeners.length > 0 ? listeners[0] : null);
+          }
+        }
+        sub.addSeparator();
+      } else {
+        ActionListener[] listeners = item.getActionListeners();
+        sub.addItem(item.getText(), item.getAccelerator(),
+            listeners.length > 0 ? listeners[0] : null);
+      }
+    }
+    return sub;
+  }
+
   static SikuliIDEStatusBar getStatusbar() {
     return sikulixIDE._status;
   }
 
   private SikuliIDEStatusBar _status;
+  private OculixSidebar sidebar;
 
   private JSplitPane mainPane;
 
   private void initTabs() {
     tabs = new CloseableTabbedPane();
-    tabs.setUI(new AquaCloseableTabbedPaneUI());
+    // Phase 1c: Use FlatLaf native closeable tabs instead of custom MetalTabbedPaneUI
+    tabs.putClientProperty("JTabbedPane.tabClosable", true);
+    tabs.putClientProperty("JTabbedPane.tabCloseCallback",
+        (java.util.function.BiConsumer<JTabbedPane, Integer>) (tabbedPane, tabIndex) -> {
+          getContextAt(tabIndex).close();
+        });
     tabs.addCloseableTabbedPaneListener(tabIndexToClose -> {
       getContextAt(tabIndexToClose).close();
       return false;

--- a/IDE/src/main/java/org/sikuli/ide/SikulixIDE.java
+++ b/IDE/src/main/java/org/sikuli/ide/SikulixIDE.java
@@ -806,6 +806,15 @@ public class SikulixIDE extends JFrame {
   }
 
   public File selectFileToOpen() {
+    // Set initial directory to workspace or last script location
+    if (currentWorkspaceDir != null) {
+      PreferencesUser.get().put("LAST_OPEN_DIR", currentWorkspaceDir.getAbsolutePath());
+    } else {
+      PaneContext ctx = getActiveContext();
+      if (ctx != null && ctx.getFolder() != null) {
+        PreferencesUser.get().put("LAST_OPEN_DIR", ctx.getFolder().getParentFile().getAbsolutePath());
+      }
+    }
     File fileSelected = new SikulixFileChooser(sikulixIDE).open();
     if (fileSelected == null) {
       return null;
@@ -1868,6 +1877,13 @@ public class SikulixIDE extends JFrame {
     chooser.setDialogTitle("Open Workspace");
     chooser.setFileSelectionMode(JFileChooser.DIRECTORIES_ONLY);
     chooser.setAcceptAllFileFilterUsed(false);
+    // Start in workspace dir or last known location
+    if (currentWorkspaceDir != null) {
+      chooser.setCurrentDirectory(currentWorkspaceDir.getParentFile());
+    } else {
+      String lastDir = PreferencesUser.get().get("LAST_OPEN_DIR", "");
+      if (!lastDir.isEmpty()) chooser.setCurrentDirectory(new File(lastDir));
+    }
     int result = chooser.showOpenDialog(ideWindow);
     if (result == JFileChooser.APPROVE_OPTION) {
       loadWorkspace(chooser.getSelectedFile());

--- a/IDE/src/main/java/org/sikuli/ide/SikulixIDE.java
+++ b/IDE/src/main/java/org/sikuli/ide/SikulixIDE.java
@@ -711,6 +711,7 @@ public class SikulixIDE extends JFrame {
     if (explorer != null) {
       explorer.setScriptDirectory(context.getFolder());
     }
+    updateScriptDependentItems();
   }
 
   void createEmptyScriptContext() {

--- a/IDE/src/main/java/org/sikuli/ide/SikulixIDE.java
+++ b/IDE/src/main/java/org/sikuli/ide/SikulixIDE.java
@@ -448,23 +448,56 @@ public class SikulixIDE extends JFrame {
     }
   }
 
-  // Phase 1b: wire sidebar action buttons to existing toolbar button logic
+  // Phase 1b: init sidebar navigation items
   private void initSidebarActions() {
-    sidebar.initActionButtons(
-        e -> btnRun.runCurrentScript(),
-        e -> btnRunSlow.runCurrentScript(),
-        e -> btnCapture.captureWithAutoDelay(),
-        e -> btnRecord.actionPerformed(e)
-    );
+    sidebar.initNavItems();
   }
 
   // Phase 1b: build sidebar submenus from existing menu actions
   private void initSidebarNavigation() {
     SidebarSubmenu fileSub = buildSubmenuFrom(_fileMenu);
     SidebarSubmenu editSub = buildSubmenuFrom(_editMenu);
-    SidebarSubmenu toolsSub = buildSubmenuFrom(_toolMenu);
+    SidebarSubmenu runSub = buildRunSubmenu();
+    SidebarSubmenu toolsSub = buildToolsSubmenu();
     SidebarSubmenu helpSub = buildSubmenuFrom(_helpMenu);
-    sidebar.initNavigation(fileSub, editSub, toolsSub, helpSub);
+    sidebar.initNavigation(fileSub, editSub, runSub, toolsSub, helpSub);
+  }
+
+  private SidebarSubmenu buildRunSubmenu() {
+    SidebarSubmenu sub = new SidebarSubmenu();
+    int scMask = Toolkit.getDefaultToolkit().getMenuShortcutKeyMaskEx();
+    sub.addItem("\u25B6  " + _I("menuRunRun"),
+        KeyStroke.getKeyStroke(java.awt.event.KeyEvent.VK_R, scMask),
+        e -> btnRun.runCurrentScript());
+    sub.addItem("\u25B6  " + _I("menuRunRunAndShowActions"),
+        KeyStroke.getKeyStroke(java.awt.event.KeyEvent.VK_R, InputEvent.ALT_DOWN_MASK | scMask),
+        e -> btnRunSlow.runCurrentScript());
+    sub.addSeparator();
+    sub.addItem("\u25B6  Run selection",
+        KeyStroke.getKeyStroke(java.awt.event.KeyEvent.VK_R, InputEvent.SHIFT_DOWN_MASK | scMask),
+        e -> getCurrentCodePane().runSelection());
+    return sub;
+  }
+
+  private SidebarSubmenu buildToolsSubmenu() {
+    SidebarSubmenu sub = new SidebarSubmenu();
+    sub.addItem("\uD83D\uDCF7  Capture", null,
+        e -> btnCapture.captureWithAutoDelay());
+    sub.addItem("\uD83D\uDD34  Record", null,
+        e -> btnRecord.actionPerformed(e));
+    sub.addSeparator();
+    // Add items from the existing _toolMenu (Extensions, etc.)
+    if (_toolMenu != null) {
+      for (int i = 0; i < _toolMenu.getItemCount(); i++) {
+        JMenuItem item = _toolMenu.getItem(i);
+        if (item != null) {
+          ActionListener[] listeners = item.getActionListeners();
+          sub.addItem(item.getText(), item.getAccelerator(),
+              listeners.length > 0 ? listeners[0] : null);
+        }
+      }
+    }
+    return sub;
   }
 
   private SidebarSubmenu buildSubmenuFrom(JMenu sourceMenu) {

--- a/IDE/src/main/java/org/sikuli/ide/SikulixIDE.java
+++ b/IDE/src/main/java/org/sikuli/ide/SikulixIDE.java
@@ -159,7 +159,8 @@ public class SikulixIDE extends JFrame {
 
   static void showAgain() {
     ideWindow.setVisible(true);
-    sikulixIDE.getActiveContext().focus();
+    PaneContext ctx = sikulixIDE.getActiveContext();
+    if (ctx != null) ctx.focus();
   }
 
   //TODO showAfterStart to be revised
@@ -1772,7 +1773,10 @@ public class SikulixIDE extends JFrame {
       for (File file : filesToLoad) {
         createFileContext(file);
       }
-      getContextAt(0).closeSilent();
+      // Close the initial empty script if it was created before session restore
+      if (contexts.size() > filesToLoad.size()) {
+        getContextAt(0).closeSilent();
+      }
       tempIndex = 1;
     }
     return filesToLoad;

--- a/IDE/src/main/java/org/sikuli/ide/ui/OculixSidebar.java
+++ b/IDE/src/main/java/org/sikuli/ide/ui/OculixSidebar.java
@@ -84,18 +84,25 @@ public class OculixSidebar extends JPanel {
    * Initializes the full sidebar layout: logo, project info, nav, status, last run, help.
    */
   public void initNavItems() {
-    // ── Logo ──
-    JLabel logo = new JLabel("OculiX");
-    logo.setFont(UIManager.getFont("h2.font"));
-    logo.setHorizontalAlignment(SwingConstants.CENTER);
-    logo.setBorder(BorderFactory.createEmptyBorder(4, 0, 2, 0));
-    mainPanel.add(logo);
+    // ── Logo Box ──
+    JPanel logoBox = new JPanel(new MigLayout("wrap 1, insets 10 6 10 6, gap 0", "[center, fill]"));
+    logoBox.setOpaque(true);
+    logoBox.setBackground(UIManager.getColor("Panel.background"));
+    logoBox.setBorder(BorderFactory.createLineBorder(UIManager.getColor("Component.borderColor"), 1));
 
-    JLabel edition = new JLabel("IDE");
-    edition.setFont(UIManager.getFont("small.font"));
-    edition.setForeground(UIManager.getColor("Label.disabledForeground"));
-    edition.setHorizontalAlignment(SwingConstants.CENTER);
-    mainPanel.add(edition, "gapbottom 6");
+    JLabel logoLine1 = new JLabel("OculiX");
+    logoLine1.setFont(new Font("Serif", Font.BOLD | Font.ITALIC, 28));
+    logoLine1.setForeground(UIManager.getColor("Label.foreground"));
+    logoLine1.setHorizontalAlignment(SwingConstants.CENTER);
+    logoBox.add(logoLine1);
+
+    JLabel logoLine2 = new JLabel("I D E");
+    logoLine2.setFont(new Font("SansSerif", Font.PLAIN, 14));
+    logoLine2.setForeground(UIManager.getColor("Label.disabledForeground"));
+    logoLine2.setHorizontalAlignment(SwingConstants.CENTER);
+    logoBox.add(logoLine2);
+
+    mainPanel.add(logoBox, "growx, gapbottom 6");
 
     // ── Project Info Panel ──
     JPanel projectPanel = createInfoPanel();

--- a/IDE/src/main/java/org/sikuli/ide/ui/OculixSidebar.java
+++ b/IDE/src/main/java/org/sikuli/ide/ui/OculixSidebar.java
@@ -19,13 +19,11 @@ import static org.sikuli.support.ide.SikuliIDEI18N._I;
 
 /**
  * Vertical sidebar replacing the classic JMenuBar + JToolBar.
- * Contains action buttons (Run, Stop, Capture, Record) and navigation
- * items (File, Edit, Tools, Help) with popup submenus.
+ * Organized in logical groups: Run, Scripts, Tools, Help.
  */
 public class OculixSidebar extends JPanel {
 
   private boolean collapsed = false;
-  private int expandedWidth = 200;
   private int collapsedWidth = 50;
 
   // Action buttons
@@ -40,12 +38,6 @@ public class OculixSidebar extends JPanel {
   private SidebarItem navTools;
   private SidebarItem navHelp;
 
-  // Submenus
-  private SidebarSubmenu fileSubmenu;
-  private SidebarSubmenu editSubmenu;
-  private SidebarSubmenu toolsSubmenu;
-  private SidebarSubmenu helpSubmenu;
-
   // Theme toggle
   private SidebarItem btnTheme;
   private boolean isDark = true;
@@ -53,131 +45,128 @@ public class OculixSidebar extends JPanel {
   // Version label
   private JLabel versionLabel;
 
-  // Panels for layout
-  private JPanel topSection;
-  private JPanel bottomSection;
-  private JPanel footerSection;
+  // Panels for layout sections
+  private JPanel mainPanel;
+  private JPanel footerPanel;
 
   public OculixSidebar() {
-    setLayout(new MigLayout("wrap 1, insets 8, fill", "[fill]", "[]0[]push[]0[]"));
-    setPreferredSize(new Dimension(expandedWidth, 0));
+    setLayout(new BorderLayout());
     setMinimumSize(new Dimension(collapsedWidth, 0));
     putClientProperty(FlatClientProperties.STYLE, "background: darken(@background, 3%)");
 
-    initSections();
+    mainPanel = new JPanel(new MigLayout("wrap 1, insets 8, gap 0", "[fill, grow]", ""));
+    mainPanel.setOpaque(false);
+
+    footerPanel = new JPanel(new MigLayout("wrap 1, insets 8, gap 2", "[fill, grow]", ""));
+    footerPanel.setOpaque(false);
+
+    add(mainPanel, BorderLayout.NORTH);
+    add(footerPanel, BorderLayout.SOUTH);
+
     addResizeHandle();
   }
 
-  private void initSections() {
-    // Top section: logo + action buttons
-    topSection = new JPanel(new MigLayout("wrap 1, insets 4, gap 2", "[fill]"));
-    topSection.setOpaque(false);
-
-    JLabel logo = new JLabel("OculiX");
-    logo.setFont(UIManager.getFont("h3.font"));
-    logo.setHorizontalAlignment(SwingConstants.CENTER);
-    logo.setBorder(BorderFactory.createEmptyBorder(8, 0, 12, 0));
-    topSection.add(logo);
-
-    topSection.add(new JSeparator());
-
-    add(topSection, "growx");
-
-    // Bottom section: navigation items
-    bottomSection = new JPanel(new MigLayout("wrap 1, insets 4, gap 2", "[fill]"));
-    bottomSection.setOpaque(false);
-    add(bottomSection, "growx");
-
-    // Footer section: theme toggle + version
-    footerSection = new JPanel(new MigLayout("wrap 1, insets 4, gap 2", "[fill]"));
-    footerSection.setOpaque(false);
-    add(footerSection, "growx, dock south");
+  private JLabel addSectionHeader(String text) {
+    JLabel header = new JLabel(text);
+    header.setFont(UIManager.getFont("small.font"));
+    header.setForeground(UIManager.getColor("Label.disabledForeground"));
+    header.setBorder(BorderFactory.createEmptyBorder(12, 8, 4, 0));
+    mainPanel.add(header);
+    return header;
   }
 
   /**
    * Initializes the action buttons section.
-   * Must be called after SikulixIDE creates its button actions.
    */
   public void initActionButtons(ActionListener runAction, ActionListener runSlowAction,
                                  ActionListener captureAction, ActionListener recordAction) {
+    // Logo
+    JLabel logo = new JLabel("OculiX");
+    logo.setFont(UIManager.getFont("h3.font"));
+    logo.setHorizontalAlignment(SwingConstants.CENTER);
+    logo.setBorder(BorderFactory.createEmptyBorder(8, 0, 8, 0));
+    mainPanel.add(logo);
+
+    mainPanel.add(new JSeparator(), "growx, gaptop 4, gapbottom 4");
+
+    // Run group
     btnRun = new SidebarItem("Run",
         loadIcon("/icons/run_big_green.png", 18), runAction);
-    btnRun.setToolTipText(_I("btnRunLabel"));
+    btnRun.setToolTipText(_I("btnRunLabel") + " (Ctrl+R)");
     btnRun.setMnemonic(java.awt.event.KeyEvent.VK_R);
-    topSection.add(btnRun);
+    mainPanel.add(btnRun);
 
     btnRunSlow = new SidebarItem("Run Slow",
         loadIcon("/icons/runviz.png", 18), runSlowAction);
     btnRunSlow.setToolTipText(_I("btnRunSlowMotionLabel"));
-    topSection.add(btnRunSlow);
+    mainPanel.add(btnRunSlow);
+
+    // Scripts group
+    addSectionHeader("SCRIPTS");
+
+    navFile = new SidebarItem(_I("menuFile") + "  \u25B8", null);
+    navFile.setMnemonic(java.awt.event.KeyEvent.VK_F);
+    mainPanel.add(navFile);
+
+    navEdit = new SidebarItem(_I("menuEdit") + "  \u25B8", null);
+    navEdit.setMnemonic(java.awt.event.KeyEvent.VK_E);
+    mainPanel.add(navEdit);
+
+    // Tools group
+    addSectionHeader("TOOLS");
 
     btnCapture = new SidebarItem("Capture",
         loadIcon("/icons/capture-small.png", 18), captureAction);
     btnCapture.setToolTipText(_I("btnCaptureLabel"));
-    topSection.add(btnCapture);
+    mainPanel.add(btnCapture);
 
     btnRecord = new SidebarItem("Record",
         loadIcon("/icons/record.png", 18), recordAction);
     btnRecord.setToolTipText(_I("btnRecordLabel"));
-    topSection.add(btnRecord);
+    mainPanel.add(btnRecord);
 
-    topSection.add(new JSeparator());
+    navTools = new SidebarItem(_I("menuTool") + "  \u25B8", null);
+    navTools.setMnemonic(java.awt.event.KeyEvent.VK_T);
+    mainPanel.add(navTools);
+
+    // Help group
+    addSectionHeader("HELP");
+
+    navHelp = new SidebarItem(_I("menuHelp") + "  \u25B8", null);
+    navHelp.setMnemonic(java.awt.event.KeyEvent.VK_H);
+    mainPanel.add(navHelp);
   }
 
   /**
-   * Initializes the navigation items with popup submenus.
-   * File, Edit, Tools, Help — each opens a popup submenu on click.
+   * Wires navigation items to popup submenus built from existing JMenu actions.
    */
   public void initNavigation(SidebarSubmenu fileSub, SidebarSubmenu editSub,
                               SidebarSubmenu toolsSub, SidebarSubmenu helpSub) {
-    this.fileSubmenu = fileSub;
-    this.editSubmenu = editSub;
-    this.toolsSubmenu = toolsSub;
-    this.helpSubmenu = helpSub;
-
-    navFile = createNavItem(_I("menuFile"), "\uD83D\uDCC1", fileSub);
-    navFile.setMnemonic(java.awt.event.KeyEvent.VK_F);
-    bottomSection.add(navFile);
-
-    navEdit = createNavItem(_I("menuEdit"), "\u270F\uFE0F", editSub);
-    navEdit.setMnemonic(java.awt.event.KeyEvent.VK_E);
-    bottomSection.add(navEdit);
-
-    navTools = createNavItem(_I("menuTool"), "\uD83D\uDD27", toolsSub);
-    navTools.setMnemonic(java.awt.event.KeyEvent.VK_T);
-    bottomSection.add(navTools);
-
-    navHelp = createNavItem(_I("menuHelp"), "\u2753", helpSub);
-    navHelp.setMnemonic(java.awt.event.KeyEvent.VK_H);
-    bottomSection.add(navHelp);
-  }
-
-  private SidebarItem createNavItem(String text, String emoji, SidebarSubmenu submenu) {
-    // Use a plain text icon as fallback since we don't have dedicated nav icons
-    SidebarItem item = new SidebarItem(text, null);
-    item.addActionListener(e -> submenu.showBelow(item));
-    return item;
+    navFile.addActionListener(e -> fileSub.showBelow(navFile));
+    navEdit.addActionListener(e -> editSub.showBelow(navEdit));
+    navTools.addActionListener(e -> toolsSub.showBelow(navTools));
+    navHelp.addActionListener(e -> helpSub.showBelow(navHelp));
   }
 
   /**
    * Initializes the footer with theme toggle and version label.
    */
   public void initFooter(String version, ActionListener themeAction) {
-    footerSection.add(new JSeparator());
+    footerPanel.add(new JSeparator(), "growx, gapbottom 4");
 
-    btnTheme = new SidebarItem("Dark / Light", null, e -> {
+    btnTheme = new SidebarItem("\u263C  Dark / Light", null, e -> {
       toggleTheme();
       if (themeAction != null) {
         themeAction.actionPerformed(e);
       }
     });
-    footerSection.add(btnTheme);
+    footerPanel.add(btnTheme);
 
-    versionLabel = new JLabel(version);
+    versionLabel = new JLabel("v" + version);
     versionLabel.setFont(UIManager.getFont("small.font"));
     versionLabel.setHorizontalAlignment(SwingConstants.CENTER);
     versionLabel.setForeground(UIManager.getColor("Label.disabledForeground"));
-    footerSection.add(versionLabel);
+    footerPanel.add(versionLabel);
   }
 
   private void toggleTheme() {
@@ -199,35 +188,25 @@ public class OculixSidebar extends JPanel {
   }
 
   /**
-   * Toggle between collapsed (icons only, 50px) and expanded (icons + labels, 180px) mode.
+   * Toggle between collapsed (icons only) and expanded (icons + labels) mode.
    */
   public void toggleCollapsed() {
     collapsed = !collapsed;
-    setPreferredSize(new Dimension(collapsed ? collapsedWidth : expandedWidth, 0));
 
-    // Update all SidebarItems
-    for (Component c : topSection.getComponents()) {
+    for (Component c : mainPanel.getComponents()) {
+      if (c instanceof SidebarItem) {
+        ((SidebarItem) c).setCollapsed(collapsed);
+      }
+      if (c instanceof JLabel && !(c instanceof SidebarItem)) {
+        c.setVisible(!collapsed);
+      }
+    }
+    for (Component c : footerPanel.getComponents()) {
       if (c instanceof SidebarItem) {
         ((SidebarItem) c).setCollapsed(collapsed);
       }
     }
-    for (Component c : bottomSection.getComponents()) {
-      if (c instanceof SidebarItem) {
-        ((SidebarItem) c).setCollapsed(collapsed);
-      }
-    }
-    for (Component c : footerSection.getComponents()) {
-      if (c instanceof SidebarItem) {
-        ((SidebarItem) c).setCollapsed(collapsed);
-      }
-    }
-
-    // Hide/show version label and logo
     versionLabel.setVisible(!collapsed);
-    Component logo = topSection.getComponent(0);
-    if (logo instanceof JLabel) {
-      ((JLabel) logo).setText(collapsed ? "OX" : "OculiX");
-    }
 
     revalidate();
     repaint();
@@ -238,7 +217,6 @@ public class OculixSidebar extends JPanel {
   }
 
   private void addResizeHandle() {
-    // Double-click on sidebar border toggles collapsed/expanded
     addMouseListener(new MouseAdapter() {
       @Override
       public void mouseClicked(MouseEvent e) {

--- a/IDE/src/main/java/org/sikuli/ide/ui/OculixSidebar.java
+++ b/IDE/src/main/java/org/sikuli/ide/ui/OculixSidebar.java
@@ -25,7 +25,7 @@ import static org.sikuli.support.ide.SikuliIDEI18N._I;
 public class OculixSidebar extends JPanel {
 
   private boolean collapsed = false;
-  private int expandedWidth = 180;
+  private int expandedWidth = 200;
   private int collapsedWidth = 50;
 
   // Action buttons
@@ -100,21 +100,25 @@ public class OculixSidebar extends JPanel {
    */
   public void initActionButtons(ActionListener runAction, ActionListener runSlowAction,
                                  ActionListener captureAction, ActionListener recordAction) {
-    btnRun = new SidebarItem(_I("btnRunLabel"),
+    btnRun = new SidebarItem("Run",
         loadIcon("/icons/run_big_green.png", 18), runAction);
+    btnRun.setToolTipText(_I("btnRunLabel"));
     btnRun.setMnemonic(java.awt.event.KeyEvent.VK_R);
     topSection.add(btnRun);
 
-    btnRunSlow = new SidebarItem(_I("btnRunSlowMotionLabel"),
+    btnRunSlow = new SidebarItem("Run Slow",
         loadIcon("/icons/runviz.png", 18), runSlowAction);
+    btnRunSlow.setToolTipText(_I("btnRunSlowMotionLabel"));
     topSection.add(btnRunSlow);
 
-    btnCapture = new SidebarItem(_I("btnCaptureLabel"),
+    btnCapture = new SidebarItem("Capture",
         loadIcon("/icons/capture-small.png", 18), captureAction);
+    btnCapture.setToolTipText(_I("btnCaptureLabel"));
     topSection.add(btnCapture);
 
     btnRecord = new SidebarItem("Record",
         loadIcon("/icons/record.png", 18), recordAction);
+    btnRecord.setToolTipText(_I("btnRecordLabel"));
     topSection.add(btnRecord);
 
     topSection.add(new JSeparator());

--- a/IDE/src/main/java/org/sikuli/ide/ui/OculixSidebar.java
+++ b/IDE/src/main/java/org/sikuli/ide/ui/OculixSidebar.java
@@ -1,0 +1,261 @@
+/*
+ * Copyright (c) 2010-2026, sikuli.org, sikulix.com, oculix-org - MIT license
+ */
+package org.sikuli.ide.ui;
+
+import com.formdev.flatlaf.FlatClientProperties;
+import com.formdev.flatlaf.FlatDarkLaf;
+import com.formdev.flatlaf.FlatLaf;
+import com.formdev.flatlaf.FlatLightLaf;
+import net.miginfocom.swing.MigLayout;
+
+import javax.swing.*;
+import java.awt.*;
+import java.awt.event.ActionListener;
+import java.awt.event.MouseAdapter;
+import java.awt.event.MouseEvent;
+
+import static org.sikuli.support.ide.SikuliIDEI18N._I;
+
+/**
+ * Vertical sidebar replacing the classic JMenuBar + JToolBar.
+ * Contains action buttons (Run, Stop, Capture, Record) and navigation
+ * items (File, Edit, Tools, Help) with popup submenus.
+ */
+public class OculixSidebar extends JPanel {
+
+  private boolean collapsed = false;
+  private int expandedWidth = 180;
+  private int collapsedWidth = 50;
+
+  // Action buttons
+  private SidebarItem btnRun;
+  private SidebarItem btnRunSlow;
+  private SidebarItem btnCapture;
+  private SidebarItem btnRecord;
+
+  // Navigation items
+  private SidebarItem navFile;
+  private SidebarItem navEdit;
+  private SidebarItem navTools;
+  private SidebarItem navHelp;
+
+  // Submenus
+  private SidebarSubmenu fileSubmenu;
+  private SidebarSubmenu editSubmenu;
+  private SidebarSubmenu toolsSubmenu;
+  private SidebarSubmenu helpSubmenu;
+
+  // Theme toggle
+  private SidebarItem btnTheme;
+  private boolean isDark = true;
+
+  // Version label
+  private JLabel versionLabel;
+
+  // Panels for layout
+  private JPanel topSection;
+  private JPanel bottomSection;
+  private JPanel footerSection;
+
+  public OculixSidebar() {
+    setLayout(new MigLayout("wrap 1, insets 8, fill", "[fill]", "[]0[]push[]0[]"));
+    setPreferredSize(new Dimension(expandedWidth, 0));
+    setMinimumSize(new Dimension(collapsedWidth, 0));
+    putClientProperty(FlatClientProperties.STYLE, "background: darken(@background, 3%)");
+
+    initSections();
+    addResizeHandle();
+  }
+
+  private void initSections() {
+    // Top section: logo + action buttons
+    topSection = new JPanel(new MigLayout("wrap 1, insets 4, gap 2", "[fill]"));
+    topSection.setOpaque(false);
+
+    JLabel logo = new JLabel("OculiX");
+    logo.setFont(UIManager.getFont("h3.font"));
+    logo.setHorizontalAlignment(SwingConstants.CENTER);
+    logo.setBorder(BorderFactory.createEmptyBorder(8, 0, 12, 0));
+    topSection.add(logo);
+
+    topSection.add(new JSeparator());
+
+    add(topSection, "growx");
+
+    // Bottom section: navigation items
+    bottomSection = new JPanel(new MigLayout("wrap 1, insets 4, gap 2", "[fill]"));
+    bottomSection.setOpaque(false);
+    add(bottomSection, "growx");
+
+    // Footer section: theme toggle + version
+    footerSection = new JPanel(new MigLayout("wrap 1, insets 4, gap 2", "[fill]"));
+    footerSection.setOpaque(false);
+    add(footerSection, "growx, dock south");
+  }
+
+  /**
+   * Initializes the action buttons section.
+   * Must be called after SikulixIDE creates its button actions.
+   */
+  public void initActionButtons(ActionListener runAction, ActionListener runSlowAction,
+                                 ActionListener captureAction, ActionListener recordAction) {
+    btnRun = new SidebarItem(_I("btnRunLabel"),
+        loadIcon("/icons/run_big_green.png", 18), runAction);
+    btnRun.setMnemonic(java.awt.event.KeyEvent.VK_R);
+    topSection.add(btnRun);
+
+    btnRunSlow = new SidebarItem(_I("btnRunSlowMotionLabel"),
+        loadIcon("/icons/runviz.png", 18), runSlowAction);
+    topSection.add(btnRunSlow);
+
+    btnCapture = new SidebarItem(_I("btnCaptureLabel"),
+        loadIcon("/icons/capture-small.png", 18), captureAction);
+    topSection.add(btnCapture);
+
+    btnRecord = new SidebarItem("Record",
+        loadIcon("/icons/record.png", 18), recordAction);
+    topSection.add(btnRecord);
+
+    topSection.add(new JSeparator());
+  }
+
+  /**
+   * Initializes the navigation items with popup submenus.
+   * File, Edit, Tools, Help — each opens a popup submenu on click.
+   */
+  public void initNavigation(SidebarSubmenu fileSub, SidebarSubmenu editSub,
+                              SidebarSubmenu toolsSub, SidebarSubmenu helpSub) {
+    this.fileSubmenu = fileSub;
+    this.editSubmenu = editSub;
+    this.toolsSubmenu = toolsSub;
+    this.helpSubmenu = helpSub;
+
+    navFile = createNavItem(_I("menuFile"), "\uD83D\uDCC1", fileSub);
+    navFile.setMnemonic(java.awt.event.KeyEvent.VK_F);
+    bottomSection.add(navFile);
+
+    navEdit = createNavItem(_I("menuEdit"), "\u270F\uFE0F", editSub);
+    navEdit.setMnemonic(java.awt.event.KeyEvent.VK_E);
+    bottomSection.add(navEdit);
+
+    navTools = createNavItem(_I("menuTool"), "\uD83D\uDD27", toolsSub);
+    navTools.setMnemonic(java.awt.event.KeyEvent.VK_T);
+    bottomSection.add(navTools);
+
+    navHelp = createNavItem(_I("menuHelp"), "\u2753", helpSub);
+    navHelp.setMnemonic(java.awt.event.KeyEvent.VK_H);
+    bottomSection.add(navHelp);
+  }
+
+  private SidebarItem createNavItem(String text, String emoji, SidebarSubmenu submenu) {
+    // Use a plain text icon as fallback since we don't have dedicated nav icons
+    SidebarItem item = new SidebarItem(text, null);
+    item.addActionListener(e -> submenu.showBelow(item));
+    return item;
+  }
+
+  /**
+   * Initializes the footer with theme toggle and version label.
+   */
+  public void initFooter(String version, ActionListener themeAction) {
+    footerSection.add(new JSeparator());
+
+    btnTheme = new SidebarItem("Dark / Light", null, e -> {
+      toggleTheme();
+      if (themeAction != null) {
+        themeAction.actionPerformed(e);
+      }
+    });
+    footerSection.add(btnTheme);
+
+    versionLabel = new JLabel(version);
+    versionLabel.setFont(UIManager.getFont("small.font"));
+    versionLabel.setHorizontalAlignment(SwingConstants.CENTER);
+    versionLabel.setForeground(UIManager.getColor("Label.disabledForeground"));
+    footerSection.add(versionLabel);
+  }
+
+  private void toggleTheme() {
+    isDark = !isDark;
+    try {
+      if (isDark) {
+        FlatDarkLaf.setup();
+      } else {
+        FlatLightLaf.setup();
+      }
+      FlatLaf.updateUI();
+    } catch (Exception ex) {
+      // Fallback: ignore theme switch failure
+    }
+  }
+
+  public boolean isDarkTheme() {
+    return isDark;
+  }
+
+  /**
+   * Toggle between collapsed (icons only, 50px) and expanded (icons + labels, 180px) mode.
+   */
+  public void toggleCollapsed() {
+    collapsed = !collapsed;
+    setPreferredSize(new Dimension(collapsed ? collapsedWidth : expandedWidth, 0));
+
+    // Update all SidebarItems
+    for (Component c : topSection.getComponents()) {
+      if (c instanceof SidebarItem) {
+        ((SidebarItem) c).setCollapsed(collapsed);
+      }
+    }
+    for (Component c : bottomSection.getComponents()) {
+      if (c instanceof SidebarItem) {
+        ((SidebarItem) c).setCollapsed(collapsed);
+      }
+    }
+    for (Component c : footerSection.getComponents()) {
+      if (c instanceof SidebarItem) {
+        ((SidebarItem) c).setCollapsed(collapsed);
+      }
+    }
+
+    // Hide/show version label and logo
+    versionLabel.setVisible(!collapsed);
+    Component logo = topSection.getComponent(0);
+    if (logo instanceof JLabel) {
+      ((JLabel) logo).setText(collapsed ? "OX" : "OculiX");
+    }
+
+    revalidate();
+    repaint();
+  }
+
+  public boolean isCollapsed() {
+    return collapsed;
+  }
+
+  private void addResizeHandle() {
+    // Double-click on sidebar border toggles collapsed/expanded
+    addMouseListener(new MouseAdapter() {
+      @Override
+      public void mouseClicked(MouseEvent e) {
+        if (e.getClickCount() == 2) {
+          toggleCollapsed();
+        }
+      }
+    });
+  }
+
+  private ImageIcon loadIcon(String path, int size) {
+    try {
+      java.net.URL url = getClass().getResource(path);
+      if (url != null) {
+        ImageIcon icon = new ImageIcon(url);
+        Image img = icon.getImage().getScaledInstance(size, size, Image.SCALE_SMOOTH);
+        return new ImageIcon(img);
+      }
+    } catch (Exception e) {
+      // ignore, return null
+    }
+    return null;
+  }
+}

--- a/IDE/src/main/java/org/sikuli/ide/ui/OculixSidebar.java
+++ b/IDE/src/main/java/org/sikuli/ide/ui/OculixSidebar.java
@@ -85,22 +85,20 @@ public class OculixSidebar extends JPanel {
    */
   public void initNavItems() {
     // ── Logo Box ──
-    JPanel logoBox = new JPanel(new MigLayout("wrap 1, insets 10 6 10 6, gap 0", "[center, fill]"));
+    JPanel logoBox = new JPanel(new MigLayout("wrap 1, insets 12 6 10 6, gap 0", "[grow, center]"));
     logoBox.setOpaque(true);
     logoBox.setBackground(UIManager.getColor("Panel.background"));
     logoBox.setBorder(BorderFactory.createLineBorder(UIManager.getColor("Component.borderColor"), 1));
 
-    JLabel logoLine1 = new JLabel("OculiX");
-    logoLine1.setFont(new Font("Serif", Font.BOLD | Font.ITALIC, 28));
-    logoLine1.setForeground(UIManager.getColor("Label.foreground"));
-    logoLine1.setHorizontalAlignment(SwingConstants.CENTER);
-    logoBox.add(logoLine1);
+    JLabel logoLine1 = new JLabel("OculiX", SwingConstants.CENTER);
+    logoLine1.setFont(new Font("Serif", Font.BOLD | Font.ITALIC, 30));
+    logoLine1.setForeground(new Color(0xE0, 0x60, 0x30)); // SikuliX-style orange/red
+    logoBox.add(logoLine1, "align center");
 
-    JLabel logoLine2 = new JLabel("I D E");
-    logoLine2.setFont(new Font("SansSerif", Font.PLAIN, 14));
+    JLabel logoLine2 = new JLabel("I D E", SwingConstants.CENTER);
+    logoLine2.setFont(new Font("SansSerif", Font.BOLD, 13));
     logoLine2.setForeground(UIManager.getColor("Label.disabledForeground"));
-    logoLine2.setHorizontalAlignment(SwingConstants.CENTER);
-    logoBox.add(logoLine2);
+    logoBox.add(logoLine2, "align center");
 
     mainPanel.add(logoBox, "growx, gapbottom 6");
 

--- a/IDE/src/main/java/org/sikuli/ide/ui/OculixSidebar.java
+++ b/IDE/src/main/java/org/sikuli/ide/ui/OculixSidebar.java
@@ -46,7 +46,8 @@ public class OculixSidebar extends JPanel {
 
   public OculixSidebar() {
     setLayout(new BorderLayout());
-    setMinimumSize(new Dimension(collapsedWidth, 0));
+    setPreferredSize(new Dimension(180, 0));
+    setMinimumSize(new Dimension(180, 0));
     putClientProperty(FlatClientProperties.STYLE, "background: darken(@background, 3%)");
 
     mainPanel = new JPanel(new MigLayout("wrap 1, insets 8, gap 0", "[fill, grow]", ""));

--- a/IDE/src/main/java/org/sikuli/ide/ui/OculixSidebar.java
+++ b/IDE/src/main/java/org/sikuli/ide/ui/OculixSidebar.java
@@ -14,19 +14,19 @@ import java.awt.*;
 import java.awt.event.ActionListener;
 import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
+import java.io.File;
 
 import static org.sikuli.support.ide.SikuliIDEI18N._I;
 
 /**
- * Vertical sidebar replacing the classic JMenuBar + JToolBar.
- * All actions are accessed via popup submenus for consistency.
+ * Vertical sidebar with navigation submenus and live info panels.
  */
 public class OculixSidebar extends JPanel {
 
   private boolean collapsed = false;
   private int collapsedWidth = 50;
 
-  // Navigation items (all with submenus)
+  // Navigation items
   private SidebarItem navFile;
   private SidebarItem navEdit;
   private SidebarItem navRun;
@@ -40,76 +40,223 @@ public class OculixSidebar extends JPanel {
   // Version label
   private JLabel versionLabel;
 
-  // Panels for layout sections
+  // Info panels
+  private JLabel projectName;
+  private JLabel projectPath;
+  private JLabel projectImages;
+  private JLabel ocrPaddleStatus;
+  private JLabel ocrTesseractStatus;
+  private JLabel javaInfo;
+  private JLabel lastRunResult;
+  private JLabel lastRunTime;
+  private JLabel lastRunDuration;
+
+  // Layout panels
   private JPanel mainPanel;
   private JPanel footerPanel;
 
   public OculixSidebar() {
     setLayout(new BorderLayout());
-    setPreferredSize(new Dimension(180, 0));
-    setMinimumSize(new Dimension(180, 0));
+    setPreferredSize(new Dimension(200, 0));
+    setMinimumSize(new Dimension(200, 0));
     putClientProperty(FlatClientProperties.STYLE, "background: darken(@background, 3%)");
 
-    mainPanel = new JPanel(new MigLayout("wrap 1, insets 8, gap 0", "[fill, grow]", ""));
+    mainPanel = new JPanel(new MigLayout("wrap 1, insets 8 10 8 10, gap 0", "[fill, grow]", ""));
     mainPanel.setOpaque(false);
 
-    footerPanel = new JPanel(new MigLayout("wrap 1, insets 8, gap 2", "[fill, grow]", ""));
+    footerPanel = new JPanel(new MigLayout("wrap 1, insets 4 10 8 10, gap 2", "[fill, grow]", ""));
     footerPanel.setOpaque(false);
 
-    add(mainPanel, BorderLayout.NORTH);
+    JScrollPane scroll = new JScrollPane(mainPanel);
+    scroll.setBorder(null);
+    scroll.setHorizontalScrollBarPolicy(ScrollPaneConstants.HORIZONTAL_SCROLLBAR_NEVER);
+    scroll.getVerticalScrollBar().setUnitIncrement(12);
+    scroll.setOpaque(false);
+    scroll.getViewport().setOpaque(false);
+
+    add(scroll, BorderLayout.CENTER);
     add(footerPanel, BorderLayout.SOUTH);
 
     addResizeHandle();
   }
 
   /**
-   * Initializes the sidebar with logo and all navigation items.
-   * All items open popup submenus — no direct action buttons.
+   * Initializes the full sidebar layout: logo, project info, nav, status, last run, help.
    */
   public void initNavItems() {
-    // Logo
+    // ── Logo ──
     JLabel logo = new JLabel("OculiX");
-    logo.setFont(UIManager.getFont("h3.font"));
+    logo.setFont(UIManager.getFont("h2.font"));
     logo.setHorizontalAlignment(SwingConstants.CENTER);
-    logo.setBorder(BorderFactory.createEmptyBorder(8, 0, 8, 0));
+    logo.setBorder(BorderFactory.createEmptyBorder(4, 0, 2, 0));
     mainPanel.add(logo);
 
-    mainPanel.add(new JSeparator(), "growx, gaptop 4, gapbottom 8");
+    JLabel edition = new JLabel("IDE");
+    edition.setFont(UIManager.getFont("small.font"));
+    edition.setForeground(UIManager.getColor("Label.disabledForeground"));
+    edition.setHorizontalAlignment(SwingConstants.CENTER);
+    mainPanel.add(edition, "gapbottom 6");
 
-    // File
+    // ── Project Info Panel ──
+    JPanel projectPanel = createInfoPanel();
+    projectName = new JLabel("\u2014 No script open");
+    projectName.setFont(UIManager.getFont("defaultFont").deriveFont(Font.BOLD, 12f));
+    projectPanel.add(projectName, "span 2");
+    projectPath = new JLabel("");
+    projectPath.setFont(UIManager.getFont("small.font"));
+    projectPath.setForeground(UIManager.getColor("Label.disabledForeground"));
+    projectPanel.add(projectPath, "span 2");
+    projectImages = new JLabel("");
+    projectImages.setFont(UIManager.getFont("small.font"));
+    projectImages.setForeground(UIManager.getColor("Label.disabledForeground"));
+    projectPanel.add(projectImages, "span 2");
+    mainPanel.add(projectPanel, "gaptop 4, gapbottom 6");
+
+    // ── SCRIPT section ──
+    addSectionHeader("SCRIPT");
     navFile = new SidebarItem(_I("menuFile") + "  \u25B8",
         loadIcon("/icons/insert-image-icon.png", 16));
     navFile.setMnemonic(java.awt.event.KeyEvent.VK_F);
     mainPanel.add(navFile);
-
-    // Edit
     navEdit = new SidebarItem(_I("menuEdit") + "  \u25B8", null);
     navEdit.setMnemonic(java.awt.event.KeyEvent.VK_E);
     mainPanel.add(navEdit);
-
-    // Run
     navRun = new SidebarItem(_I("menuRun") + "  \u25B8",
         loadIcon("/icons/run_big_green.png", 16));
     navRun.setMnemonic(java.awt.event.KeyEvent.VK_R);
     mainPanel.add(navRun);
 
-    mainPanel.add(new JSeparator(), "growx, gaptop 8, gapbottom 8");
-
-    // Tools (Capture, Record, Extensions)
+    // ── TOOLS section ──
+    addSectionHeader("TOOLS");
     navTools = new SidebarItem(_I("menuTool") + "  \u25B8",
         loadIcon("/icons/capture-small.png", 16));
     navTools.setMnemonic(java.awt.event.KeyEvent.VK_T);
     mainPanel.add(navTools);
 
-    // Help
+    // ── STATUS section ──
+    addSectionHeader("STATUS");
+    JPanel statusPanel = createInfoPanel();
+    ocrPaddleStatus = createStatusLabel("\u2B24 PaddleOCR", statusPanel);
+    ocrTesseractStatus = createStatusLabel("\u2B24 Tesseract", statusPanel);
+    javaInfo = createStatusLabel("", statusPanel);
+    mainPanel.add(statusPanel, "gapbottom 6");
+
+    // ── LAST RUN section ──
+    addSectionHeader("LAST RUN");
+    JPanel lastRunPanel = createInfoPanel();
+    lastRunResult = new JLabel("\u2014 Not run yet");
+    lastRunResult.setFont(UIManager.getFont("defaultFont").deriveFont(Font.BOLD, 11f));
+    lastRunPanel.add(lastRunResult, "span 2");
+    lastRunDuration = new JLabel("");
+    lastRunDuration.setFont(UIManager.getFont("small.font"));
+    lastRunDuration.setForeground(UIManager.getColor("Label.disabledForeground"));
+    lastRunPanel.add(lastRunDuration, "span 2");
+    lastRunTime = new JLabel("");
+    lastRunTime.setFont(UIManager.getFont("small.font"));
+    lastRunTime.setForeground(UIManager.getColor("Label.disabledForeground"));
+    lastRunPanel.add(lastRunTime, "span 2");
+    mainPanel.add(lastRunPanel, "gapbottom 6");
+
+    // ── HELP section ──
+    addSectionHeader("HELP");
     navHelp = new SidebarItem(_I("menuHelp") + "  \u25B8", null);
     navHelp.setMnemonic(java.awt.event.KeyEvent.VK_H);
     mainPanel.add(navHelp);
+
+    // Initial status check
+    refreshOcrStatus();
+  }
+
+  private JPanel createInfoPanel() {
+    JPanel panel = new JPanel(new MigLayout("wrap 2, insets 6, gap 2", "[fill, grow]", ""));
+    panel.setOpaque(true);
+    panel.setBackground(UIManager.getColor("Panel.background"));
+    panel.setBorder(BorderFactory.createCompoundBorder(
+        BorderFactory.createLineBorder(UIManager.getColor("Separator.foreground"), 1),
+        BorderFactory.createEmptyBorder(4, 6, 4, 6)));
+    return panel;
+  }
+
+  private JLabel createStatusLabel(String text, JPanel parent) {
+    JLabel label = new JLabel(text);
+    label.setFont(UIManager.getFont("small.font"));
+    parent.add(label, "span 2");
+    return label;
+  }
+
+  private void addSectionHeader(String text) {
+    JLabel header = new JLabel(text);
+    header.setFont(UIManager.getFont("small.font"));
+    header.setForeground(UIManager.getColor("Label.disabledForeground"));
+    header.setBorder(BorderFactory.createEmptyBorder(10, 4, 3, 0));
+    mainPanel.add(header);
+  }
+
+  // ── Public API for live updates ──
+
+  /**
+   * Updates the project info panel when a script is opened.
+   */
+  public void updateProjectInfo(String name, File scriptDir) {
+    if (name == null || name.isEmpty()) {
+      projectName.setText("\u2014 No script open");
+      projectPath.setText("");
+      projectImages.setText("");
+      return;
+    }
+    projectName.setText("\uD83D\uDCC4 " + name);
+    projectPath.setText(scriptDir != null ? truncatePath(scriptDir.getAbsolutePath(), 25) : "");
+    projectPath.setToolTipText(scriptDir != null ? scriptDir.getAbsolutePath() : "");
+
+    // Count images in script bundle
+    int imgCount = 0;
+    if (scriptDir != null && scriptDir.exists()) {
+      File[] pngs = scriptDir.listFiles((dir, fn) -> fn.endsWith(".png"));
+      if (pngs != null) imgCount = pngs.length;
+    }
+    projectImages.setText("\uD83D\uDDBC " + imgCount + " image" + (imgCount != 1 ? "s" : ""));
   }
 
   /**
-   * Wires navigation items to popup submenus.
+   * Updates the last run result panel.
    */
+  public void updateLastRun(int exitCode, long durationMs) {
+    if (exitCode == 0) {
+      lastRunResult.setText("\u2705 Passed");
+      lastRunResult.setForeground(new Color(0x3D, 0xDB, 0xA4));
+    } else {
+      lastRunResult.setText("\u274C Failed (code " + exitCode + ")");
+      lastRunResult.setForeground(new Color(0xFF, 0x6B, 0x6B));
+    }
+    lastRunDuration.setText("\u23F1 " + String.format("%.1fs", durationMs / 1000.0));
+    lastRunTime.setText(new java.text.SimpleDateFormat("dd/MM/yyyy HH:mm:ss").format(new java.util.Date()));
+  }
+
+  /**
+   * Refreshes OCR engine status indicators.
+   */
+  public void refreshOcrStatus() {
+    // PaddleOCR
+    boolean paddleOk = false;
+    try {
+      Class<?> engineClass = Class.forName("com.sikulix.ocr.PaddleOCREngine");
+      Object engine = engineClass.getDeclaredConstructor().newInstance();
+      paddleOk = (boolean) engineClass.getMethod("isAvailable").invoke(engine);
+    } catch (Exception ignored) {}
+    ocrPaddleStatus.setText("\u2B24 PaddleOCR" + (paddleOk ? "  OK" : ""));
+    ocrPaddleStatus.setForeground(paddleOk ? new Color(0x3D, 0xDB, 0xA4) : new Color(0xFF, 0x6B, 0x6B));
+
+    // Tesseract (always bundled)
+    ocrTesseractStatus.setText("\u2B24 Tesseract  built-in");
+    ocrTesseractStatus.setForeground(new Color(0x3D, 0xDB, 0xA4));
+
+    // Java info
+    javaInfo.setText("\u2615 Java " + System.getProperty("java.version"));
+    javaInfo.setForeground(UIManager.getColor("Label.disabledForeground"));
+  }
+
+  // ── Navigation wiring ──
+
   public void initNavigation(SidebarSubmenu fileSub, SidebarSubmenu editSub,
                               SidebarSubmenu runSub, SidebarSubmenu toolsSub,
                               SidebarSubmenu helpSub) {
@@ -120,20 +267,15 @@ public class OculixSidebar extends JPanel {
     navHelp.addActionListener(e -> helpSub.showBelow(navHelp));
   }
 
-  /**
-   * Initializes the footer with theme toggle and version label.
-   */
+  // ── Footer ──
+
   public void initFooter(String version, ActionListener themeAction) {
     footerPanel.add(new JSeparator(), "growx, gapbottom 4");
-
     btnTheme = new SidebarItem("\u263C  Dark / Light", null, e -> {
       toggleTheme();
-      if (themeAction != null) {
-        themeAction.actionPerformed(e);
-      }
+      if (themeAction != null) themeAction.actionPerformed(e);
     });
     footerPanel.add(btnTheme);
-
     versionLabel = new JLabel("v" + version);
     versionLabel.setFont(UIManager.getFont("small.font"));
     versionLabel.setHorizontalAlignment(SwingConstants.CENTER);
@@ -144,59 +286,44 @@ public class OculixSidebar extends JPanel {
   private void toggleTheme() {
     isDark = !isDark;
     try {
-      if (isDark) {
-        FlatDarkLaf.setup();
-      } else {
-        FlatLightLaf.setup();
-      }
+      if (isDark) FlatDarkLaf.setup(); else FlatLightLaf.setup();
       FlatLaf.updateUI();
-    } catch (Exception ex) {
-      // Fallback: ignore theme switch failure
-    }
+    } catch (Exception ex) {}
   }
 
-  public boolean isDarkTheme() {
-    return isDark;
-  }
+  public boolean isDarkTheme() { return isDark; }
 
-  /**
-   * Toggle between collapsed (icons only) and expanded (icons + labels) mode.
-   */
+  // ── Collapse ──
+
   public void toggleCollapsed() {
     collapsed = !collapsed;
-
     for (Component c : mainPanel.getComponents()) {
-      if (c instanceof SidebarItem) {
-        ((SidebarItem) c).setCollapsed(collapsed);
-      }
-      if (c instanceof JLabel && !(c instanceof SidebarItem)) {
-        c.setVisible(!collapsed);
-      }
+      if (c instanceof SidebarItem) ((SidebarItem) c).setCollapsed(collapsed);
+      if (c instanceof JLabel && !(c instanceof SidebarItem)) c.setVisible(!collapsed);
+      if (c instanceof JPanel && c != mainPanel) c.setVisible(!collapsed);
     }
     for (Component c : footerPanel.getComponents()) {
-      if (c instanceof SidebarItem) {
-        ((SidebarItem) c).setCollapsed(collapsed);
-      }
+      if (c instanceof SidebarItem) ((SidebarItem) c).setCollapsed(collapsed);
     }
     versionLabel.setVisible(!collapsed);
-
     revalidate();
     repaint();
   }
 
-  public boolean isCollapsed() {
-    return collapsed;
-  }
+  public boolean isCollapsed() { return collapsed; }
 
   private void addResizeHandle() {
     addMouseListener(new MouseAdapter() {
       @Override
       public void mouseClicked(MouseEvent e) {
-        if (e.getClickCount() == 2) {
-          toggleCollapsed();
-        }
+        if (e.getClickCount() == 2) toggleCollapsed();
       }
     });
+  }
+
+  private String truncatePath(String path, int maxLen) {
+    if (path.length() <= maxLen) return path;
+    return "..." + path.substring(path.length() - maxLen + 3);
   }
 
   private ImageIcon loadIcon(String path, int size) {
@@ -207,9 +334,7 @@ public class OculixSidebar extends JPanel {
         Image img = icon.getImage().getScaledInstance(size, size, Image.SCALE_SMOOTH);
         return new ImageIcon(img);
       }
-    } catch (Exception e) {
-      // ignore, return null
-    }
+    } catch (Exception e) {}
     return null;
   }
 }

--- a/IDE/src/main/java/org/sikuli/ide/ui/OculixSidebar.java
+++ b/IDE/src/main/java/org/sikuli/ide/ui/OculixSidebar.java
@@ -19,22 +19,17 @@ import static org.sikuli.support.ide.SikuliIDEI18N._I;
 
 /**
  * Vertical sidebar replacing the classic JMenuBar + JToolBar.
- * Organized in logical groups: Run, Scripts, Tools, Help.
+ * All actions are accessed via popup submenus for consistency.
  */
 public class OculixSidebar extends JPanel {
 
   private boolean collapsed = false;
   private int collapsedWidth = 50;
 
-  // Action buttons
-  private SidebarItem btnRun;
-  private SidebarItem btnRunSlow;
-  private SidebarItem btnCapture;
-  private SidebarItem btnRecord;
-
-  // Navigation items
+  // Navigation items (all with submenus)
   private SidebarItem navFile;
   private SidebarItem navEdit;
+  private SidebarItem navRun;
   private SidebarItem navTools;
   private SidebarItem navHelp;
 
@@ -66,20 +61,11 @@ public class OculixSidebar extends JPanel {
     addResizeHandle();
   }
 
-  private JLabel addSectionHeader(String text) {
-    JLabel header = new JLabel(text);
-    header.setFont(UIManager.getFont("small.font"));
-    header.setForeground(UIManager.getColor("Label.disabledForeground"));
-    header.setBorder(BorderFactory.createEmptyBorder(12, 8, 4, 0));
-    mainPanel.add(header);
-    return header;
-  }
-
   /**
-   * Initializes the action buttons section.
+   * Initializes the sidebar with logo and all navigation items.
+   * All items open popup submenus — no direct action buttons.
    */
-  public void initActionButtons(ActionListener runAction, ActionListener runSlowAction,
-                                 ActionListener captureAction, ActionListener recordAction) {
+  public void initNavItems() {
     // Logo
     JLabel logo = new JLabel("OculiX");
     logo.setFont(UIManager.getFont("h3.font"));
@@ -87,63 +73,48 @@ public class OculixSidebar extends JPanel {
     logo.setBorder(BorderFactory.createEmptyBorder(8, 0, 8, 0));
     mainPanel.add(logo);
 
-    mainPanel.add(new JSeparator(), "growx, gaptop 4, gapbottom 4");
+    mainPanel.add(new JSeparator(), "growx, gaptop 4, gapbottom 8");
 
-    // Run group
-    btnRun = new SidebarItem("Run",
-        loadIcon("/icons/run_big_green.png", 18), runAction);
-    btnRun.setToolTipText(_I("btnRunLabel") + " (Ctrl+R)");
-    btnRun.setMnemonic(java.awt.event.KeyEvent.VK_R);
-    mainPanel.add(btnRun);
-
-    btnRunSlow = new SidebarItem("Run Slow",
-        loadIcon("/icons/runviz.png", 18), runSlowAction);
-    btnRunSlow.setToolTipText(_I("btnRunSlowMotionLabel"));
-    mainPanel.add(btnRunSlow);
-
-    // Scripts group
-    addSectionHeader("SCRIPTS");
-
-    navFile = new SidebarItem(_I("menuFile") + "  \u25B8", null);
+    // File
+    navFile = new SidebarItem(_I("menuFile") + "  \u25B8",
+        loadIcon("/icons/insert-image-icon.png", 16));
     navFile.setMnemonic(java.awt.event.KeyEvent.VK_F);
     mainPanel.add(navFile);
 
+    // Edit
     navEdit = new SidebarItem(_I("menuEdit") + "  \u25B8", null);
     navEdit.setMnemonic(java.awt.event.KeyEvent.VK_E);
     mainPanel.add(navEdit);
 
-    // Tools group
-    addSectionHeader("TOOLS");
+    // Run
+    navRun = new SidebarItem(_I("menuRun") + "  \u25B8",
+        loadIcon("/icons/run_big_green.png", 16));
+    navRun.setMnemonic(java.awt.event.KeyEvent.VK_R);
+    mainPanel.add(navRun);
 
-    btnCapture = new SidebarItem("Capture",
-        loadIcon("/icons/capture-small.png", 18), captureAction);
-    btnCapture.setToolTipText(_I("btnCaptureLabel"));
-    mainPanel.add(btnCapture);
+    mainPanel.add(new JSeparator(), "growx, gaptop 8, gapbottom 8");
 
-    btnRecord = new SidebarItem("Record",
-        loadIcon("/icons/record.png", 18), recordAction);
-    btnRecord.setToolTipText(_I("btnRecordLabel"));
-    mainPanel.add(btnRecord);
-
-    navTools = new SidebarItem(_I("menuTool") + "  \u25B8", null);
+    // Tools (Capture, Record, Extensions)
+    navTools = new SidebarItem(_I("menuTool") + "  \u25B8",
+        loadIcon("/icons/capture-small.png", 16));
     navTools.setMnemonic(java.awt.event.KeyEvent.VK_T);
     mainPanel.add(navTools);
 
-    // Help group
-    addSectionHeader("HELP");
-
+    // Help
     navHelp = new SidebarItem(_I("menuHelp") + "  \u25B8", null);
     navHelp.setMnemonic(java.awt.event.KeyEvent.VK_H);
     mainPanel.add(navHelp);
   }
 
   /**
-   * Wires navigation items to popup submenus built from existing JMenu actions.
+   * Wires navigation items to popup submenus.
    */
   public void initNavigation(SidebarSubmenu fileSub, SidebarSubmenu editSub,
-                              SidebarSubmenu toolsSub, SidebarSubmenu helpSub) {
+                              SidebarSubmenu runSub, SidebarSubmenu toolsSub,
+                              SidebarSubmenu helpSub) {
     navFile.addActionListener(e -> fileSub.showBelow(navFile));
     navEdit.addActionListener(e -> editSub.showBelow(navEdit));
+    navRun.addActionListener(e -> runSub.showBelow(navRun));
     navTools.addActionListener(e -> toolsSub.showBelow(navTools));
     navHelp.addActionListener(e -> helpSub.showBelow(navHelp));
   }

--- a/IDE/src/main/java/org/sikuli/ide/ui/ScriptExplorer.java
+++ b/IDE/src/main/java/org/sikuli/ide/ui/ScriptExplorer.java
@@ -1,0 +1,207 @@
+/*
+ * Copyright (c) 2010-2026, sikuli.org, sikulix.com, oculix-org - MIT license
+ */
+package org.sikuli.ide.ui;
+
+import net.miginfocom.swing.MigLayout;
+
+import javax.swing.*;
+import javax.swing.tree.DefaultMutableTreeNode;
+import javax.swing.tree.DefaultTreeCellRenderer;
+import javax.swing.tree.DefaultTreeModel;
+import java.awt.*;
+import java.awt.event.MouseAdapter;
+import java.awt.event.MouseEvent;
+import java.io.File;
+import java.util.Arrays;
+import java.util.Comparator;
+
+/**
+ * File explorer panel showing the contents of the active .sikuli script bundle.
+ * Displays script files and captured images in a tree view.
+ */
+public class ScriptExplorer extends JPanel {
+
+  private JTree fileTree;
+  private DefaultTreeModel treeModel;
+  private DefaultMutableTreeNode rootNode;
+  private JLabel emptyLabel;
+  private JScrollPane scrollPane;
+  private File currentDir;
+
+  public ScriptExplorer() {
+    setLayout(new BorderLayout());
+    setMinimumSize(new Dimension(140, 0));
+    setPreferredSize(new Dimension(180, 0));
+
+    // Header
+    JPanel header = new JPanel(new MigLayout("insets 4 8 4 8, fill", "[grow]", "[]"));
+    header.setOpaque(false);
+    JLabel title = new JLabel("Explorer");
+    title.setFont(UIManager.getFont("defaultFont").deriveFont(Font.BOLD, 11f));
+    header.add(title);
+    add(header, BorderLayout.NORTH);
+
+    // Tree
+    rootNode = new DefaultMutableTreeNode("No script");
+    treeModel = new DefaultTreeModel(rootNode);
+    fileTree = new JTree(treeModel);
+    fileTree.setRootVisible(true);
+    fileTree.setShowsRootHandles(true);
+    fileTree.setCellRenderer(new FileTreeCellRenderer());
+    fileTree.setBorder(BorderFactory.createEmptyBorder(4, 8, 4, 4));
+
+    fileTree.addMouseListener(new MouseAdapter() {
+      @Override
+      public void mouseClicked(MouseEvent e) {
+        if (e.getClickCount() == 2) {
+          DefaultMutableTreeNode node = (DefaultMutableTreeNode) fileTree.getLastSelectedPathComponent();
+          if (node != null && node.getUserObject() instanceof FileNode) {
+            FileNode fn = (FileNode) node.getUserObject();
+            if (fn.file.getName().endsWith(".png")) {
+              openImage(fn.file);
+            }
+          }
+        }
+      }
+    });
+
+    scrollPane = new JScrollPane(fileTree);
+    scrollPane.setBorder(null);
+
+    // Empty state
+    emptyLabel = new JLabel("<html><center>Open or create a script<br>to browse files</center></html>");
+    emptyLabel.setFont(UIManager.getFont("small.font"));
+    emptyLabel.setForeground(UIManager.getColor("Label.disabledForeground"));
+    emptyLabel.setHorizontalAlignment(SwingConstants.CENTER);
+
+    add(emptyLabel, BorderLayout.CENTER);
+  }
+
+  /**
+   * Updates the explorer to show the contents of the given script directory.
+   * Pass null to show the empty state.
+   */
+  public void setScriptDirectory(File dir) {
+    this.currentDir = dir;
+
+    if (dir == null || !dir.exists()) {
+      showEmpty();
+      return;
+    }
+
+    remove(emptyLabel);
+    remove(scrollPane);
+
+    rootNode.removeAllChildren();
+    rootNode.setUserObject(dir.getName());
+
+    File[] files = dir.listFiles();
+    if (files != null) {
+      // Sort: .py first, then .png, then rest
+      Arrays.sort(files, Comparator
+          .comparingInt((File f) -> f.getName().endsWith(".py") ? 0 : f.getName().endsWith(".png") ? 1 : 2)
+          .thenComparing(File::getName));
+
+      int imageCount = 0;
+      DefaultMutableTreeNode imagesNode = new DefaultMutableTreeNode("Images");
+
+      for (File file : files) {
+        if (file.isDirectory()) continue; // skip subdirectories
+        if (file.getName().endsWith(".png")) {
+          imagesNode.add(new DefaultMutableTreeNode(new FileNode(file)));
+          imageCount++;
+        } else {
+          rootNode.add(new DefaultMutableTreeNode(new FileNode(file)));
+        }
+      }
+
+      if (imageCount > 0) {
+        imagesNode.setUserObject("Images (" + imageCount + ")");
+        rootNode.add(imagesNode);
+      }
+    }
+
+    treeModel.reload();
+    expandAll();
+
+    add(scrollPane, BorderLayout.CENTER);
+    revalidate();
+    repaint();
+  }
+
+  private void showEmpty() {
+    remove(scrollPane);
+    remove(emptyLabel);
+    add(emptyLabel, BorderLayout.CENTER);
+    revalidate();
+    repaint();
+  }
+
+  public void refresh() {
+    if (currentDir != null) {
+      setScriptDirectory(currentDir);
+    }
+  }
+
+  private void expandAll() {
+    for (int i = 0; i < fileTree.getRowCount(); i++) {
+      fileTree.expandRow(i);
+    }
+  }
+
+  private void openImage(File imageFile) {
+    try {
+      Desktop.getDesktop().open(imageFile);
+    } catch (Exception e) {
+      // Fallback: ignore
+    }
+  }
+
+  // ── Inner classes ──
+
+  static class FileNode {
+    final File file;
+
+    FileNode(File file) {
+      this.file = file;
+    }
+
+    @Override
+    public String toString() {
+      return file.getName();
+    }
+  }
+
+  static class FileTreeCellRenderer extends DefaultTreeCellRenderer {
+    @Override
+    public Component getTreeCellRendererComponent(JTree tree, Object value, boolean sel,
+                                                   boolean expanded, boolean leaf, int row, boolean hasFocus) {
+      super.getTreeCellRendererComponent(tree, value, sel, expanded, leaf, row, hasFocus);
+
+      if (value instanceof DefaultMutableTreeNode) {
+        Object obj = ((DefaultMutableTreeNode) value).getUserObject();
+        if (obj instanceof FileNode) {
+          FileNode fn = (FileNode) obj;
+          String name = fn.file.getName();
+          if (name.endsWith(".py")) {
+            setText("\uD83D\uDCC4 " + name);
+          } else if (name.endsWith(".png")) {
+            setText("\uD83D\uDDBC " + name);
+          } else if (name.endsWith(".html") || name.endsWith(".json")) {
+            setText("\uD83D\uDCC3 " + name);
+          } else {
+            setText("\uD83D\uDCCE " + name);
+          }
+        } else if (obj instanceof String) {
+          String s = (String) obj;
+          if (s.startsWith("Images")) {
+            setText("\uD83D\uDCC2 " + s);
+          }
+        }
+      }
+      setOpaque(false);
+      return this;
+    }
+  }
+}

--- a/IDE/src/main/java/org/sikuli/ide/ui/ScriptExplorer.java
+++ b/IDE/src/main/java/org/sikuli/ide/ui/ScriptExplorer.java
@@ -3,211 +3,248 @@
  */
 package org.sikuli.ide.ui;
 
+import com.formdev.flatlaf.FlatClientProperties;
 import net.miginfocom.swing.MigLayout;
 
 import javax.swing.*;
-import javax.swing.tree.DefaultMutableTreeNode;
-import javax.swing.tree.DefaultTreeCellRenderer;
-import javax.swing.tree.DefaultTreeModel;
 import java.awt.*;
+import java.awt.event.ActionListener;
 import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
 import java.io.File;
-import java.util.Arrays;
-import java.util.Comparator;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
- * File explorer panel showing the contents of the active .sikuli script bundle.
- * Displays script files and captured images in a tree view.
+ * Workspace explorer showing open scripts as visual cards.
+ * Each card represents a script (.sikuli bundle or temp script).
+ * Clicking a card activates the corresponding editor tab.
  */
 public class ScriptExplorer extends JPanel {
 
-  private JTree fileTree;
-  private DefaultTreeModel treeModel;
-  private DefaultMutableTreeNode rootNode;
+  private JPanel cardContainer;
   private JLabel emptyLabel;
   private JScrollPane scrollPane;
-  private File currentDir;
+  private final List<ScriptCard> cards = new ArrayList<>();
+  private int activeIndex = -1;
+
+  // Callback to switch tabs when a card is clicked
+  private ActionListener onCardSelected;
 
   public ScriptExplorer() {
     setLayout(new BorderLayout());
-    setMinimumSize(new Dimension(140, 0));
-    setPreferredSize(new Dimension(180, 0));
+    setMinimumSize(new Dimension(160, 0));
+    setPreferredSize(new Dimension(200, 0));
 
     // Header
-    JPanel header = new JPanel(new MigLayout("insets 4 8 4 8, fill", "[grow]", "[]"));
+    JPanel header = new JPanel(new MigLayout("insets 6 10 6 10, fill", "[grow]", "[]"));
     header.setOpaque(false);
-    JLabel title = new JLabel("Explorer");
-    title.setFont(UIManager.getFont("defaultFont").deriveFont(Font.BOLD, 11f));
+    JLabel title = new JLabel("Workspace");
+    title.setFont(UIManager.getFont("defaultFont").deriveFont(Font.BOLD, 12f));
     header.add(title);
     add(header, BorderLayout.NORTH);
 
-    // Tree
-    rootNode = new DefaultMutableTreeNode("No script");
-    treeModel = new DefaultTreeModel(rootNode);
-    fileTree = new JTree(treeModel);
-    fileTree.setRootVisible(true);
-    fileTree.setShowsRootHandles(true);
-    fileTree.setCellRenderer(new FileTreeCellRenderer());
-    fileTree.setBorder(BorderFactory.createEmptyBorder(4, 8, 4, 4));
+    // Card container (scrollable)
+    cardContainer = new JPanel(new MigLayout("wrap 1, insets 4 6 4 6, gap 4", "[fill, grow]", ""));
+    cardContainer.setOpaque(false);
 
-    fileTree.addMouseListener(new MouseAdapter() {
-      @Override
-      public void mouseClicked(MouseEvent e) {
-        if (e.getClickCount() == 2) {
-          DefaultMutableTreeNode node = (DefaultMutableTreeNode) fileTree.getLastSelectedPathComponent();
-          if (node != null && node.getUserObject() instanceof FileNode) {
-            FileNode fn = (FileNode) node.getUserObject();
-            if (fn.file.getName().endsWith(".png")) {
-              openImage(fn.file);
-            }
-          }
-        }
-      }
-    });
-
-    scrollPane = new JScrollPane(fileTree);
+    scrollPane = new JScrollPane(cardContainer);
     scrollPane.setBorder(null);
+    scrollPane.setHorizontalScrollBarPolicy(ScrollPaneConstants.HORIZONTAL_SCROLLBAR_NEVER);
+    scrollPane.getVerticalScrollBar().setUnitIncrement(12);
+    scrollPane.setOpaque(false);
+    scrollPane.getViewport().setOpaque(false);
 
     // Empty state
-    emptyLabel = new JLabel("<html><center>Open or create a script<br>to browse files</center></html>");
-    emptyLabel.setFont(UIManager.getFont("small.font"));
+    emptyLabel = new JLabel("<html><center>No scripts open<br><br><span style='font-size:9px'>Use File \u25B8 New<br>to create a script</span></center></html>");
+    emptyLabel.setFont(UIManager.getFont("defaultFont").deriveFont(11f));
     emptyLabel.setForeground(UIManager.getColor("Label.disabledForeground"));
     emptyLabel.setHorizontalAlignment(SwingConstants.CENTER);
 
     add(emptyLabel, BorderLayout.CENTER);
   }
 
-  /**
-   * Updates the explorer to show the contents of the given script directory.
-   * Pass null to show the empty state.
-   */
-  public void setScriptDirectory(File dir) {
-    this.currentDir = dir;
+  public void setOnCardSelected(ActionListener listener) {
+    this.onCardSelected = listener;
+  }
 
-    if (dir == null) {
-      showEmpty();
+  /**
+   * Rebuilds the card list from the given script contexts.
+   * Call this whenever tabs change.
+   */
+  public void updateScripts(List<ScriptInfo> scripts, int selectedIndex) {
+    cards.clear();
+    cardContainer.removeAll();
+
+    if (scripts.isEmpty()) {
+      remove(scrollPane);
+      remove(emptyLabel);
+      add(emptyLabel, BorderLayout.CENTER);
+      activeIndex = -1;
+      revalidate();
+      repaint();
       return;
     }
 
-    // Remove both to avoid stacking
     remove(emptyLabel);
     remove(scrollPane);
 
-    if (!dir.exists()) {
-      showEmpty();
-      return;
+    for (int i = 0; i < scripts.size(); i++) {
+      ScriptInfo info = scripts.get(i);
+      ScriptCard card = new ScriptCard(info, i);
+      cards.add(card);
+      cardContainer.add(card, "growx");
     }
 
-    rootNode.removeAllChildren();
-    rootNode.setUserObject(dir.getName());
-
-    File[] files = dir.listFiles();
-    if (files != null) {
-      // Sort: .py first, then .png, then rest
-      Arrays.sort(files, Comparator
-          .comparingInt((File f) -> f.getName().endsWith(".py") ? 0 : f.getName().endsWith(".png") ? 1 : 2)
-          .thenComparing(File::getName));
-
-      int imageCount = 0;
-      DefaultMutableTreeNode imagesNode = new DefaultMutableTreeNode("Images");
-
-      for (File file : files) {
-        if (file.isDirectory()) continue; // skip subdirectories
-        if (file.getName().endsWith(".png")) {
-          imagesNode.add(new DefaultMutableTreeNode(new FileNode(file)));
-          imageCount++;
-        } else {
-          rootNode.add(new DefaultMutableTreeNode(new FileNode(file)));
-        }
-      }
-
-      if (imageCount > 0) {
-        imagesNode.setUserObject("Images (" + imageCount + ")");
-        rootNode.add(imagesNode);
-      }
-    }
-
-    treeModel.reload();
-    expandAll();
+    setActiveCard(selectedIndex);
 
     add(scrollPane, BorderLayout.CENTER);
     revalidate();
     repaint();
   }
 
-  private void showEmpty() {
-    remove(scrollPane);
-    remove(emptyLabel);
-    add(emptyLabel, BorderLayout.CENTER);
-    revalidate();
-    repaint();
-  }
-
-  public void refresh() {
-    if (currentDir != null) {
-      setScriptDirectory(currentDir);
+  /**
+   * Highlights the card at the given index.
+   */
+  public void setActiveCard(int index) {
+    activeIndex = index;
+    for (int i = 0; i < cards.size(); i++) {
+      cards.get(i).setActive(i == index);
     }
   }
 
-  private void expandAll() {
-    for (int i = 0; i < fileTree.getRowCount(); i++) {
-      fileTree.expandRow(i);
+  /**
+   * Updates a single card's info (e.g. after save/rename).
+   */
+  public void updateCard(int index, ScriptInfo info) {
+    if (index >= 0 && index < cards.size()) {
+      cards.get(index).updateInfo(info);
     }
   }
 
-  private void openImage(File imageFile) {
-    try {
-      Desktop.getDesktop().open(imageFile);
-    } catch (Exception e) {
-      // Fallback: ignore
-    }
-  }
+  // ── ScriptCard ──
 
-  // ── Inner classes ──
+  class ScriptCard extends JPanel {
+    private final int index;
+    private JLabel nameLabel;
+    private JLabel infoLabel;
+    private JLabel statusLabel;
+    private boolean active = false;
+    private final Color hoverBg;
+    private final Color activeBg;
+    private final Color normalBg;
 
-  static class FileNode {
-    final File file;
+    ScriptCard(ScriptInfo info, int index) {
+      this.index = index;
+      setLayout(new MigLayout("insets 8 10 8 10, gap 4", "[grow][]", "[]2[]"));
+      setCursor(Cursor.getPredefinedCursor(Cursor.HAND_CURSOR));
 
-    FileNode(File file) {
-      this.file = file;
-    }
+      normalBg = UIManager.getColor("Panel.background");
+      hoverBg = UIManager.getColor("List.selectionInactiveBackground");
+      activeBg = UIManager.getColor("List.selectionBackground");
 
-    @Override
-    public String toString() {
-      return file.getName();
-    }
-  }
+      setOpaque(true);
+      setBackground(normalBg);
+      setBorder(BorderFactory.createCompoundBorder(
+          BorderFactory.createLineBorder(UIManager.getColor("Component.borderColor"), 1),
+          BorderFactory.createEmptyBorder(0, 0, 0, 0)));
 
-  static class FileTreeCellRenderer extends DefaultTreeCellRenderer {
-    @Override
-    public Component getTreeCellRendererComponent(JTree tree, Object value, boolean sel,
-                                                   boolean expanded, boolean leaf, int row, boolean hasFocus) {
-      super.getTreeCellRendererComponent(tree, value, sel, expanded, leaf, row, hasFocus);
+      // Script icon + name
+      nameLabel = new JLabel();
+      nameLabel.setFont(UIManager.getFont("defaultFont").deriveFont(Font.BOLD, 12f));
+      add(nameLabel, "growx");
 
-      if (value instanceof DefaultMutableTreeNode) {
-        Object obj = ((DefaultMutableTreeNode) value).getUserObject();
-        if (obj instanceof FileNode) {
-          FileNode fn = (FileNode) obj;
-          String name = fn.file.getName();
-          if (name.endsWith(".py")) {
-            setText("\uD83D\uDCC4 " + name);
-          } else if (name.endsWith(".png")) {
-            setText("\uD83D\uDDBC " + name);
-          } else if (name.endsWith(".html") || name.endsWith(".json")) {
-            setText("\uD83D\uDCC3 " + name);
-          } else {
-            setText("\uD83D\uDCCE " + name);
-          }
-        } else if (obj instanceof String) {
-          String s = (String) obj;
-          if (s.startsWith("Images")) {
-            setText("\uD83D\uDCC2 " + s);
+      // Save status
+      statusLabel = new JLabel();
+      statusLabel.setFont(UIManager.getFont("small.font"));
+      add(statusLabel, "wrap");
+
+      // Image count
+      infoLabel = new JLabel();
+      infoLabel.setFont(UIManager.getFont("small.font"));
+      infoLabel.setForeground(UIManager.getColor("Label.disabledForeground"));
+      add(infoLabel, "span 2");
+
+      updateInfo(info);
+
+      addMouseListener(new MouseAdapter() {
+        @Override
+        public void mouseClicked(MouseEvent e) {
+          if (onCardSelected != null) {
+            onCardSelected.actionPerformed(
+                new java.awt.event.ActionEvent(ScriptCard.this, index, "select"));
           }
         }
+
+        @Override
+        public void mouseEntered(MouseEvent e) {
+          if (!active) {
+            setBackground(hoverBg);
+          }
+        }
+
+        @Override
+        public void mouseExited(MouseEvent e) {
+          setBackground(active ? activeBg : normalBg);
+        }
+      });
+    }
+
+    void updateInfo(ScriptInfo info) {
+      nameLabel.setText("\uD83D\uDCC4 " + info.name);
+      nameLabel.setToolTipText(info.path);
+
+      if (info.saved) {
+        statusLabel.setText("\u2713");
+        statusLabel.setForeground(new Color(0x3D, 0xDB, 0xA4));
+        statusLabel.setToolTipText("Saved");
+      } else {
+        statusLabel.setText("*");
+        statusLabel.setForeground(new Color(0xFF, 0xAA, 0x33));
+        statusLabel.setToolTipText("Not saved");
       }
-      setOpaque(false);
-      return this;
+
+      String imgText = info.imageCount + " image" + (info.imageCount != 1 ? "s" : "");
+      infoLabel.setText("\uD83D\uDDBC " + imgText);
+    }
+
+    void setActive(boolean active) {
+      this.active = active;
+      setBackground(active ? activeBg : normalBg);
+      if (active) {
+        nameLabel.setForeground(UIManager.getColor("List.selectionForeground"));
+        infoLabel.setForeground(UIManager.getColor("List.selectionForeground"));
+      } else {
+        nameLabel.setForeground(UIManager.getColor("Label.foreground"));
+        infoLabel.setForeground(UIManager.getColor("Label.disabledForeground"));
+      }
+    }
+  }
+
+  // ── ScriptInfo (data class) ──
+
+  public static class ScriptInfo {
+    public final String name;
+    public final String path;
+    public final int imageCount;
+    public final boolean saved;
+
+    public ScriptInfo(String name, String path, int imageCount, boolean saved) {
+      this.name = name;
+      this.path = path;
+      this.imageCount = imageCount;
+      this.saved = saved;
+    }
+
+    public static ScriptInfo fromFolder(String name, File folder, boolean isTemp) {
+      int imgCount = 0;
+      String path = "";
+      if (folder != null && folder.exists()) {
+        File[] pngs = folder.listFiles((dir, fn) -> fn.endsWith(".png"));
+        if (pngs != null) imgCount = pngs.length;
+        path = folder.getAbsolutePath();
+      }
+      return new ScriptInfo(name, path, imgCount, !isTemp);
     }
   }
 }

--- a/IDE/src/main/java/org/sikuli/ide/ui/ScriptExplorer.java
+++ b/IDE/src/main/java/org/sikuli/ide/ui/ScriptExplorer.java
@@ -23,13 +23,15 @@ import java.util.List;
 public class ScriptExplorer extends JPanel {
 
   private JPanel cardContainer;
+  private JLabel titleLabel;
   private JLabel emptyLabel;
   private JScrollPane scrollPane;
   private final List<ScriptCard> cards = new ArrayList<>();
   private int activeIndex = -1;
 
-  // Callback to switch tabs when a card is clicked
+  // Callbacks
   private ActionListener onCardSelected;
+  private ActionListener onCardRenamed;
 
   public ScriptExplorer() {
     setLayout(new BorderLayout());
@@ -39,9 +41,9 @@ public class ScriptExplorer extends JPanel {
     // Header
     JPanel header = new JPanel(new MigLayout("insets 6 10 6 10, fill", "[grow]", "[]"));
     header.setOpaque(false);
-    JLabel title = new JLabel("Workspace");
-    title.setFont(UIManager.getFont("defaultFont").deriveFont(Font.BOLD, 12f));
-    header.add(title);
+    titleLabel = new JLabel("Workspace");
+    titleLabel.setFont(UIManager.getFont("defaultFont").deriveFont(Font.BOLD, 12f));
+    header.add(titleLabel);
     add(header, BorderLayout.NORTH);
 
     // Card container (scrollable)
@@ -66,6 +68,14 @@ public class ScriptExplorer extends JPanel {
 
   public void setOnCardSelected(ActionListener listener) {
     this.onCardSelected = listener;
+  }
+
+  public void setWorkspaceName(String name) {
+    titleLabel.setText(name != null ? name : "Workspace");
+  }
+
+  public void setOnCardRenamed(ActionListener listener) {
+    this.onCardRenamed = listener;
   }
 
   /**
@@ -167,10 +177,27 @@ public class ScriptExplorer extends JPanel {
 
       updateInfo(info);
 
+      // Right-click context menu
+      JPopupMenu popup = new JPopupMenu();
+      JMenuItem renameItem = new JMenuItem("Rename");
+      renameItem.addActionListener(ev -> {
+        if (onCardRenamed != null) {
+          String newName = JOptionPane.showInputDialog(ScriptExplorer.this,
+              "New name:", info.name);
+          if (newName != null && !newName.trim().isEmpty()) {
+            onCardRenamed.actionPerformed(
+                new java.awt.event.ActionEvent(ScriptCard.this, index, newName.trim()));
+          }
+        }
+      });
+      popup.add(renameItem);
+
       addMouseListener(new MouseAdapter() {
         @Override
         public void mouseClicked(MouseEvent e) {
-          if (onCardSelected != null) {
+          if (SwingUtilities.isRightMouseButton(e)) {
+            popup.show(ScriptCard.this, e.getX(), e.getY());
+          } else if (onCardSelected != null) {
             onCardSelected.actionPerformed(
                 new java.awt.event.ActionEvent(ScriptCard.this, index, "select"));
           }

--- a/IDE/src/main/java/org/sikuli/ide/ui/ScriptExplorer.java
+++ b/IDE/src/main/java/org/sikuli/ide/ui/ScriptExplorer.java
@@ -85,13 +85,19 @@ public class ScriptExplorer extends JPanel {
   public void setScriptDirectory(File dir) {
     this.currentDir = dir;
 
-    if (dir == null || !dir.exists()) {
+    if (dir == null) {
       showEmpty();
       return;
     }
 
+    // Remove both to avoid stacking
     remove(emptyLabel);
     remove(scrollPane);
+
+    if (!dir.exists()) {
+      showEmpty();
+      return;
+    }
 
     rootNode.removeAllChildren();
     rootNode.setUserObject(dir.getName());

--- a/IDE/src/main/java/org/sikuli/ide/ui/SidebarItem.java
+++ b/IDE/src/main/java/org/sikuli/ide/ui/SidebarItem.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 2010-2026, sikuli.org, sikulix.com, oculix-org - MIT license
+ */
+package org.sikuli.ide.ui;
+
+import com.formdev.flatlaf.FlatClientProperties;
+
+import javax.swing.*;
+import java.awt.*;
+import java.awt.event.ActionListener;
+import java.awt.event.MouseAdapter;
+import java.awt.event.MouseEvent;
+
+/**
+ * A sidebar button with icon and optional label text.
+ * Supports collapsed mode (icon only) and expanded mode (icon + label).
+ */
+public class SidebarItem extends JButton {
+
+  private final String labelText;
+  private boolean collapsed = false;
+
+  public SidebarItem(String text, Icon icon, ActionListener action) {
+    this.labelText = text;
+    setIcon(icon);
+    setText(text);
+    setToolTipText(text);
+    setHorizontalAlignment(SwingConstants.LEFT);
+    setIconTextGap(10);
+    setFocusPainted(false);
+    setBorderPainted(false);
+    setContentAreaFilled(false);
+    setCursor(Cursor.getPredefinedCursor(Cursor.HAND_CURSOR));
+    setFont(UIManager.getFont("defaultFont").deriveFont(12.0f));
+    putClientProperty(FlatClientProperties.BUTTON_TYPE, FlatClientProperties.BUTTON_TYPE_BORDERLESS);
+
+    if (action != null) {
+      addActionListener(action);
+    }
+
+    addMouseAdapter();
+  }
+
+  public SidebarItem(String text, Icon icon) {
+    this(text, icon, null);
+  }
+
+  private void addMouseAdapter() {
+    addMouseListener(new MouseAdapter() {
+      @Override
+      public void mouseEntered(MouseEvent e) {
+        if (isEnabled()) {
+          setContentAreaFilled(true);
+        }
+      }
+
+      @Override
+      public void mouseExited(MouseEvent e) {
+        setContentAreaFilled(false);
+      }
+    });
+  }
+
+  public void setCollapsed(boolean collapsed) {
+    this.collapsed = collapsed;
+    if (collapsed) {
+      setText(null);
+      setHorizontalAlignment(SwingConstants.CENTER);
+    } else {
+      setText(labelText);
+      setHorizontalAlignment(SwingConstants.LEFT);
+    }
+    revalidate();
+  }
+
+  public boolean isCollapsed() {
+    return collapsed;
+  }
+
+  @Override
+  public Dimension getPreferredSize() {
+    Dimension d = super.getPreferredSize();
+    if (collapsed) {
+      d.width = 50;
+    }
+    d.height = Math.max(d.height, 36);
+    return d;
+  }
+
+  @Override
+  public Dimension getMaximumSize() {
+    Dimension d = super.getMaximumSize();
+    d.height = getPreferredSize().height;
+    return d;
+  }
+}

--- a/IDE/src/main/java/org/sikuli/ide/ui/SidebarSubmenu.java
+++ b/IDE/src/main/java/org/sikuli/ide/ui/SidebarSubmenu.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2010-2026, sikuli.org, sikulix.com, oculix-org - MIT license
+ */
+package org.sikuli.ide.ui;
+
+import javax.swing.*;
+import java.awt.*;
+import java.awt.event.ActionListener;
+
+/**
+ * A popup menu used for sidebar sub-items (File, Edit, Tools, Help).
+ * Displayed when clicking a sidebar navigation item.
+ */
+public class SidebarSubmenu extends JPopupMenu {
+
+  public SidebarSubmenu() {
+    setLightWeightPopupEnabled(true);
+  }
+
+  public JMenuItem addItem(String text, KeyStroke accelerator, ActionListener action) {
+    JMenuItem item = new JMenuItem(text);
+    if (accelerator != null) {
+      item.setAccelerator(accelerator);
+    }
+    if (action != null) {
+      item.addActionListener(action);
+    }
+    add(item);
+    return item;
+  }
+
+  public JMenuItem addItem(String text, ActionListener action) {
+    return addItem(text, null, action);
+  }
+
+  public void showBelow(Component invoker) {
+    show(invoker, invoker.getWidth(), 0);
+  }
+}

--- a/IDE/src/main/java/org/sikuli/ide/ui/WelcomeTab.java
+++ b/IDE/src/main/java/org/sikuli/ide/ui/WelcomeTab.java
@@ -27,6 +27,7 @@ public class WelcomeTab extends JPanel {
     this.onOpen = onOpen;
     setLayout(new MigLayout("fill, wrap 1", "[center]", "push[]20[]20[]20[]push"));
     setOpaque(true);
+    setBackground(UIManager.getColor("Panel.background"));
     buildUI();
   }
 
@@ -71,25 +72,6 @@ public class WelcomeTab extends JPanel {
     quickStartPanel.add(createActionLink("\uD83D\uDCC2  Open Script", "Ctrl+O", onOpen));
 
     add(quickStartPanel);
-
-    // System Status section
-    JPanel statusPanel = new JPanel(new MigLayout("wrap 2, insets 16 40 16 40, gap 8", "[][grow]"));
-    statusPanel.setOpaque(false);
-    statusPanel.setBorder(BorderFactory.createCompoundBorder(
-        BorderFactory.createLineBorder(UIManager.getColor("Separator.foreground"), 1),
-        BorderFactory.createEmptyBorder(16, 16, 16, 16)));
-
-    JLabel statusLabel = new JLabel("Status");
-    statusLabel.setFont(UIManager.getFont("h3.font"));
-    statusPanel.add(statusLabel, "span 2, gapbottom 8");
-
-    statusPanel.add(new JLabel("Java"));
-    statusPanel.add(new JLabel(String.valueOf(Commons.getJavaVersion())));
-
-    statusPanel.add(new JLabel("Version"));
-    statusPanel.add(new JLabel(Commons.getSXVersionShort()));
-
-    add(statusPanel);
 
     // Version footer
     JLabel versionFooter = new JLabel("v" + Commons.getSXVersionShort() + " — MIT License");

--- a/IDE/src/main/java/org/sikuli/ide/ui/WelcomeTab.java
+++ b/IDE/src/main/java/org/sikuli/ide/ui/WelcomeTab.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright (c) 2010-2026, sikuli.org, sikulix.com, oculix-org - MIT license
+ */
+package org.sikuli.ide.ui;
+
+import com.formdev.flatlaf.FlatClientProperties;
+import net.miginfocom.swing.MigLayout;
+import org.sikuli.support.Commons;
+
+import javax.swing.*;
+import java.awt.*;
+import java.awt.event.ActionListener;
+import java.awt.event.MouseAdapter;
+import java.awt.event.MouseEvent;
+import java.net.URL;
+
+/**
+ * Welcome panel displayed when no script is open.
+ * Shows quick actions (New, Open), status info, and branding.
+ */
+public class WelcomeTab extends JPanel {
+
+  private ActionListener onNew;
+  private ActionListener onOpen;
+
+  public WelcomeTab(ActionListener onNew, ActionListener onOpen) {
+    this.onNew = onNew;
+    this.onOpen = onOpen;
+    setLayout(new MigLayout("fill, wrap 1", "[center]", "push[]20[]20[]20[]push"));
+    setOpaque(true);
+    buildUI();
+  }
+
+  private void buildUI() {
+    // Logo and title
+    JPanel headerPanel = new JPanel(new MigLayout("wrap 1, insets 0", "[center]"));
+    headerPanel.setOpaque(false);
+
+    URL iconUrl = getClass().getResource("/icons/sikulix-red.png");
+    if (iconUrl != null) {
+      ImageIcon logo = new ImageIcon(iconUrl);
+      Image scaled = logo.getImage().getScaledInstance(80, 80, Image.SCALE_SMOOTH);
+      JLabel logoLabel = new JLabel(new ImageIcon(scaled));
+      headerPanel.add(logoLabel);
+    }
+
+    JLabel title = new JLabel("OculiX IDE");
+    title.setFont(UIManager.getFont("h1.font"));
+    headerPanel.add(title);
+
+    JLabel subtitle = new JLabel("Visual Automation — Powered by SikuliX");
+    subtitle.setFont(UIManager.getFont("h4.font"));
+    subtitle.setForeground(UIManager.getColor("Label.disabledForeground"));
+    headerPanel.add(subtitle);
+
+    add(headerPanel);
+
+    // Quick Start section
+    JPanel quickStartPanel = new JPanel(new MigLayout("wrap 1, insets 20 40 20 40, gap 8", "[fill, 300]"));
+    quickStartPanel.setOpaque(false);
+    quickStartPanel.putClientProperty(FlatClientProperties.STYLE,
+        "border: 1,1,1,1,@separator,1,16");
+
+    JLabel quickStartLabel = new JLabel("Quick Start");
+    quickStartLabel.setFont(UIManager.getFont("h3.font"));
+    quickStartPanel.add(quickStartLabel, "gapbottom 8");
+
+    quickStartPanel.add(createActionLink("\uD83D\uDCC4  New Script", "Ctrl+N", onNew));
+    quickStartPanel.add(createActionLink("\uD83D\uDCC2  Open Script", "Ctrl+O", onOpen));
+
+    add(quickStartPanel);
+
+    // System Status section
+    JPanel statusPanel = new JPanel(new MigLayout("wrap 2, insets 16 40 16 40, gap 8", "[][grow]"));
+    statusPanel.setOpaque(false);
+    statusPanel.putClientProperty(FlatClientProperties.STYLE,
+        "border: 1,1,1,1,@separator,1,16");
+
+    JLabel statusLabel = new JLabel("Status");
+    statusLabel.setFont(UIManager.getFont("h3.font"));
+    statusPanel.add(statusLabel, "span 2, gapbottom 8");
+
+    statusPanel.add(new JLabel("Java"));
+    statusPanel.add(new JLabel(String.valueOf(Commons.getJavaVersion())));
+
+    statusPanel.add(new JLabel("Version"));
+    statusPanel.add(new JLabel(Commons.getSXVersionShort()));
+
+    add(statusPanel);
+
+    // Version footer
+    JLabel versionFooter = new JLabel("v" + Commons.getSXVersionShort() + " — MIT License");
+    versionFooter.setFont(UIManager.getFont("small.font"));
+    versionFooter.setForeground(UIManager.getColor("Label.disabledForeground"));
+    add(versionFooter);
+  }
+
+  private JPanel createActionLink(String text, String shortcut, ActionListener action) {
+    JPanel link = new JPanel(new MigLayout("insets 6 12 6 12, fill", "[]push[]"));
+    link.setOpaque(false);
+    link.setCursor(Cursor.getPredefinedCursor(Cursor.HAND_CURSOR));
+
+    JLabel label = new JLabel(text);
+    label.setFont(UIManager.getFont("defaultFont").deriveFont(14.0f));
+    link.add(label);
+
+    JLabel shortcutLabel = new JLabel(shortcut);
+    shortcutLabel.setFont(UIManager.getFont("small.font"));
+    shortcutLabel.setForeground(UIManager.getColor("Label.disabledForeground"));
+    link.add(shortcutLabel);
+
+    link.addMouseListener(new MouseAdapter() {
+      @Override
+      public void mouseEntered(MouseEvent e) {
+        link.setOpaque(true);
+        link.setBackground(UIManager.getColor("List.selectionBackground"));
+        link.repaint();
+      }
+
+      @Override
+      public void mouseExited(MouseEvent e) {
+        link.setOpaque(false);
+        link.repaint();
+      }
+
+      @Override
+      public void mouseClicked(MouseEvent e) {
+        if (action != null) {
+          action.actionPerformed(null);
+        }
+      }
+    });
+
+    return link;
+  }
+}

--- a/IDE/src/main/java/org/sikuli/ide/ui/WelcomeTab.java
+++ b/IDE/src/main/java/org/sikuli/ide/ui/WelcomeTab.java
@@ -38,7 +38,9 @@ public class WelcomeTab extends JPanel {
     URL iconUrl = getClass().getResource("/icons/sikulix-red.png");
     if (iconUrl != null) {
       ImageIcon logo = new ImageIcon(iconUrl);
-      Image scaled = logo.getImage().getScaledInstance(128, 128, Image.SCALE_SMOOTH);
+      int targetWidth = 280;
+      int targetHeight = (int) ((double) logo.getIconHeight() / logo.getIconWidth() * targetWidth);
+      Image scaled = logo.getImage().getScaledInstance(targetWidth, targetHeight, Image.SCALE_SMOOTH);
       JLabel logoLabel = new JLabel(new ImageIcon(scaled));
       headerPanel.add(logoLabel);
     }

--- a/IDE/src/main/java/org/sikuli/ide/ui/WelcomeTab.java
+++ b/IDE/src/main/java/org/sikuli/ide/ui/WelcomeTab.java
@@ -3,7 +3,6 @@
  */
 package org.sikuli.ide.ui;
 
-import com.formdev.flatlaf.FlatClientProperties;
 import net.miginfocom.swing.MigLayout;
 import org.sikuli.support.Commons;
 
@@ -58,8 +57,9 @@ public class WelcomeTab extends JPanel {
     // Quick Start section
     JPanel quickStartPanel = new JPanel(new MigLayout("wrap 1, insets 20 40 20 40, gap 8", "[fill, 300]"));
     quickStartPanel.setOpaque(false);
-    quickStartPanel.putClientProperty(FlatClientProperties.STYLE,
-        "border: 1,1,1,1,$Separator.foreground,1,16");
+    quickStartPanel.setBorder(BorderFactory.createCompoundBorder(
+        BorderFactory.createLineBorder(UIManager.getColor("Separator.foreground"), 1),
+        BorderFactory.createEmptyBorder(16, 16, 16, 16)));
 
     JLabel quickStartLabel = new JLabel("Quick Start");
     quickStartLabel.setFont(UIManager.getFont("h3.font"));
@@ -73,8 +73,9 @@ public class WelcomeTab extends JPanel {
     // System Status section
     JPanel statusPanel = new JPanel(new MigLayout("wrap 2, insets 16 40 16 40, gap 8", "[][grow]"));
     statusPanel.setOpaque(false);
-    statusPanel.putClientProperty(FlatClientProperties.STYLE,
-        "border: 1,1,1,1,$Separator.foreground,1,16");
+    statusPanel.setBorder(BorderFactory.createCompoundBorder(
+        BorderFactory.createLineBorder(UIManager.getColor("Separator.foreground"), 1),
+        BorderFactory.createEmptyBorder(16, 16, 16, 16)));
 
     JLabel statusLabel = new JLabel("Status");
     statusLabel.setFont(UIManager.getFont("h3.font"));

--- a/IDE/src/main/java/org/sikuli/ide/ui/WelcomeTab.java
+++ b/IDE/src/main/java/org/sikuli/ide/ui/WelcomeTab.java
@@ -39,7 +39,7 @@ public class WelcomeTab extends JPanel {
     URL iconUrl = getClass().getResource("/icons/sikulix-red.png");
     if (iconUrl != null) {
       ImageIcon logo = new ImageIcon(iconUrl);
-      Image scaled = logo.getImage().getScaledInstance(80, 80, Image.SCALE_SMOOTH);
+      Image scaled = logo.getImage().getScaledInstance(128, 128, Image.SCALE_SMOOTH);
       JLabel logoLabel = new JLabel(new ImageIcon(scaled));
       headerPanel.add(logoLabel);
     }
@@ -59,7 +59,7 @@ public class WelcomeTab extends JPanel {
     JPanel quickStartPanel = new JPanel(new MigLayout("wrap 1, insets 20 40 20 40, gap 8", "[fill, 300]"));
     quickStartPanel.setOpaque(false);
     quickStartPanel.putClientProperty(FlatClientProperties.STYLE,
-        "border: 1,1,1,1,@separator,1,16");
+        "border: 1,1,1,1,$Separator.foreground,1,16");
 
     JLabel quickStartLabel = new JLabel("Quick Start");
     quickStartLabel.setFont(UIManager.getFont("h3.font"));
@@ -74,7 +74,7 @@ public class WelcomeTab extends JPanel {
     JPanel statusPanel = new JPanel(new MigLayout("wrap 2, insets 16 40 16 40, gap 8", "[][grow]"));
     statusPanel.setOpaque(false);
     statusPanel.putClientProperty(FlatClientProperties.STYLE,
-        "border: 1,1,1,1,@separator,1,16");
+        "border: 1,1,1,1,$Separator.foreground,1,16");
 
     JLabel statusLabel = new JLabel("Status");
     statusLabel.setFont(UIManager.getFont("h3.font"));

--- a/IDE/src/main/java/org/sikuli/ide/ui/WelcomeTab.java
+++ b/IDE/src/main/java/org/sikuli/ide/ui/WelcomeTab.java
@@ -21,10 +21,15 @@ public class WelcomeTab extends JPanel {
 
   private ActionListener onNew;
   private ActionListener onOpen;
+  private ActionListener onNewWorkspace;
+  private ActionListener onOpenWorkspace;
 
-  public WelcomeTab(ActionListener onNew, ActionListener onOpen) {
+  public WelcomeTab(ActionListener onNew, ActionListener onOpen,
+                     ActionListener onNewWorkspace, ActionListener onOpenWorkspace) {
     this.onNew = onNew;
     this.onOpen = onOpen;
+    this.onNewWorkspace = onNewWorkspace;
+    this.onOpenWorkspace = onOpenWorkspace;
     setLayout(new MigLayout("fill, wrap 1", "[center]", "push[]20[]20[]20[]push"));
     setOpaque(true);
     setBackground(UIManager.getColor("Panel.background"));
@@ -70,6 +75,9 @@ public class WelcomeTab extends JPanel {
 
     quickStartPanel.add(createActionLink("\uD83D\uDCC4  New Script", "Ctrl+N", onNew));
     quickStartPanel.add(createActionLink("\uD83D\uDCC2  Open Script", "Ctrl+O", onOpen));
+    quickStartPanel.add(new JSeparator(), "growx, gaptop 8, gapbottom 8");
+    quickStartPanel.add(createActionLink("\uD83D\uDCC1  New Workspace", "", onNewWorkspace));
+    quickStartPanel.add(createActionLink("\uD83D\uDCC2  Open Workspace", "", onOpenWorkspace));
 
     add(quickStartPanel);
 

--- a/IDE/src/main/java/org/sikuli/ide/ui/WorkspaceDialog.java
+++ b/IDE/src/main/java/org/sikuli/ide/ui/WorkspaceDialog.java
@@ -1,0 +1,167 @@
+/*
+ * Copyright (c) 2010-2026, sikuli.org, sikulix.com, oculix-org - MIT license
+ */
+package org.sikuli.ide.ui;
+
+import net.miginfocom.swing.MigLayout;
+
+import javax.swing.*;
+import java.awt.*;
+import java.io.File;
+import java.io.FileWriter;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+
+/**
+ * Modal dialog for creating a new workspace.
+ * Collects name, description, author, then lets the user choose a directory.
+ * Creates a workspace.json file in the selected directory.
+ */
+public class WorkspaceDialog extends JDialog {
+
+  private JTextField nameField;
+  private JTextField descriptionField;
+  private JTextField authorField;
+  private boolean confirmed = false;
+  private File workspaceDir;
+
+  public WorkspaceDialog(Frame parent) {
+    super(parent, "New Workspace", true);
+    setSize(420, 300);
+    setLocationRelativeTo(parent);
+    setResizable(false);
+    buildUI();
+  }
+
+  private void buildUI() {
+    JPanel content = new JPanel(new MigLayout("wrap 2, insets 20, gap 8", "[right, 100]10[grow, fill, 250]", ""));
+    content.setBackground(UIManager.getColor("Panel.background"));
+
+    // Title
+    JLabel title = new JLabel("Create Workspace");
+    title.setFont(UIManager.getFont("h2.font"));
+    content.add(title, "span 2, align center, gapbottom 12");
+
+    // Name
+    content.add(new JLabel("Name *"));
+    nameField = new JTextField();
+    nameField.setToolTipText("Workspace name (required)");
+    content.add(nameField);
+
+    // Description
+    content.add(new JLabel("Description"));
+    descriptionField = new JTextField();
+    descriptionField.setToolTipText("Short description (optional)");
+    content.add(descriptionField);
+
+    // Author
+    content.add(new JLabel("Author"));
+    authorField = new JTextField(System.getProperty("user.name"));
+    authorField.setToolTipText("Author name (optional)");
+    content.add(authorField);
+
+    // Buttons
+    JPanel buttons = new JPanel(new MigLayout("insets 0", "push[]8[]", ""));
+    buttons.setOpaque(false);
+
+    JButton cancelBtn = new JButton("Cancel");
+    cancelBtn.addActionListener(e -> {
+      confirmed = false;
+      dispose();
+    });
+    buttons.add(cancelBtn);
+
+    JButton okBtn = new JButton("Create");
+    okBtn.addActionListener(e -> onCreateClicked());
+    okBtn.putClientProperty("JButton.buttonType", "default");
+    buttons.add(okBtn);
+
+    content.add(buttons, "span 2, align right, gaptop 12");
+
+    setContentPane(content);
+
+    // Enter key = Create
+    getRootPane().setDefaultButton(okBtn);
+  }
+
+  private void onCreateClicked() {
+    String name = nameField.getText().trim();
+    if (name.isEmpty()) {
+      nameField.requestFocus();
+      nameField.setBorder(BorderFactory.createLineBorder(new Color(0xFF, 0x6B, 0x6B), 2));
+      return;
+    }
+
+    // Choose directory
+    JFileChooser chooser = new JFileChooser();
+    chooser.setDialogTitle("Choose workspace directory");
+    chooser.setFileSelectionMode(JFileChooser.DIRECTORIES_ONLY);
+    chooser.setAcceptAllFileFilterUsed(false);
+
+    int result = chooser.showOpenDialog(this);
+    if (result != JFileChooser.APPROVE_OPTION) {
+      return;
+    }
+
+    workspaceDir = chooser.getSelectedFile();
+
+    // Create workspace.json
+    try {
+      File wsFile = new File(workspaceDir, "workspace.json");
+      String json = buildWorkspaceJson(name);
+      try (FileWriter writer = new FileWriter(wsFile)) {
+        writer.write(json);
+      }
+      confirmed = true;
+      dispose();
+    } catch (Exception ex) {
+      JOptionPane.showMessageDialog(this,
+          "Error creating workspace: " + ex.getMessage(),
+          "Error", JOptionPane.ERROR_MESSAGE);
+    }
+  }
+
+  private String buildWorkspaceJson(String name) {
+    String desc = descriptionField.getText().trim();
+    String author = authorField.getText().trim();
+    String date = new SimpleDateFormat("yyyy-MM-dd").format(new Date());
+
+    StringBuilder sb = new StringBuilder();
+    sb.append("{\n");
+    sb.append("  \"name\": \"").append(escapeJson(name)).append("\",\n");
+    sb.append("  \"description\": \"").append(escapeJson(desc)).append("\",\n");
+    sb.append("  \"author\": \"").append(escapeJson(author)).append("\",\n");
+    sb.append("  \"created\": \"").append(date).append("\",\n");
+    sb.append("  \"scripts\": []\n");
+    sb.append("}\n");
+    return sb.toString();
+  }
+
+  private String escapeJson(String s) {
+    return s.replace("\\", "\\\\").replace("\"", "\\\"");
+  }
+
+  public boolean isConfirmed() {
+    return confirmed;
+  }
+
+  public File getWorkspaceDir() {
+    return workspaceDir;
+  }
+
+  public String getWorkspaceName() {
+    return nameField.getText().trim();
+  }
+
+  /**
+   * Shows the dialog and returns the workspace directory if confirmed, null otherwise.
+   */
+  public static File showDialog(Frame parent) {
+    WorkspaceDialog dialog = new WorkspaceDialog(parent);
+    dialog.setVisible(true);
+    if (dialog.isConfirmed()) {
+      return dialog.getWorkspaceDir();
+    }
+    return null;
+  }
+}

--- a/IDE/src/main/resources/i18n/IDE_en_US.properties
+++ b/IDE/src/main/resources/i18n/IDE_en_US.properties
@@ -175,3 +175,6 @@ extBtnInfo=More Info
 extMsgInstalled=Installed
 extBtnInstallVer=Install {0}
 extBtnUpdateVer=Update to {0}
+
+sidebarThemeToggle=Dark / Light
+menuRecent=Recent

--- a/IDE/src/main/resources/i18n/IDE_fr.properties
+++ b/IDE/src/main/resources/i18n/IDE_fr.properties
@@ -164,3 +164,9 @@ extBtnInfo=Plus d'informations
 extMsgInstalled=Install\u00E9
 extBtnInstallVer=Install\u00E9 {0}
 extBtnUpdateVer=Mis \u00E0 jour {0}
+
+btnRecord=Enregistrer ({0})
+btnRecordLabel=Enregistrer
+btnRecordStopHint=Appuyez sur {0} pour arr\u00EAter
+sidebarThemeToggle=Sombre / Clair
+menuRecent=R\u00E9cents

--- a/IDE/src/main/resources/org/sikuli/support/gui/sxideabout.txt
+++ b/IDE/src/main/resources/org/sikuli/support/gui/sxideabout.txt
@@ -1,15 +1,17 @@
-#globals; s 300 500; m 20; c; f 16
+#globals; s 350 500; m 20; c; f 16
 
 #image; /icons/sikulix-red-x.png; r 200
 ---
-SikuliX IDE; fontsize 20; bold
+OculiX IDE; fontsize 22; bold
+Powered by SikuliX; fontsize 13
+---
 {sxversion}; bold
 Java {javaversion}; bold
 ---
-#link; sikulix.com | https://sikulix.github.io
+#link; github.com/oculix-org | https://github.com/oculix-org/Oculix
 ---
-Copyright (c) 2010-2021; fontsize 14
-sikuli.org --- sikulix.com; fontsize 12
-#link; MIT License | http://www.sikulix.com/disclaimer/; fontsize 14
+Copyright (c) 2010-2026; fontsize 14
+sikuli.org --- sikulix.com --- oculix-org; fontsize 12
+#link; MIT License | https://github.com/oculix-org/Oculix/blob/master/LICENSE; fontsize 14
 ---
 #close; Press ESC or Click; f 12

--- a/IDE/src/main/resources/org/sikuli/support/gui/sxidestartup.txt
+++ b/IDE/src/main/resources/org/sikuli/support/gui/sxidestartup.txt
@@ -2,5 +2,5 @@
 
 #image; /icons/sikulix-red-x.png
 ---
-SikuliX-IDE  ---  {sxversion}  ---  starting on Java {javaversion}; bold
+OculiX IDE  ---  {sxversion}  ---  starting on Java {javaversion}; bold
 


### PR DESCRIPTION
## Context

Refactoring of the IDE layer: modern look & feel, Eclipse-style layout, 
workspace-aware script management, and stabilization of the IDE startup/save 
lifecycle. 35 commits, 18 files, +1744 / -165.

Opened as **draft** — not ready to merge. Looking for feedback before I 
clean up the history and squash.

## Motivation

The legacy IDE had several pain points I wanted to address in one coherent pass:
- Aging Look & Feel tied to platform defaults, no dark theme
- Hand-rolled layout code fragile on HiDPI
- `mac_widgets` dependency dragging dead weight we don't use
- No first-run experience, no visual script browser
- Several latent NPEs in session restore and save paths

## What's in this branch

### Phase 0 — Dependencies & theming (16754f35, 21b00ea8)
- Add **FlatLaf** (modern L&F with native dark theme)
- Add **DJ-Raven** (extra components)
- Add **MigLayout** (replaces brittle hand-rolled layouts)
- Neutralize `mac_widgets` legacy dependency
- Fix console message colors for dark theme

### Phase 1 — Sidebar & navigation (a7eee349 → 4c082fdb)
- New `OculixSidebar` component (345 LOC) with grouped items and submenus
- Accelerator migration away from the old scattered keybinding code
- FlatLaf tabs integration
- All sidebar items unified as submenus (no more mixed UI)
- `SidebarItem` / `SidebarSubmenu` helper components

### Phase 2 — Welcome Tab & status bar (82e2a213 → 21393553)
- New `WelcomeTab` (129 LOC) shown on startup, hidden when a script opens
- Redesigned `SikuliIDEStatusBar` (+72 LOC)
- Live info panels in sidebar: project, status, last run
- SikuliX-style orange logo, serif "OculiX + IDE" branding
- Grey-out Run/Capture/Record when no script is open
- Menu cleanup and modern fonts

### Phase 3 — Eclipse-style layout & workspace (0a0276ae → dc730fc7)
- **Eclipse-style split**: explorer left, console bottom, editor center
- Full rewrite of `ScriptExplorer` (277 LOC) as a visual workspace with 
  script cards instead of the old tree
- New `WorkspaceDialog` (167 LOC): create / open / rename workspaces
- Auto-refresh of workspace cards on save / create / rename
- File menu rebuilt with visible section headers (flat layout)
- File dialogs default to workspace / script directory
- `.sikuli` bundle validation on workspace open
- Default save dialog to `folder.sikuli` instead of plain file

### Phase 4 — Stability & audit fixes (1bda3370, 713e62a9, 7161f02d, 
9825388b, 77c7516b, 17578155, 9293fa93, a3c10163, 27abdd20, and others)
- IDE startup crash: protect `restoreSession` against empty / missing scripts
- Quit crash: `saveSession` NPE when no scripts open
- `WelcomeTab` lifecycle: border syntax, null context safety, image ratio
- `setFile` error handling: use local var, return false instead of fatal
- Save As: refresh workspace cards + honor workspace directory
- Save As: ensure `.py` extension inside the `.sikuli` bundle
- Workspace open: NPE in `setFile` + flexible `.py` detection
- Final audit: 5 critical bugs fixed in one pass

## Files touched (18)

**New files (6)** — all under `IDE/src/main/java/org/sikuli/ide/ui/`:
- `OculixSidebar.java` (+345)
- `ScriptExplorer.java` (+277)
- `WorkspaceDialog.java` (+167)
- `WelcomeTab.java` (+129)
- `SidebarItem.java` (+96)
- `SidebarSubmenu.java` (+39)

**Main refactor**:
- `SikulixIDE.java` (+680 / heavy)
- `SikuliIDEStatusBar.java` (+72)
- `EditorConsolePane.java`, `EditorImageButton.java`, `ButtonOnToolbar.java`, 
  `Sikulix.java` (minor adjustments)

**Build & i18n**:
- `IDE/pom.xml` (+24): FlatLaf, DJ-Raven, MigLayout
- `IDE_en_US.properties` (+3), `IDE_fr.properties` (+6)
- `sxideabout.txt`, `sxidestartup.txt` (branding)

## What I'd like feedback on

1. **`SikulixIDE.java` blast radius** — it grew a lot. Worth splitting out 
   the workspace logic into its own class, or keep it centralized?
2. **`mac_widgets` neutralization** — I kept the dependency declared but 
   unused for now. OK to remove fully in a follow-up?
3. **Eclipse-style layout** — does this fit the direction you want for 
   OculiX, or do you prefer the original single-pane approach?
4. **Dark theme as default** — currently opt-in. Should it be default for 
   new installs?

## Tested on

- Windows 11 / JDK 21 ✅
- Linux (Ubuntu 24.04) — smoke-tested ✅
- macOS ARM — **not tested**, no hardware. Help appreciated.

## Not in this PR

- No changes to the Script API or recognizer logic
- No changes to the OpenCV / PaddleOCR / ADB stacks
- **Recorder untouched** — no changes to the recording pipeline
- **Launcher untouched** — no changes to the startup launcher
- i18n limited to EN + FR strings I added; no full re-translation pass

## Commit history

Will be squashed / cleaned before merge. Current 35 commits kept for 
transparency during review.