### PR TITLE
fix: wrap showAfterStart in SwingUtilities.invokeLater to prevent dea…

### DIFF
--- a/IDE/src/main/java/org/sikuli/support/runner/JythonRunner.java
+++ b/IDE/src/main/java/org/sikuli/support/runner/JythonRunner.java
@@ -12,6 +12,7 @@ import static org.sikuli.util.CommandArgsEnum.*;
 import java.io.File;
 import java.io.PrintStream;
 import java.util.Arrays;
+import javax.swing.SwingUtilities;
 import java.util.regex.Matcher;
 
 /**
@@ -97,7 +98,7 @@ public class JythonRunner extends AbstractLocalFileScriptRunner {
       }
       Commons.startLog(3, "Jython ready: version %s (%4.1f sec)", interpreterVersion, Commons.getSinceStart());
       if (!Commons.hasOption(RUN)) {
-        SikulixIDE.showAfterStart();
+        SwingUtilities.invokeLater(() -> SikulixIDE.showAfterStart());
       }
     }
   }


### PR DESCRIPTION
## Problem

On Linux, launching the IDE from source causes a permanent deadlock — 
the window never appears. 

The cause is a Swing threading issue: `JythonRunner.doInit()` 
calls `SikulixIDE.showAfterStart()` from a background thread. This triggers 
window layout which acquires `AWTTreeLock`, while the EDT simultaneously 
holds `AWTTreeLock` and waits for the `HTMLDocument` read lock (logging 
startup messages to the console). Neither thread proceeds.

## Fix

Wrap the `showAfterStart()` call in `SwingUtilities.invokeLater()` so the 
window is shown on the EDT after it finishes its current work.

## Tested on

- Ubuntu 24.04, Java 21.0.10, OculiX v3.0.3-rc1