### PR TITLE
README: fix Oculix Maven snippet

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,9 +162,9 @@ mvn clean install -DskipTests
 
 ```xml
 <dependency>
-  <groupId>com.sikulix</groupId>
-  <artifactId>oculixapi</artifactId>
-  <version>3.0.2</version>
+    <groupId>io.github.oculix-org</groupId>
+    <artifactId>oculixapi</artifactId>
+    <version>3.0.2</version>
 </dependency>
 ```
 


### PR DESCRIPTION
tried pulling oculix via Maven and ran into errors. 
updated the snippet with the version that works currently.

- [ ]  Linked issue: none, just a README update 
- [ ]  Root cause in one or two sentences: incorrect dependency in maven leads to fail on `mvn install`
- [ ]  What changed at a high level: updated the README with the correct snippet from: https://central.sonatype.com/artifact/io.github.oculix-org/oculixapi
- [ ]  How you tested it — `mvn clean install` on Linux, Ubuntu 22.04
- [ ]  Regressions considered — no regressions, just a README update
- [ ]  Screenshots if the change is visual: does not apply