### PR TITLE
Sync rc fixes to master

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,6 +16,10 @@ updates:
     labels:
       - "dependencies"
       - "module:IDE"
+    # JRuby 10.x requires Java 21; OculiX targets Java 17. Stay on the 9.4 line.
+    ignore:
+      - dependency-name: "org.jruby:jruby-complete"
+        update-types: ["version-update:semver-major"]
 
   # Module API
   - package-ecosystem: "maven"
@@ -29,6 +33,10 @@ updates:
     labels:
       - "dependencies"
       - "module:API"
+    # JRuby 10.x requires Java 21; OculiX targets Java 17. Stay on the 9.4 line.
+    ignore:
+      - dependency-name: "org.jruby:jruby-complete"
+        update-types: ["version-update:semver-major"]
 
   # Module MCP
   - package-ecosystem: "maven"
@@ -42,3 +50,7 @@ updates:
     labels:
       - "dependencies"
       - "module:MCP"
+    # Defensive: same ignore as API/IDE in case JRuby gets added here later.
+    ignore:
+      - dependency-name: "org.jruby:jruby-complete"
+        update-types: ["version-update:semver-major"]

--- a/.github/workflows/release-rc.yml
+++ b/.github/workflows/release-rc.yml
@@ -159,7 +159,7 @@ jobs:
           gh release create "$TAG" \
             --title "OculiX ${VERSION} (release candidate)" \
             --notes "Pre-release build. Do not use in production. See CHANGELOG / commits for the included fixes." \
-            --target "$GITHUB_SHA" \
+            --target "$GITHUB_REF_NAME" \
             --prerelease \
             --latest=false
         fi

--- a/.github/workflows/release-rc.yml
+++ b/.github/workflows/release-rc.yml
@@ -159,7 +159,7 @@ jobs:
           gh release create "$TAG" \
             --title "OculiX ${VERSION} (release candidate)" \
             --notes "Pre-release build. Do not use in production. See CHANGELOG / commits for the included fixes." \
-            --target master \
+            --target "$GITHUB_SHA" \
             --prerelease \
             --latest=false
         fi

--- a/API/pom.xml
+++ b/API/pom.xml
@@ -88,11 +88,12 @@
     <dependency>
       <groupId>io.github.julienmerconsulting.apertix</groupId>
       <artifactId>opencv</artifactId>
-      <version>4.10.0-2</version>
+      <version>4.10.0-3</version>
       <!-- https://github.com/julienmerconsulting/Apertix
-           4.10.0-2 builds OpenCV with WITH_OBSENSOR=OFF, removing the broken
-           libOrbbecSDK.1.9.dylib dependency that caused UnsatisfiedLinkError
-           on macOS (both Intel and Apple Silicon). -->
+           4.10.0-3 ships dual Linux native builds: modern (glibc >= 2.38) at
+           linux-{x86-64,aarch64}/ and legacy (manylinux_2_28, glibc >= 2.28)
+           at linux-{x86-64,aarch64}-legacy/. Selection is done at runtime
+           in Commons.loadOpenCV() based on detected glibc version. -->
     </dependency>
     <dependency>
       <groupId>commons-cli</groupId>

--- a/API/pom.xml
+++ b/API/pom.xml
@@ -49,7 +49,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <sikuli.jartype>plain.xml</sikuli.jartype>
     <sikulixjythonversion>2.7.4</sikulixjythonversion>
-    <sikulixjrubyversion>10.1.0.0</sikulixjrubyversion>
+    <sikulixjrubyversion>9.4.14.0</sikulixjrubyversion>
     <versiontess4j>5.18.0</versiontess4j>
     <timestamp>${maven.build.timestamp}</timestamp>
     <maven.build.timestamp.format>yyyy-MM-dd_HH:mm</maven.build.timestamp.format>

--- a/API/src/main/java/org/sikuli/support/Commons.java
+++ b/API/src/main/java/org/sikuli/support/Commons.java
@@ -1162,31 +1162,39 @@ public static void loadOpenCV() {
     }
     String libName = Core.NATIVE_LIBRARY_NAME;
 
-    // 1. Apertix / nu.pattern.OpenCV: try loadLocally() (extracts native from
-    //    jar) then loadShared() (relies on system loader). openpnp/opencv
-    //    historically exposes both; Apertix may only expose one — we try
-    //    whichever is present.
-    try {
-      Class<?> opencvClass = Class.forName(libOpenCVclassref);
-      String[] tryMethods = { "loadLocally", "loadShared" };
-      for (String m : tryMethods) {
-        try {
-          opencvClass.getMethod(m).invoke(null);
-          libOpenCVloaded = true;
-          System.err.println("[OculiX] OpenCV loaded via " + libOpenCVclassref + "." + m + "()");
-          return;
-        } catch (NoSuchMethodException nsme) {
-          System.err.println("[OculiX] " + libOpenCVclassref + "." + m + "() not found, trying next");
-        } catch (Throwable e) {
-          System.err.println("[OculiX] " + libOpenCVclassref + "." + m + "() threw: "
-              + e.getClass().getSimpleName() + ": " + e.getMessage());
-        }
+    // On Linux, we bypass nu.pattern.OpenCV.loadLocally() because Apertix
+    // 4.10.0-3+ ships two native variants (modern + manylinux_2_28-legacy)
+    // and the consumer is expected to pick the right one based on the
+    // runtime glibc version. loadLocally() is only aware of the modern path.
+    if (runningLinux()) {
+      if (loadOpenCVLinuxTiered(libName)) {
+        libOpenCVloaded = true;
+        return;
       }
-    } catch (ClassNotFoundException cnfe) {
-      System.err.println("[OculiX] " + libOpenCVclassref + " not on classpath (Apertix jar missing?)");
-    } catch (Throwable e) {
-      System.err.println("[OculiX] Apertix stage failed: "
-          + e.getClass().getSimpleName() + ": " + e.getMessage());
+    } else {
+      // macOS / Windows: single-tier, hand off to Apertix's loader.
+      try {
+        Class<?> opencvClass = Class.forName(libOpenCVclassref);
+        String[] tryMethods = { "loadLocally", "loadShared" };
+        for (String m : tryMethods) {
+          try {
+            opencvClass.getMethod(m).invoke(null);
+            libOpenCVloaded = true;
+            System.err.println("[OculiX] OpenCV loaded via " + libOpenCVclassref + "." + m + "()");
+            return;
+          } catch (NoSuchMethodException nsme) {
+            System.err.println("[OculiX] " + libOpenCVclassref + "." + m + "() not found, trying next");
+          } catch (Throwable e) {
+            System.err.println("[OculiX] " + libOpenCVclassref + "." + m + "() threw: "
+                + e.getClass().getSimpleName() + ": " + e.getMessage());
+          }
+        }
+      } catch (ClassNotFoundException cnfe) {
+        System.err.println("[OculiX] " + libOpenCVclassref + " not on classpath (Apertix jar missing?)");
+      } catch (Throwable e) {
+        System.err.println("[OculiX] Apertix stage failed: "
+            + e.getClass().getSimpleName() + ": " + e.getMessage());
+      }
     }
 
     // 2. System.loadLibrary (lib already on java.library.path)
@@ -1199,7 +1207,8 @@ public static void loadOpenCV() {
       System.err.println("[OculiX] System.loadLibrary(" + libName + ") failed: " + e.getMessage());
     }
 
-    // 3. Fallback: extract native lib from jar resource and load manually.
+    // 3. Manual extraction fallback for macOS / Windows (Linux already
+    //    exhausted its tiered attempts in step 1).
     String resource = null;
     String fileName = null;
     String nativeDir = getNativeLibDir();
@@ -1209,47 +1218,159 @@ public static void loadOpenCV() {
     } else if (runningMac()) {
       resource = nativeDir + "/lib" + libName + ".dylib";
       fileName = "lib" + libName + ".dylib";
-    } else if (runningLinux()) {
-      resource = nativeDir + "/lib" + libName + ".so";
-      fileName = "lib" + libName + ".so";
     }
-    if (resource != null) {
-      try {
-        java.io.InputStream is = Commons.class.getClassLoader().getResourceAsStream(resource);
-        if (is == null) {
-          // Some classloaders want a leading slash when going through Class, not ClassLoader.
-          is = Commons.class.getResourceAsStream("/" + resource);
-        }
-        if (is == null) {
-          System.err.println("[OculiX] jar resource not found on classpath: " + resource);
-        } else {
-          File tempDir = getTempFolder();
-          if (tempDir == null) {
-            tempDir = new File(System.getProperty("java.io.tmpdir"));
-          }
-          File tempLib = new File(tempDir, fileName);
-          try (java.io.FileOutputStream fos = new java.io.FileOutputStream(tempLib)) {
-            byte[] buf = new byte[8192];
-            int len;
-            while ((len = is.read(buf)) > 0) {
-              fos.write(buf, 0, len);
-            }
-          } finally {
-            is.close();
-          }
-          System.load(tempLib.getAbsolutePath());
-          libOpenCVloaded = true;
-          System.err.println("[OculiX] OpenCV loaded from jar resource: " + tempLib);
-          return;
-        }
-      } catch (Throwable e) {
-        System.err.println("[OculiX] jar extraction of " + resource + " failed: "
-            + e.getClass().getSimpleName() + ": " + e.getMessage());
-      }
+    if (resource != null && extractAndLoad(resource, fileName)) {
+      libOpenCVloaded = true;
+      return;
     }
 
     System.err.println("[OculiX] FATAL: OpenCV native library '" + libName + "' could NOT be loaded. "
         + "Next new Mat() call will throw UnsatisfiedLinkError.");
+  }
+
+  // GLIBC version below which we must use the legacy tier.
+  private static final int OPENCV_MODERN_GLIBC_MAJOR = 2;
+  private static final int OPENCV_MODERN_GLIBC_MINOR = 38;
+  // GLIBC version baked into the legacy tier (manylinux_2_28).
+  private static final int OPENCV_LEGACY_GLIBC_MINOR = 28;
+
+  /**
+   * Linux-only: pick the right Apertix native tier (modern vs legacy) based
+   * on the runtime glibc version, extract and load. Returns true on success.
+   */
+  private static boolean loadOpenCVLinuxTiered(String libName) {
+    String fileName = "lib" + libName + ".so";
+    String archDir = runningArm64() ? "linux-aarch64" : "linux-x86-64";
+    int[] glibc = detectGlibcVersion();
+
+    boolean useLegacy;
+    String reason;
+    if (glibc == null) {
+      useLegacy = true;
+      reason = "glibc detection failed (musl?), defaulting to legacy tier";
+    } else if (glibc[0] < OPENCV_MODERN_GLIBC_MAJOR
+        || (glibc[0] == OPENCV_MODERN_GLIBC_MAJOR && glibc[1] < OPENCV_LEGACY_GLIBC_MINOR)) {
+      useLegacy = true;
+      reason = "glibc " + glibc[0] + "." + glibc[1] + " is below legacy minimum "
+          + OPENCV_MODERN_GLIBC_MAJOR + "." + OPENCV_LEGACY_GLIBC_MINOR
+          + " — load may still fail";
+    } else if (glibc[0] == OPENCV_MODERN_GLIBC_MAJOR && glibc[1] < OPENCV_MODERN_GLIBC_MINOR) {
+      useLegacy = true;
+      reason = "glibc " + glibc[0] + "." + glibc[1] + " < "
+          + OPENCV_MODERN_GLIBC_MAJOR + "." + OPENCV_MODERN_GLIBC_MINOR + ", using legacy tier";
+    } else {
+      useLegacy = false;
+      reason = "glibc " + glibc[0] + "." + glibc[1] + " >= "
+          + OPENCV_MODERN_GLIBC_MAJOR + "." + OPENCV_MODERN_GLIBC_MINOR + ", using modern tier";
+    }
+    System.err.println("[OculiX] " + reason);
+
+    String firstTier = useLegacy ? archDir + "-legacy" : archDir;
+    if (extractAndLoad(firstTier + "/" + fileName, fileName)) {
+      System.err.println("[OculiX] OpenCV loaded from " + firstTier + "/");
+      return true;
+    }
+
+    // Cascade: if modern was the first choice and failed, retry with legacy
+    // before giving up. Covers e.g. systems where glibc reports >= 2.38 but
+    // libstdc++ is too old, or where detection misread the runtime.
+    if (!useLegacy) {
+      String fallbackTier = archDir + "-legacy";
+      System.err.println("[OculiX] modern tier load failed, retrying with " + fallbackTier + "/");
+      if (extractAndLoad(fallbackTier + "/" + fileName, fileName)) {
+        System.err.println("[OculiX] OpenCV loaded from " + fallbackTier + "/ (cascade fallback)");
+        return true;
+      }
+    }
+    return false;
+  }
+
+  /** JNA binding to libc's gnu_get_libc_version(), present on glibc systems. */
+  private interface LibC extends com.sun.jna.Library {
+    String gnu_get_libc_version();
+  }
+
+  /**
+   * Returns {major, minor} of the runtime glibc, or null if not detectable
+   * (e.g. musl-based systems like Alpine, or non-Linux platforms).
+   */
+  private static int[] detectGlibcVersion() {
+    if (!runningLinux()) return null;
+    // 1. JNA → gnu_get_libc_version (cleanest, no process spawn).
+    try {
+      LibC libc = com.sun.jna.Native.load("c", LibC.class);
+      return parseGlibcVersion(libc.gnu_get_libc_version());
+    } catch (Throwable ignored) {
+      // Symbol absent (musl) or JNA failure — try ldd.
+    }
+    // 2. Fallback: parse `ldd --version` first line.
+    try {
+      Process p = new ProcessBuilder("ldd", "--version").redirectErrorStream(true).start();
+      try (java.io.BufferedReader br = new java.io.BufferedReader(
+          new java.io.InputStreamReader(p.getInputStream()))) {
+        String firstLine = br.readLine();
+        p.waitFor();
+        if (firstLine != null) {
+          Matcher m = Pattern.compile("(\\d+)\\.(\\d+)").matcher(firstLine);
+          if (m.find()) {
+            return new int[] { Integer.parseInt(m.group(1)), Integer.parseInt(m.group(2)) };
+          }
+        }
+      }
+    } catch (Throwable ignored) {
+    }
+    return null;
+  }
+
+  private static int[] parseGlibcVersion(String v) {
+    if (v == null) return null;
+    String[] parts = v.split("\\.");
+    if (parts.length < 2) return null;
+    try {
+      return new int[] { Integer.parseInt(parts[0].trim()), Integer.parseInt(parts[1].trim()) };
+    } catch (NumberFormatException nfe) {
+      return null;
+    }
+  }
+
+  /**
+   * Extract a classpath resource to the temp folder and System.load() it.
+   * Returns true on success. Caller is responsible for setting libOpenCVloaded
+   * when the loaded resource is the OpenCV native.
+   */
+  private static boolean extractAndLoad(String resourcePath, String fileName) {
+    try {
+      java.io.InputStream is = Commons.class.getClassLoader().getResourceAsStream(resourcePath);
+      if (is == null) {
+        // Some classloaders want a leading slash when going through Class, not ClassLoader.
+        is = Commons.class.getResourceAsStream("/" + resourcePath);
+      }
+      if (is == null) {
+        System.err.println("[OculiX] jar resource not found on classpath: " + resourcePath);
+        return false;
+      }
+      File tempDir = getTempFolder();
+      if (tempDir == null) {
+        tempDir = new File(System.getProperty("java.io.tmpdir"));
+      }
+      File tempLib = new File(tempDir, fileName);
+      try (java.io.FileOutputStream fos = new java.io.FileOutputStream(tempLib)) {
+        byte[] buf = new byte[8192];
+        int len;
+        while ((len = is.read(buf)) > 0) {
+          fos.write(buf, 0, len);
+        }
+      } finally {
+        is.close();
+      }
+      System.load(tempLib.getAbsolutePath());
+      System.err.println("[OculiX] native loaded from jar resource: " + tempLib);
+      return true;
+    } catch (Throwable e) {
+      System.err.println("[OculiX] jar extraction of " + resourcePath + " failed: "
+          + e.getClass().getSimpleName() + ": " + e.getMessage());
+      return false;
+    }
   }
 
   private static final String jarLibsPath = "/sikulixlibs/";

--- a/IDE/pom.xml
+++ b/IDE/pom.xml
@@ -46,7 +46,7 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <sikulixjythonversion>2.7.4</sikulixjythonversion>
-    <sikulixjrubyversion>10.1.0.0</sikulixjrubyversion>
+    <sikulixjrubyversion>9.4.14.0</sikulixjrubyversion>
   </properties>
 
   <dependencies>


### PR DESCRIPTION
# Sync RC Fixes to Master

[![Java](https://img.shields.io/badge/Java-17-007396?logo=openjdk&logoColor=white)](https://openjdk.org/projects/jdk/17/)
[![JRuby](https://img.shields.io/badge/JRuby-9.4.14.0-CC0000?logo=ruby&logoColor=white)](https://www.jruby.org/)
[![OpenCV](https://img.shields.io/badge/OpenCV-4.10.0--3-5C3EE8?logo=opencv&logoColor=white)](https://opencv.org/)
[![CI](https://img.shields.io/badge/CI-GitHub_Actions-2088FF?logo=githubactions&logoColor=white)](https://github.com/oculix-org/Oculix/actions)
[![Branch](https://img.shields.io/badge/branch-sync--rc--fixes--to--master-blue?logo=git)](https://github.com/oculix-org/Oculix/tree/sync-rc-fixes-to-master)
[![Commits](https://img.shields.io/badge/commits-5_ahead-success?logo=git)](https://github.com/oculix-org/Oculix/compare/master...sync-rc-fixes-to-master)

> Forward-port to `master` of the fixes validated on `release/oculix-rc`:
> Linux runtime compatibility (glibc), Java 17 build, and release
> workflow hardening.

---

## 📋 Summary

| # | Commit | Area | Impact |
|---|--------|------|--------|
| 1 | [`5f5f421`](https://github.com/oculix-org/Oculix/commit/5f5f421) | **Runtime** | Pick OpenCV native tier at runtime based on glibc |
| 2 | [`ed92685`](https://github.com/oculix-org/Oculix/commit/ed92685) | **Build**   | Revert JRuby 10.x → 9.4.14.0 (Java 17 compat) |
| 3 | [`887368f`](https://github.com/oculix-org/Oculix/commit/887368f) | **Deps**    | Dependabot: ignore JRuby major bumps |
| 4 | [`6a34dab`](https://github.com/oculix-org/Oculix/commit/6a34dab) | **Release** | Tag at workflow commit, not `master` HEAD |
| 5 | [`503f68d`](https://github.com/oculix-org/Oculix/commit/503f68d) | **Release** | Make releases visible in the GitHub UI (target = branch ref) |

**Total:** `2 source files` · `1 workflow` · `1 dependabot` — no API breakage.

---

## 🔧 Details by category

### 🐧 1. Linux runtime compatibility — `5f5f421`

> Fixes the `GLIBC_2.38 not found` `UnsatisfiedLinkError` on Ubuntu 22.04
> (issue #15) and unblocks RHEL 8/9, Debian 12, and older LTS distros.

Apertix 4.10.0-3 ships two Linux variants of `libopencv_java4100.so`:

| Variant | Required glibc | Typical distros |
|---------|---------------|-----------------|
| `linux-{x86-64,aarch64}/`        | ≥ 2.38 | Ubuntu 24.04, Fedora 39+ |
| `linux-{x86-64,aarch64}-legacy/` | ≥ 2.28 (manylinux_2_28) | Ubuntu 22.04, RHEL 8/9, Debian 12 |

On Linux, `Commons.loadOpenCV()` now bypasses
`nu.pattern.OpenCV.loadLocally()` and:

1. detects the runtime glibc via JNA `gnu_get_libc_version()` (with `ldd --version` fallback),
2. selects the matching resource path,
3. cascade-retries with the *legacy* tier when *modern* fails,
4. defaults to *legacy* on musl / detection failure.

**Files**
- `API/pom.xml` *(+9 / -0)*
- `API/src/main/java/org/sikuli/support/Commons.java` *(+185 / -63)*

---

### ☕ 2. Revert JRuby 10.x → 9.4.14.0 — `ed92685`

JRuby 10.x is compiled for **Java 21** (class file version 65). The
`release-rc.yml` workflow pins `java-version: '17'` (class file version
61 max), so the Dependabot bump (PR #197 / #199) silently broke every
GHA build job:

- `mvn ... | egrep` swallowed the exit code
- no JAR was produced
- `find windows-jars` failed at the release stage

JRuby **9.4.14.0** (released 2025-08-28) — the latest of the 9.4 line —
keeps full Java 8-17 support. All three modules (API / IDE / MCP)
compile cleanly with `-Dmaven.compiler.release=17`.

**Files**
- `API/pom.xml` *(JRuby version)*
- `IDE/pom.xml` *(JRuby version)*

---

### 🤖 3. Dependabot guard rail — `887368f`

Adds `ignore: { update-types: [version-update:semver-major] }` for
**JRuby** in the `/IDE`, `/API`, and `/MCP` sections of
`dependabot.yml`. Patches and minors on the 9.4 line remain allowed.

> 💡 Remove this rule the day OculiX moves to Java 21.

**Files**
- `.github/dependabot.yml` *(+12)*

---

### 🚀 4-5. `release-rc.yml` hardening — `6a34dab` + `503f68d`

| Commit | Problem | Fix |
|--------|---------|-----|
| `6a34dab` | `--target master` pinned the tag to `master HEAD`, which lacks the rc version bump in `pom.xml` → source tarball didn't match the JARs | Tag at `$GITHUB_SHA` (= the commit actually built) |
| `503f68d` | GitHub hides releases whose `target_commitish` is a full SHA from `/releases` listings (only the direct tag URL works) | Pass the **branch name** (`release/oculix-rc`) — the release becomes visible again, tag SHA stays correct |

**Files**
- `.github/workflows/release-rc.yml` *(2 lines changed total)*

---

## ✅ Test plan

- [ ] CI green on `sync-rc-fixes-to-master` (all 3 modules build)
- [ ] Runtime smoke test on **Ubuntu 22.04** (glibc 2.35) → *legacy* tier loaded
- [ ] Runtime smoke test on **Ubuntu 24.04** (glibc 2.39) → *modern* tier loaded
- [ ] Runtime smoke test on **musl** (Alpine) → fallback to *legacy*, no crash
- [ ] Re-run `release-rc` workflow → release visible under the *Releases* tab
- [ ] Verify the tag points at the workflow commit, not `master`
- [ ] No new Dependabot PR for JRuby 10.x on the next scan


---

<sub>🌿 Source: `oculix-org/Oculix@sync-rc-fixes-to-master` → `oculix-org/Oculix@master`</sub>