### PR TITLE
App: whitespace-safe executable paths

### DIFF
--- a/API/src/main/java/org/sikuli/script/App.java
+++ b/API/src/main/java/org/sikuli/script/App.java
@@ -120,23 +120,21 @@ public class App {
     process = new NullProcess();
   }
 
-  public App(String name) {
-    this();
-    setName(name);
+  public App(String executable) {
+    this(executable, null);
   }
 
   /**
-   * Creates an App from an executable path and an optional arguments string,
-   * kept as separate parameters so the executable path is never run through
-   * {@link CommandLine#parse(String)} — which strips surrounding quotes and
-   * re-tokenises on whitespace. Use this overload for executables whose path
-   * contains spaces (e.g. {@code C:\Program Files\...}, {@code /Applications/
-   * Some App.app/...}).
+   * Creates an App from an executable path and an optional arguments string.
+   * The executable is stored verbatim (no whitespace splitting, no quote
+   * stripping) — use this constructor when the path contains spaces, such as
+   * {@code C:\Program Files\MyApp\app.exe} or
+   * {@code /Applications/Some App.app/Contents/MacOS/app}.
    *
    * @param executable absolute or resolvable path of the binary; whitespace-safe
    * @param arguments  space-separated arguments string, or {@code null} / empty
    *                   for none. Standard shell quoting is tokenised inside
-   *                   {@code arguments}; the executable is not parsed.
+   *                   {@code arguments}; the executable is never parsed.
    * @since 3.0.3 — see #191
    */
   public App(String executable, String arguments) {

--- a/API/src/main/java/org/sikuli/script/App.java
+++ b/API/src/main/java/org/sikuli/script/App.java
@@ -233,7 +233,11 @@ public class App {
   }
 
   public App setArguments(String arguments) {
-    this.cmd = CommandLine.parse("\"" + cmd.getExecutable() + "\" " + arguments);
+    String exe = cmd.getExecutable();
+    this.cmd = new CommandLine(exe);
+    if (StringUtils.isNotBlank(arguments)) {
+      this.cmd.addArguments(arguments);
+    }
     return this;
   }
 
@@ -257,10 +261,7 @@ public class App {
     if (StringUtils.isBlank(name)) {
       return;
     }
-
-    // Use apache.commons.exec.CommandLine to correctly tokenize given command.
-    cmd = CommandLine.parse(name);
-
+    cmd = new CommandLine(name);
     process = osUtil.findProcesses(cmd.getExecutable()).stream().findFirst().orElse(new NullProcess());
   }
 

--- a/API/src/main/java/org/sikuli/script/App.java
+++ b/API/src/main/java/org/sikuli/script/App.java
@@ -125,6 +125,32 @@ public class App {
     setName(name);
   }
 
+  /**
+   * Creates an App from an executable path and an optional arguments string,
+   * kept as separate parameters so the executable path is never run through
+   * {@link CommandLine#parse(String)} — which strips surrounding quotes and
+   * re-tokenises on whitespace. Use this overload for executables whose path
+   * contains spaces (e.g. {@code C:\Program Files\...}, {@code /Applications/
+   * Some App.app/...}).
+   *
+   * @param executable absolute or resolvable path of the binary; whitespace-safe
+   * @param arguments  space-separated arguments string, or {@code null} / empty
+   *                   for none. Standard shell quoting is tokenised inside
+   *                   {@code arguments}; the executable is not parsed.
+   * @since 3.0.3 — see #191
+   */
+  public App(String executable, String arguments) {
+    this();
+    if (StringUtils.isBlank(executable)) {
+      return;
+    }
+    cmd = new CommandLine(executable);
+    if (StringUtils.isNotBlank(arguments)) {
+      cmd.addArguments(arguments);
+    }
+    process = osUtil.findProcesses(cmd.getExecutable()).stream().findFirst().orElse(new NullProcess());
+  }
+
   private App(OsProcess process) {
     this.process = process;
   }


### PR DESCRIPTION
## Summary

Makes `App` whitespace-safe so executables with spaces in their path work correctly on Windows (`C:\Program Files\...`), macOS (`/Applications/Some App.app/...`), and Linux (any path containing a space).

**Root cause.** `CommandLine.parse()` from Apache Commons Exec strips surrounding quotes and re-tokenises the first token on whitespace — so `"\"/path with space/bin\""` becomes exe=`/path`, args=`[with, space/bin]`. Escaping with quotes doesn't help, `parse()` eats them.

**The fix.** Every `App` entry point now routes through `new CommandLine(exe)` (the raw constructor — no parsing, path stored verbatim) plus `cmd.addArguments(args)` (tokenises the argument string only; quoting inside args works normally). `CommandLine.parse` is no longer called anywhere in `App.java`.

## API

```java
// Existing, still works (backwards-compatible)
new App("notepad");

// New — whitespace-safe path + optional args
new App("C:\\Program Files\\Notepad++\\notepad++.exe", null);
new App("C:\\Program Files\\Notepad++\\notepad++.exe", "--fresh");

// Existing setters, now whitespace-safe internally
app.setName("C:\\Program Files\\MyApp\\app.exe");
app.setArguments("--flag value");
```

## Commits

| SHA | What |
|---|---|
| `c0ed9e60` | Add `App(executable, arguments)` constructor with whitespace-safe path |
| `2226c670` | Unify: `App(name)` delegates to `App(name, null)` — single code path |
| `4a979e4e` | Purge remaining `CommandLine.parse` from `setName(String)` and `setArguments(String)` |

## Test plan

- [x] Compiles clean with `mvn -pl API compile`
- [ ] Manual smoke test on Windows with `C:\Program Files\...\notepad++.exe` (target: @adriancostin6 on a pre-release)
- [ ] Manual smoke test on macOS with `/Applications/Some App.app/...`

## Backwards compatibility

`new App("notepad /a /b")` (packing args into the name string as one blob) no longer parses — the whole string is taken as the executable. This usage was never documented and no internal caller relies on it.

## Scope

Does not close the issue — per commitment in the thread, `#191` will be closed once @adriancostin6 confirms the fix works on a pre-release build.

Refs #191

