### PR TITLE
Bundle Tesseract via Legerix for cross-platform OCR support

### DIFF
--- a/API/pom.xml
+++ b/API/pom.xml
@@ -122,7 +122,7 @@
     <dependency>
       <groupId>io.github.oculix-org</groupId>
       <artifactId>legerix</artifactId>
-      <version>5.5.0-3</version>
+      <version>5.5.0-4</version>
       <!-- Bundled Tesseract/Leptonica natives + tessdata (eng, fra, spa,
            chi_sim, hin) for all supported platforms. Legerix.loadNatives()
            extracts the right binaries to a cache dir and loads them via JNA,

--- a/API/pom.xml
+++ b/API/pom.xml
@@ -122,7 +122,7 @@
     <dependency>
       <groupId>io.github.oculix-org</groupId>
       <artifactId>legerix</artifactId>
-      <version>5.5.0-2</version>
+      <version>5.5.0-3</version>
       <!-- Bundled Tesseract/Leptonica natives + tessdata (eng, fra, spa,
            chi_sim, hin) for all supported platforms. Legerix.loadNatives()
            extracts the right binaries to a cache dir and loads them via JNA,

--- a/API/pom.xml
+++ b/API/pom.xml
@@ -120,6 +120,15 @@
       <version>${versiontess4j}</version>
     </dependency>
     <dependency>
+      <groupId>io.github.oculix-org</groupId>
+      <artifactId>legerix</artifactId>
+      <version>5.5.0-2</version>
+      <!-- Bundled Tesseract/Leptonica natives + tessdata (eng, fra, spa,
+           chi_sim, hin) for all supported platforms. Legerix.loadNatives()
+           extracts the right binaries to a cache dir and loads them via JNA,
+           so users no longer need a system-installed tesseract. -->
+    </dependency>
+    <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-nop</artifactId>
       <version>2.0.17</version>

--- a/API/src/main/java/org/sikuli/script/OCR.java
+++ b/API/src/main/java/org/sikuli/script/OCR.java
@@ -165,7 +165,11 @@ public class OCR {
     public Options reset() {
       oem = OEM.DEFAULT.ordinal();
       psm = PSM.AUTO.ordinal();
-      language = "eng";
+      // Honour Settings.OcrLanguage if set, else fall back to eng. Keeps a
+      // single source of truth so both globalOptions() and freshly-cloned
+      // Options agree on the default language.
+      String settingsLang = Settings.OcrLanguage;
+      language = (settingsLang == null || settingsLang.isEmpty()) ? "eng" : settingsLang;
       dataPath = null;
       isLightFont = false;
       textHeight = getDefaultTextHeight();
@@ -207,10 +211,27 @@ public class OCR {
      * INTERNAL: validates this Options before OCR usage.
      */
     protected void validate() {
-      if (!new File(dataPath(), language() + ".traineddata").exists()) {
-        throw new SikuliXception(String.format("OCR: language: no %s.traineddata in %s",
-                language(), dataPath()));
+      String lang = language();
+      File trained = new File(dataPath(), lang + ".traineddata");
+      if (!trained.exists()) {
+        List<String> available = availableLanguages();
+        String availMsg = available.isEmpty() ? "(none found)" : String.join(", ", available);
+        String msg = "\n\n"
+            + "══════════════════════════════════════════════════════════════\n"
+            + " OCR language '" + lang + "' is not available.\n"
+            + "══════════════════════════════════════════════════════════════\n\n"
+            + " Looked in: " + dataPath() + "\n"
+            + " Languages currently bundled: " + availMsg + "\n\n"
+            + " Fix:\n"
+            + "  - Pick a bundled language via Settings.OcrLanguage = \"eng\";\n"
+            + "  - Or drop a <lang>.traineddata file into a custom tessdata\n"
+            + "    folder and set Settings.OcrDataPath to its parent.\n"
+            + "══════════════════════════════════════════════════════════════";
+        Debug.error(msg);
+        throw new SikuliXception(String.format("OCR: language: no %s.traineddata in %s (available: %s)",
+                lang, dataPath(), availMsg));
       }
+      maybePrintWelcome(this);
     }
     //</editor-fold>
 
@@ -681,6 +702,59 @@ public class OCR {
    */
   public static void status() {
     Debug.logp("Global settings " + globalOptions().toString());
+  }
+
+  /**
+   * @return the language codes (e.g. "eng", "fra", "chi_sim") for which a
+   *         &lt;lang&gt;.traineddata file exists in the current default tessdata
+   *         folder. Empty list if the folder is missing or unreadable.
+   */
+  public static List<String> availableLanguages() {
+    List<String> out = new ArrayList<>();
+    String dataPath = globalOptions().dataPath();
+    if (dataPath == null) {
+      // OCR not yet exercised — fall back to the Legerix-bundled tessdata
+      // so callers (e.g. IDE Preferences) can populate a language picker
+      // before the first read.
+      dataPath = Commons.getTesseractDataPath();
+    }
+    if (dataPath == null) {
+      return out;
+    }
+    File dir = new File(dataPath);
+    File[] files = dir.listFiles((d, name) -> name.endsWith(".traineddata"));
+    if (files == null) {
+      return out;
+    }
+    for (File f : files) {
+      String name = f.getName();
+      out.add(name.substring(0, name.length() - ".traineddata".length()));
+    }
+    Collections.sort(out);
+    return out;
+  }
+
+  private static volatile boolean welcomePrinted = false;
+
+  private static void maybePrintWelcome(Options opts) {
+    if (welcomePrinted) {
+      return;
+    }
+    welcomePrinted = true;
+    List<String> langs = availableLanguages();
+    String tessVersion = "?";
+    if (Commons.isTesseractLoaded()) {
+      try {
+        Class<?> legerix = Class.forName("io.github.julienmerconsulting.legerix.Legerix");
+        Object v = legerix.getMethod("getTesseractVersion").invoke(null);
+        if (v != null) tessVersion = v.toString();
+      } catch (Throwable ignore) { }
+    }
+    String engine = Commons.isTesseractLoaded()
+        ? "bundled Tesseract " + tessVersion + " (Legerix)"
+        : "system Tesseract";
+    Debug.log(3, "OCR: ready — engine=%s, lang=%s, available=%s",
+        engine, opts.language(), langs.isEmpty() ? "(none)" : String.join(",", langs));
   }
   //</editor-fold>
 

--- a/API/src/main/java/org/sikuli/script/TextRecognizer.java
+++ b/API/src/main/java/org/sikuli/script/TextRecognizer.java
@@ -80,55 +80,61 @@ public class TextRecognizer {
   private static boolean isValid = false;
 
   private static String getTesseractInstallCommand() {
-    String installCmd;
-    if (Commons.runningMac()) {
-      installCmd = "  brew install tesseract";
-    } else if (Commons.runningLinux()) {
-      installCmd = "  sudo apt-get install tesseract-ocr   (Debian/Ubuntu)\n"
-          + "  sudo dnf install tesseract            (Fedora/RHEL)\n"
-          + "  sudo zypper install tesseract         (SUSE)";
-    } else {
-      installCmd = "Reinstall OculiX — Windows binaries should be bundled with tess4j.";
-    }
-    //TODO add the respective Oculix wiki page when ready
-    installCmd += "\n\n"
-        + " Then restart OculiX.\n\n"
-        + " More info: https://github.com/oculix-org/Oculix/wiki/OCR-Setup\n\n"
+    // Tesseract natives are bundled via Legerix on all supported platforms
+    // (mac/linux x86_64 + aarch64, windows x86_64). If Legerix failed to load,
+    // it almost always means a packaging/extraction problem rather than a
+    // missing system binary, so we direct the user to reinstall OculiX rather
+    // than to install tesseract from a package manager.
+    return "  Reinstall OculiX — Tesseract binaries are bundled via Legerix.\n"
+        + "  If the problem persists, please open an issue.\n\n"
+        + "  More info: https://github.com/oculix-org/Oculix/wiki/OCR-Setup\n\n"
         + "══════════════════════════════════════════════════════════════";
-    return installCmd;
   }
 
   private static void checkLib() {
-    if (!isValid) {
+    if (isValid) {
+      return;
+    }
+    // Fast path: Legerix has already loaded bundled libtesseract via JNA in
+    // Commons.loadTesseract(). No need to shell out to a system `tesseract`
+    // binary — the Tess4J Tesseract1() wrapper will pick up the JNA-loaded
+    // library directly.
+    if (Commons.isTesseractLoaded()) {
       String versionTess4J = Commons.getSXVersionTess4j();
-      String versionTesseractExpected = LoadLibs.LIB_NAME.replace("libtesseract", "");
-      String versionTesseract = "" + versionTesseractExpected;
-      if (!Commons.runningWindows()) {
-        versionTesseract = "";
-        String run = ProcessRunner.run(new String[]{"tesseract", "--version"});
-        String[] result = run.split(" ");
-        if (result.length > 1) {
-          if (result[0].contains("tesseract")) {
-            versionTesseract = result[1];
-          }
-          if (!versionTesseractExpected.equals(versionTesseract.replace(".", ""))) {
-            Debug.log(lvl, "OCR: start: Tesseract version mismatch: found %s != expected %s (but might work)", versionTesseract, versionTesseractExpected);
-          }
+      isValid = true;
+      Debug.log(lvl, "OCR: start: Tess4J %s using bundled Tesseract (Legerix)", versionTess4J);
+      return;
+    }
+    // Legacy fallback: legerix not on classpath (or failed to extract). Probe
+    // for a system-installed tesseract so existing setups keep working.
+    String versionTess4J = Commons.getSXVersionTess4j();
+    String versionTesseractExpected = LoadLibs.LIB_NAME.replace("libtesseract", "");
+    String versionTesseract = "" + versionTesseractExpected;
+    if (!Commons.runningWindows()) {
+      versionTesseract = "";
+      String run = ProcessRunner.run(new String[]{"tesseract", "--version"});
+      String[] result = run.split(" ");
+      if (result.length > 1) {
+        if (result[0].contains("tesseract")) {
+          versionTesseract = result[1];
+        }
+        if (!versionTesseractExpected.equals(versionTesseract.replace(".", ""))) {
+          Debug.log(lvl, "OCR: start: Tesseract version mismatch: found %s != expected %s (but might work)", versionTesseract, versionTesseractExpected);
         }
       }
-      isValid = !versionTesseract.isEmpty();
-      if (isValid) {
-        Debug.log(lvl, "OCR: start: Tess4J %s using Tesseract %s", versionTess4J, versionTesseract);
-      } else {
-        String installCmd = getTesseractInstallCommand();
-        String msg = "\n\n"
-            + "══════════════════════════════════════════════════════════════\n"
-            + " Tesseract OCR engine not found on your system.\n"
-            + "══════════════════════════════════════════════════════════════\n\n"
-            + " Install it with:\n" + installCmd;
-        Debug.error(msg);
-        throw new SikuliXception("Tesseract OCR engine not found on your system.");
-      }
+    }
+    isValid = !versionTesseract.isEmpty();
+    if (isValid) {
+      Debug.log(lvl, "OCR: start: Tess4J %s using Tesseract %s", versionTess4J, versionTesseract);
+    } else {
+      String installCmd = getTesseractInstallCommand();
+      String msg = "\n\n"
+          + "══════════════════════════════════════════════════════════════\n"
+          + " Tesseract OCR engine not found.\n"
+          + "══════════════════════════════════════════════════════════════\n\n"
+          + " Fix:\n" + installCmd;
+      Debug.error(msg);
+      throw new SikuliXception("Tesseract OCR engine not found.");
     }
   }
 
@@ -385,8 +391,23 @@ public class TextRecognizer {
 
   //<editor-fold desc="30 helper">
   private static void initDefaultDataPath() {
-    if (OCR.Options.defaultDataPath == null) {
-      // export SikuliX eng.traineddata, if libs are exported as well
+    if (OCR.Options.defaultDataPath != null) {
+      return;
+    }
+    // Priority order:
+    //   1. Settings.OcrDataPath (user override)
+    //   2. Legerix bundled tessdata (eng, fra, spa, chi_sim, hin)
+    //   3. Legacy SikulixTesseract resource extraction
+    String defaultDataPath = null;
+    if (Settings.OcrDataPath != null) {
+      defaultDataPath = new File(Settings.OcrDataPath, "tessdata").getAbsolutePath();
+    } else {
+      String legerixPath = Commons.getTesseractDataPath();
+      if (legerixPath != null && new File(legerixPath).isDirectory()) {
+        defaultDataPath = legerixPath;
+      }
+    }
+    if (defaultDataPath == null) {
       File fTessDataPath = new File(Commons.getAppDataPath(), "SikulixTesseract/tessdata");
       boolean shouldExport = Commons.shouldExport();
       boolean fExists = fTessDataPath.exists();
@@ -395,15 +416,9 @@ public class TextRecognizer {
           throw new SikuliXception(String.format("OCR: start: export tessdata did not work: %s", fTessDataPath));
         }
       }
-      // if set, try with provided tessdata parent folder
-      String defaultDataPath;
-      if (Settings.OcrDataPath != null) {
-        defaultDataPath = new File(Settings.OcrDataPath, "tessdata").getAbsolutePath();
-      } else {
-        defaultDataPath = fTessDataPath.getAbsolutePath();
-      }
-      OCR.Options.defaultDataPath = defaultDataPath;
+      defaultDataPath = fTessDataPath.getAbsolutePath();
     }
+    OCR.Options.defaultDataPath = defaultDataPath;
   }
 
   protected <SFIRBS> String doRead(SFIRBS from) {

--- a/API/src/main/java/org/sikuli/support/Commons.java
+++ b/API/src/main/java/org/sikuli/support/Commons.java
@@ -151,6 +151,7 @@ public class Commons {
     // static-init chain has been triggered yet. Fixes UnsatisfiedLinkError on
     // first new Mat() from non-Finder call paths (e.g. Pattern.patternMask field init).
     loadOpenCV();
+    loadTesseract();
   }
 
   public static void init() {
@@ -1250,6 +1251,52 @@ public static void loadOpenCV() {
 
     System.err.println("[OculiX] FATAL: OpenCV native library '" + libName + "' could NOT be loaded. "
         + "Next new Mat() call will throw UnsatisfiedLinkError.");
+  }
+
+  private static final String libLegerixClassref = "io.github.julienmerconsulting.legerix.Legerix";
+  // No inline initializers: this field is declared AFTER the static {} block
+  // that calls loadTesseract(), so an explicit `= false` would run later in
+  // <clinit> and clobber the value loadTesseract() set. JLS default (false)
+  // is what we want.
+  private static volatile boolean libTesseractLoaded;
+  private static volatile String libTesseractDataPath;
+
+  public static boolean isTesseractLoaded() {
+    return libTesseractLoaded;
+  }
+
+  public static String getTesseractDataPath() {
+    return libTesseractDataPath;
+  }
+
+  public static void loadTesseract() {
+    if (libTesseractLoaded) {
+      return;
+    }
+    try {
+      Class<?> legerix = Class.forName(libLegerixClassref);
+      legerix.getMethod("loadNatives").invoke(null);
+      Object tessdataPath = legerix.getMethod("getTessdataPath").invoke(null);
+      if (tessdataPath != null) {
+        libTesseractDataPath = tessdataPath.toString();
+      }
+      libTesseractLoaded = true;
+      String version = "?";
+      try {
+        Object v = legerix.getMethod("getTesseractVersion").invoke(null);
+        if (v != null) version = v.toString();
+      } catch (Throwable ignore) { }
+      System.err.println("[OculiX] Tesseract loaded via Legerix (Tesseract " + version
+          + ", tessdata=" + libTesseractDataPath + ")");
+    } catch (ClassNotFoundException cnfe) {
+      System.err.println("[OculiX] " + libLegerixClassref + " not on classpath (Legerix jar missing?) — "
+          + "OCR will fall back to system tesseract if available.");
+    } catch (Throwable e) {
+      Throwable cause = e.getCause() != null ? e.getCause() : e;
+      System.err.println("[OculiX] Legerix.loadNatives() failed: "
+          + cause.getClass().getSimpleName() + ": " + cause.getMessage()
+          + " — OCR will fall back to system tesseract if available.");
+    }
   }
 
   private static final String jarLibsPath = "/sikulixlibs/";

--- a/API/src/main/java/org/sikuli/support/Commons.java
+++ b/API/src/main/java/org/sikuli/support/Commons.java
@@ -1273,30 +1273,107 @@ public static void loadOpenCV() {
     if (libTesseractLoaded) {
       return;
     }
+    boolean nativesLoaded = false;
+    String version = "?";
     try {
       Class<?> legerix = Class.forName(libLegerixClassref);
-      legerix.getMethod("loadNatives").invoke(null);
-      Object tessdataPath = legerix.getMethod("getTessdataPath").invoke(null);
-      if (tessdataPath != null) {
-        libTesseractDataPath = tessdataPath.toString();
+      try {
+        legerix.getMethod("loadNatives").invoke(null);
+        nativesLoaded = true;
+      } catch (Throwable e) {
+        // Common on Windows when Legerix's bundled tesseract/leptonica DLLs
+        // depend on image/runtime libs that aren't on the system PATH (libpng,
+        // libtiff, libwebp, libcurl, libarchive, ...). The natives won't load,
+        // but we can still recover the bundled tessdata: Legerix extracts it
+        // to the cache dir before the JNA load step, AND we have the same
+        // /tessdata resources in the fat-jar to fall back on. If natives are
+        // unusable, Tess4J's own bundled DLLs (also in the fat-jar) handle the
+        // OCR runtime — we just need the .traineddata files.
+        Throwable cause = e.getCause() != null ? e.getCause() : e;
+        System.err.println("[OculiX] Legerix.loadNatives() failed: "
+            + cause.getClass().getSimpleName() + ": " + cause.getMessage());
       }
-      libTesseractLoaded = true;
-      String version = "?";
       try {
         Object v = legerix.getMethod("getTesseractVersion").invoke(null);
         if (v != null) version = v.toString();
       } catch (Throwable ignore) { }
-      System.err.println("[OculiX] Tesseract loaded via Legerix (Tesseract " + version
-          + ", tessdata=" + libTesseractDataPath + ")");
+      // Try to recover the tessdata path even if loadNatives() failed —
+      // Legerix may have populated extractionDir during its setup phase.
+      try {
+        Object tessdataPath = legerix.getMethod("getTessdataPath").invoke(null);
+        if (tessdataPath != null) {
+          File p = new File(tessdataPath.toString());
+          if (p.isDirectory() && hasAnyTraineddata(p)) {
+            libTesseractDataPath = p.getAbsolutePath();
+          }
+        }
+      } catch (Throwable ignore) { }
+      // Last resort: extract /tessdata/*.traineddata directly from our own
+      // classpath into a stable cache folder.
+      if (libTesseractDataPath == null) {
+        File extracted = extractBundledTessdata();
+        if (extracted != null) {
+          libTesseractDataPath = extracted.getAbsolutePath();
+        }
+      }
     } catch (ClassNotFoundException cnfe) {
       System.err.println("[OculiX] " + libLegerixClassref + " not on classpath (Legerix jar missing?) — "
           + "OCR will fall back to system tesseract if available.");
-    } catch (Throwable e) {
-      Throwable cause = e.getCause() != null ? e.getCause() : e;
-      System.err.println("[OculiX] Legerix.loadNatives() failed: "
-          + cause.getClass().getSimpleName() + ": " + cause.getMessage()
-          + " — OCR will fall back to system tesseract if available.");
+      return;
     }
+    if (nativesLoaded) {
+      libTesseractLoaded = true;
+      System.err.println("[OculiX] Tesseract loaded via Legerix (Tesseract " + version
+          + ", tessdata=" + libTesseractDataPath + ")");
+    } else if (libTesseractDataPath != null) {
+      // Tess4J ships its own self-contained Tesseract DLLs/dylibs/sos and will
+      // load them lazily via JNA on first new Tesseract1(). We don't flip
+      // libTesseractLoaded — that flag tracks Legerix specifically — but the
+      // tessdata path is enough for TextRecognizer to find the language data.
+      System.err.println("[OculiX] Legerix natives unavailable — using Tess4J bundled binaries with "
+          + "Legerix-bundled tessdata (" + libTesseractDataPath + ")");
+    } else {
+      System.err.println("[OculiX] No Tesseract available — OCR will require a system install.");
+    }
+  }
+
+  private static boolean hasAnyTraineddata(File dir) {
+    String[] names = dir.list();
+    if (names == null) return false;
+    for (String n : names) {
+      if (n.endsWith(".traineddata")) return true;
+    }
+    return false;
+  }
+
+  private static File extractBundledTessdata() {
+    // Bundled languages in Legerix 5.5.x: eng, fra, spa, chi_sim, hin, plus osd
+    String[] langs = {"eng", "fra", "spa", "chi_sim", "hin", "osd"};
+    File target = new File(getAppDataPath(), "OculixTesseract/tessdata");
+    if (!target.exists() && !target.mkdirs()) {
+      return null;
+    }
+    int extracted = 0;
+    for (String lang : langs) {
+      File out = new File(target, lang + ".traineddata");
+      if (out.exists() && out.length() > 0) {
+        extracted++;
+        continue;
+      }
+      String resource = "/tessdata/" + lang + ".traineddata";
+      try (java.io.InputStream is = Commons.class.getResourceAsStream(resource)) {
+        if (is == null) continue;
+        try (java.io.FileOutputStream fos = new java.io.FileOutputStream(out)) {
+          byte[] buf = new byte[8192];
+          int n;
+          while ((n = is.read(buf)) > 0) fos.write(buf, 0, n);
+        }
+        extracted++;
+      } catch (Throwable e) {
+        System.err.println("[OculiX] Failed to extract " + resource + ": " + e.getMessage());
+      }
+    }
+    return extracted > 0 ? target : null;
   }
 
   private static final String jarLibsPath = "/sikulixlibs/";

--- a/IDE/makeide-lux.xml
+++ b/IDE/makeide-lux.xml
@@ -18,7 +18,10 @@
       <unpackOptions>
         <excludes>
           <exclude>**/win32-x86/**</exclude>
-          <exclude>**/tessdata/**</exclude>
+          <!-- Do NOT exclude **/tessdata/** — Legerix bundles its
+               .traineddata files (eng/fra/spa/chi_sim/hin) in /tessdata/ at
+               the jar root and reads them during loadNatives(). Stripping
+               that folder breaks the native loader entirely. -->
           <exclude>/nu/pattern/opencv/osx/**</exclude>
           <exclude>/nu/pattern/opencv/windows/**</exclude>
         </excludes>

--- a/IDE/makeide-mac.xml
+++ b/IDE/makeide-mac.xml
@@ -18,7 +18,10 @@
       <unpackOptions>
         <excludes>
           <exclude>**/win32-x86/**</exclude>
-          <exclude>**/tessdata/**</exclude>
+          <!-- Do NOT exclude **/tessdata/** — Legerix bundles its
+               .traineddata files (eng/fra/spa/chi_sim/hin) in /tessdata/ at
+               the jar root and reads them during loadNatives(). Stripping
+               that folder breaks the native loader entirely. -->
           <exclude>/nu/pattern/opencv/linux/**</exclude>
           <exclude>/nu/pattern/opencv/windows/**</exclude>
         </excludes>

--- a/IDE/makeide-win.xml
+++ b/IDE/makeide-win.xml
@@ -18,7 +18,10 @@
       <unpackOptions>
         <excludes>
           <exclude>**/win32-x86/**</exclude>
-          <exclude>**/tessdata/**</exclude>
+          <!-- Do NOT exclude **/tessdata/** — Legerix bundles its
+               .traineddata files (eng/fra/spa/chi_sim/hin) in /tessdata/ at
+               the jar root and reads them during loadNatives(). Stripping
+               that folder breaks the native loader entirely. -->
           <exclude>/nu/pattern/opencv/linux/**</exclude>
           <exclude>/nu/pattern/opencv/osx/**</exclude>
           <exclude>/nu/pattern/opencv/windows/x86_32/**</exclude>

--- a/IDE/makeide.xml
+++ b/IDE/makeide.xml
@@ -22,7 +22,10 @@
       <unpackOptions>
         <excludes>
           <exclude>**/win32-x86/**</exclude>
-          <exclude>**/tessdata/**</exclude>
+          <!-- Do NOT exclude **/tessdata/** — Legerix bundles its
+               .traineddata files (eng/fra/spa/chi_sim/hin) in /tessdata/ at
+               the jar root and reads them during loadNatives(). Stripping
+               that folder breaks the native loader entirely. -->
           <exclude>/nu/pattern/opencv/linux/x86_32/**</exclude>
           <exclude>/nu/pattern/opencv/windows/x86_32/**</exclude>
         </excludes>


### PR DESCRIPTION
## Summary
This PR adds bundled Tesseract/Leptonica native binaries and language data via the Legerix library, eliminating the need for users to install Tesseract separately on macOS, Linux, and Windows.

## Key Changes

- **Commons.java**: Added `loadTesseract()` method that:
  - Attempts to load Tesseract natives via Legerix reflection
  - Falls back to extracting bundled tessdata from classpath if natives fail to load
  - Provides graceful degradation to system-installed Tesseract if Legerix is unavailable
  - Tracks tessdata path for use by TextRecognizer

- **TextRecognizer.java**: Refactored OCR initialization to:
  - Prioritize bundled Tesseract via Legerix (fast path, no system binary needed)
  - Fall back to system-installed Tesseract for legacy compatibility
  - Updated install instructions to direct users to reinstall OculiX rather than install system packages
  - Simplified version checking when using bundled binaries

- **OCR.java**: Enhanced language and data path handling:
  - Added `availableLanguages()` method to list bundled language packs
  - Improved error messages when requested language is unavailable, showing what languages are bundled
  - Added `maybePrintWelcome()` to log OCR engine details on first use
  - Made `Options.reset()` respect `Settings.OcrLanguage` setting
  - Improved `initDefaultDataPath()` to prioritize Legerix tessdata over legacy extraction

- **pom.xml**: Added Legerix 5.5.0-4 dependency with bundled Tesseract/Leptonica natives and tessdata (eng, fra, spa, chi_sim, hin)

- **IDE build files**: Updated to preserve `/tessdata/` resources in fat JAR (required by Legerix native loader)

## Implementation Details

- Legerix natives are loaded via reflection to avoid hard dependency if the library is missing
- Graceful fallback chain: Legerix natives → Legerix-extracted tessdata → bundled tessdata extraction → system Tesseract
- Bundled languages: eng, fra, spa, chi_sim, hin, plus osd (orientation/script detection)
- Tessdata extraction uses stable cache directory (`OculixTesseract/tessdata`) to avoid repeated extraction
- All changes maintain backward compatibility with existing system-installed Tesseract setups

https://claude.ai/code/session_01EFgEbUvuUWgcH3c15eMmpT