### PR TITLE
fix: bundle Legerix tessdata properly in API/IDE fat-jars (rc4)

### DIFF
--- a/API/makeapi-lux.xml
+++ b/API/makeapi-lux.xml
@@ -18,7 +18,10 @@
       <unpackOptions>
         <excludes>
           <exclude>**/win32-x86/**</exclude>
-          <exclude>**/tessdata/**</exclude>
+          <!-- Do NOT exclude **/tessdata/** here: Legerix bundles its
+               .traineddata files (eng/fra/spa/chi_sim/hin) in /tessdata/
+               at the jar root. Stripping breaks Legerix.getTessdataPath()
+               and leaves the API standalone fat-jar without OCR data. -->
           <exclude>/nu/pattern/opencv/osx/**</exclude>
           <exclude>/nu/pattern/opencv/windows/**</exclude>
         </excludes>
@@ -26,7 +29,21 @@
       <excludes>
         <exclude>org.jruby:jruby-complete</exclude>
         <exclude>org.apache.pdfbox:*</exclude>
+        <exclude>io.github.oculix-org:legerix</exclude>
       </excludes>
+      <scope>runtime</scope>
+    </dependencySet>
+    <!-- Legerix unpacked LAST so its /tessdata/{eng,fra,spa,chi_sim,hin}.traineddata
+         and /linux-x86-64/* natives win over Tess4J's bundled tessdata
+         (which only ships eng + osd and would otherwise overwrite Legerix's
+         multilingual set during unpack). -->
+    <dependencySet>
+      <outputDirectory>/</outputDirectory>
+      <useProjectArtifact>false</useProjectArtifact>
+      <unpack>true</unpack>
+      <includes>
+        <include>io.github.oculix-org:legerix</include>
+      </includes>
       <scope>runtime</scope>
     </dependencySet>
   </dependencySets>

--- a/API/makeapi-mac.xml
+++ b/API/makeapi-mac.xml
@@ -18,7 +18,10 @@
       <unpackOptions>
         <excludes>
           <exclude>**/win32-x86/**</exclude>
-          <exclude>**/tessdata/**</exclude>
+          <!-- Do NOT exclude **/tessdata/** here: Legerix bundles its
+               .traineddata files (eng/fra/spa/chi_sim/hin) in /tessdata/
+               at the jar root. Stripping breaks Legerix.getTessdataPath()
+               and leaves the API standalone fat-jar without OCR data. -->
           <exclude>/nu/pattern/opencv/linux/**</exclude>
           <exclude>/nu/pattern/opencv/windows/**</exclude>
         </excludes>
@@ -26,7 +29,21 @@
       <excludes>
         <exclude>org.jruby:jruby-complete</exclude>
         <exclude>org.apache.pdfbox:*</exclude>
+        <exclude>io.github.oculix-org:legerix</exclude>
       </excludes>
+      <scope>runtime</scope>
+    </dependencySet>
+    <!-- Legerix unpacked LAST so its /tessdata/{eng,fra,spa,chi_sim,hin}.traineddata
+         and /darwin*/* natives win over Tess4J's bundled tessdata
+         (which only ships eng + osd and would otherwise overwrite Legerix's
+         multilingual set during unpack). -->
+    <dependencySet>
+      <outputDirectory>/</outputDirectory>
+      <useProjectArtifact>false</useProjectArtifact>
+      <unpack>true</unpack>
+      <includes>
+        <include>io.github.oculix-org:legerix</include>
+      </includes>
       <scope>runtime</scope>
     </dependencySet>
   </dependencySets>

--- a/API/makeapi-win.xml
+++ b/API/makeapi-win.xml
@@ -18,7 +18,10 @@
       <unpackOptions>
         <excludes>
           <exclude>**/win32-x86/**</exclude>
-          <exclude>**/tessdata/**</exclude>
+          <!-- Do NOT exclude **/tessdata/** here: Legerix bundles its
+               .traineddata files (eng/fra/spa/chi_sim/hin) in /tessdata/
+               at the jar root. Stripping breaks Legerix.getTessdataPath()
+               and leaves the API standalone fat-jar without OCR data. -->
           <exclude>/nu/pattern/opencv/linux/**</exclude>
           <exclude>/nu/pattern/opencv/osx/**</exclude>
           <exclude>/nu/pattern/opencv/windows/x86_32/**</exclude>
@@ -27,7 +30,21 @@
       <excludes>
         <exclude>org.jruby:jruby-complete</exclude>
         <exclude>org.apache.pdfbox:*</exclude>
+        <exclude>io.github.oculix-org:legerix</exclude>
       </excludes>
+      <scope>runtime</scope>
+    </dependencySet>
+    <!-- Legerix unpacked LAST so its /tessdata/{eng,fra,spa,chi_sim,hin}.traineddata
+         and /win32-x86-64/* natives win over Tess4J's bundled tessdata
+         (which only ships eng + osd and would otherwise overwrite Legerix's
+         multilingual set during unpack). -->
+    <dependencySet>
+      <outputDirectory>/</outputDirectory>
+      <useProjectArtifact>false</useProjectArtifact>
+      <unpack>true</unpack>
+      <includes>
+        <include>io.github.oculix-org:legerix</include>
+      </includes>
       <scope>runtime</scope>
     </dependencySet>
   </dependencySets>

--- a/API/pom.xml
+++ b/API/pom.xml
@@ -121,15 +121,6 @@
       <version>${versiontess4j}</version>
     </dependency>
     <dependency>
-      <groupId>io.github.oculix-org</groupId>
-      <artifactId>legerix</artifactId>
-      <version>5.5.0-4</version>
-      <!-- Bundled Tesseract/Leptonica natives + tessdata (eng, fra, spa,
-           chi_sim, hin) for all supported platforms. Legerix.loadNatives()
-           extracts the right binaries to a cache dir and loads them via JNA,
-           so users no longer need a system-installed tesseract. -->
-    </dependency>
-    <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-nop</artifactId>
       <version>2.0.17</version>
@@ -168,6 +159,18 @@
       <artifactId>junit-jupiter</artifactId>
       <version>6.0.3</version>
       <scope>test</scope>
+    </dependency>
+    <!-- Legerix declared LAST so Maven Assembly unpacks it last in the fat-jar,
+         letting its /tessdata/{eng,fra,spa,chi_sim,hin}.traineddata and
+         /<platform>/* native libs (libtesseract + libleptonica + all their
+         vcpkg-bundled runtime deps) win over Tess4J's bundled tessdata
+         (which only ships eng + osd). Combined with the dedicated final
+         dependencySet in makeapi-*.xml / makeide-*.xml as a belt-and-
+         suspenders. Do NOT move this dependency back up. -->
+    <dependency>
+      <groupId>io.github.oculix-org</groupId>
+      <artifactId>legerix</artifactId>
+      <version>5.5.0-4</version>
     </dependency>
   </dependencies>
 

--- a/API/pom.xml
+++ b/API/pom.xml
@@ -10,7 +10,7 @@
 
   <groupId>io.github.oculix-org</groupId>
   <artifactId>oculixapi</artifactId>
-  <version>3.0.3-rc3</version>
+  <version>3.0.3-rc4</version>
 
   <packaging>jar</packaging>
 

--- a/IDE/makeide-lux.xml
+++ b/IDE/makeide-lux.xml
@@ -18,10 +18,6 @@
       <unpackOptions>
         <excludes>
           <exclude>**/win32-x86/**</exclude>
-          <!-- Do NOT exclude **/tessdata/** — Legerix bundles its
-               .traineddata files (eng/fra/spa/chi_sim/hin) in /tessdata/ at
-               the jar root and reads them during loadNatives(). Stripping
-               that folder breaks the native loader entirely. -->
           <exclude>/nu/pattern/opencv/osx/**</exclude>
           <exclude>/nu/pattern/opencv/windows/**</exclude>
         </excludes>
@@ -29,7 +25,21 @@
       <excludes>
         <exclude>org.jruby:jruby-complete</exclude>
         <exclude>org.apache.pdfbox:*</exclude>
+        <exclude>io.github.oculix-org:legerix</exclude>
       </excludes>
+      <scope>runtime</scope>
+    </dependencySet>
+    <!-- Legerix unpacked LAST so its /tessdata/{eng,fra,spa,chi_sim,hin}.traineddata
+         and /linux-*/* natives win over Tess4J's bundled tessdata
+         (which only ships eng + osd and would otherwise overwrite Legerix's
+         multilingual set during unpack). -->
+    <dependencySet>
+      <outputDirectory>/</outputDirectory>
+      <useProjectArtifact>false</useProjectArtifact>
+      <unpack>true</unpack>
+      <includes>
+        <include>io.github.oculix-org:legerix</include>
+      </includes>
       <scope>runtime</scope>
     </dependencySet>
   </dependencySets>

--- a/IDE/makeide-mac.xml
+++ b/IDE/makeide-mac.xml
@@ -18,10 +18,6 @@
       <unpackOptions>
         <excludes>
           <exclude>**/win32-x86/**</exclude>
-          <!-- Do NOT exclude **/tessdata/** — Legerix bundles its
-               .traineddata files (eng/fra/spa/chi_sim/hin) in /tessdata/ at
-               the jar root and reads them during loadNatives(). Stripping
-               that folder breaks the native loader entirely. -->
           <exclude>/nu/pattern/opencv/linux/**</exclude>
           <exclude>/nu/pattern/opencv/windows/**</exclude>
         </excludes>
@@ -29,7 +25,21 @@
       <excludes>
         <exclude>org.jruby:jruby-complete</exclude>
         <exclude>org.apache.pdfbox:*</exclude>
+        <exclude>io.github.oculix-org:legerix</exclude>
       </excludes>
+      <scope>runtime</scope>
+    </dependencySet>
+    <!-- Legerix unpacked LAST so its /tessdata/{eng,fra,spa,chi_sim,hin}.traineddata
+         and /darwin*/* natives win over Tess4J's bundled tessdata
+         (which only ships eng + osd and would otherwise overwrite Legerix's
+         multilingual set during unpack). -->
+    <dependencySet>
+      <outputDirectory>/</outputDirectory>
+      <useProjectArtifact>false</useProjectArtifact>
+      <unpack>true</unpack>
+      <includes>
+        <include>io.github.oculix-org:legerix</include>
+      </includes>
       <scope>runtime</scope>
     </dependencySet>
   </dependencySets>

--- a/IDE/makeide-win.xml
+++ b/IDE/makeide-win.xml
@@ -18,10 +18,6 @@
       <unpackOptions>
         <excludes>
           <exclude>**/win32-x86/**</exclude>
-          <!-- Do NOT exclude **/tessdata/** — Legerix bundles its
-               .traineddata files (eng/fra/spa/chi_sim/hin) in /tessdata/ at
-               the jar root and reads them during loadNatives(). Stripping
-               that folder breaks the native loader entirely. -->
           <exclude>/nu/pattern/opencv/linux/**</exclude>
           <exclude>/nu/pattern/opencv/osx/**</exclude>
           <exclude>/nu/pattern/opencv/windows/x86_32/**</exclude>
@@ -30,7 +26,21 @@
       <excludes>
         <exclude>org.jruby:jruby-complete</exclude>
         <exclude>org.apache.pdfbox:*</exclude>
+        <exclude>io.github.oculix-org:legerix</exclude>
       </excludes>
+      <scope>runtime</scope>
+    </dependencySet>
+    <!-- Legerix unpacked LAST so its /tessdata/{eng,fra,spa,chi_sim,hin}.traineddata
+         and /win32-x86-64/* natives win over Tess4J's bundled tessdata
+         (which only ships eng + osd and would otherwise overwrite Legerix's
+         multilingual set during unpack). -->
+    <dependencySet>
+      <outputDirectory>/</outputDirectory>
+      <useProjectArtifact>false</useProjectArtifact>
+      <unpack>true</unpack>
+      <includes>
+        <include>io.github.oculix-org:legerix</include>
+      </includes>
       <scope>runtime</scope>
     </dependencySet>
   </dependencySets>

--- a/IDE/makeide.xml
+++ b/IDE/makeide.xml
@@ -17,19 +17,29 @@
       <excludes>
         <exclude>org.jruby:jruby-complete</exclude>
         <exclude>org.apache.pdfbox:*</exclude>
+        <exclude>io.github.oculix-org:legerix</exclude>
       </excludes>
       <unpack>true</unpack>
       <unpackOptions>
         <excludes>
           <exclude>**/win32-x86/**</exclude>
-          <!-- Do NOT exclude **/tessdata/** — Legerix bundles its
-               .traineddata files (eng/fra/spa/chi_sim/hin) in /tessdata/ at
-               the jar root and reads them during loadNatives(). Stripping
-               that folder breaks the native loader entirely. -->
           <exclude>/nu/pattern/opencv/linux/x86_32/**</exclude>
           <exclude>/nu/pattern/opencv/windows/x86_32/**</exclude>
         </excludes>
       </unpackOptions>
+      <scope>runtime</scope>
+    </dependencySet>
+    <!-- Legerix unpacked LAST so its /tessdata/{eng,fra,spa,chi_sim,hin}.traineddata
+         and per-platform natives win over Tess4J's bundled tessdata
+         (which only ships eng + osd and would otherwise overwrite Legerix's
+         multilingual set during unpack). -->
+    <dependencySet>
+      <outputDirectory>/</outputDirectory>
+      <useProjectArtifact>false</useProjectArtifact>
+      <unpack>true</unpack>
+      <includes>
+        <include>io.github.oculix-org:legerix</include>
+      </includes>
       <scope>runtime</scope>
     </dependencySet>
   </dependencySets>

--- a/IDE/pom.xml
+++ b/IDE/pom.xml
@@ -10,7 +10,7 @@
 
   <groupId>io.github.oculix-org</groupId>
   <artifactId>oculixide</artifactId>
-  <version>3.0.3-rc3</version>
+  <version>3.0.3-rc4</version>
 
   <name>OculiX IDE</name>
   <description>Visual automation IDE - edit and run OculiX scripts</description>

--- a/MCP/pom.xml
+++ b/MCP/pom.xml
@@ -10,7 +10,7 @@
 
   <groupId>io.github.oculix-org</groupId>
   <artifactId>oculixmcp</artifactId>
-  <version>3.0.3-rc3</version>
+  <version>3.0.3-rc4</version>
 
   <packaging>jar</packaging>
 
@@ -51,7 +51,7 @@
     <dependency>
       <groupId>io.github.oculix-org</groupId>
       <artifactId>oculixapi</artifactId>
-      <version>3.0.3-rc3</version>
+      <version>3.0.3-rc4</version>
     </dependency>
 
     <!-- JSON (already used by API, keep consistent) -->

--- a/Reporter/pom.xml
+++ b/Reporter/pom.xml
@@ -10,7 +10,7 @@
 
   <groupId>io.github.oculix-org</groupId>
   <artifactId>oculixreporter</artifactId>
-  <version>3.0.3-rc3</version>
+  <version>3.0.3-rc4</version>
 
   <packaging>jar</packaging>
 

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.github.oculix-org</groupId>
   <artifactId>oculix</artifactId>
-  <version>3.0.3-rc3</version>
+  <version>3.0.3-rc4</version>
   <name>OculiX</name>
   <description>Visual automation - if you can see it, you can automate it</description>
   <url>https://github.com/oculix-org/Oculix</url>


### PR DESCRIPTION
## Summary

Fixes the asymmetric tessdata bundling between API and IDE fat-jars that was breaking OCR for users of the API standalone (reported by Adrian, author of robotframework-sikulixlibrary).

## Root causes

1. `API/makeapi-*.xml` had `<exclude>**/tessdata/**</exclude>` — a leftover from the pre-Legerix era when SikuliX shipped `/tessdataSX`. With Legerix bundling its tessdata as a Maven dep resource, this exclude actively stripped Legerix's payload from the API fat-jar, leaving `Legerix.getTessdataPath()` empty and forcing the runtime fallback to the dégradé `/tessdataSX` legacy path.

2. Even after removing the exclude, Tess4J (also a dep) ships its own `/tessdata/` (eng + osd + configs). Maven Assembly was unpacking Tess4J **after** Legerix, overwriting Legerix's 4 extra languages (fra, spa, chi_sim, hin).

## Fixes

- Remove `<exclude>**/tessdata/**</exclude>` from `API/makeapi-{win,mac,lux}.xml`, replace with explanatory comment
- Strip the now-redundant "Do NOT exclude" comments from `IDE/makeide-*.xml` — the warning lives on the API side where it matters
- Add a dedicated final `dependencySet` in all 6 assembly descriptors that unpacks **only** Legerix, after the main set, so its tessdata and per-platform natives win over Tess4J
- Move the Legerix dependency declaration to the very bottom of `API/pom.xml` as belt-and-suspenders for Maven dep resolution order
- Bump version `3.0.3-rc3` → `3.0.3-rc4`

## Verification

`mvn -DskipTests -pl API -am -Pcomplete-lux-jar clean package` produces `oculixapi-3.0.3-rc4-complete-lux.jar` containing all 6 traineddata at jar root:

```
tessdata/eng.traineddata          (4.1 MB — Legerix)
tessdata/fra.traineddata          (1.1 MB — Legerix)
tessdata/spa.traineddata          (2.3 MB — Legerix)
tessdata/chi_sim.traineddata      (2.5 MB — Legerix)
tessdata/hin.traineddata          (1.1 MB — Legerix)
tessdata/osd.traineddata         (10.6 MB — Tess4J)
```

`mvn -DskipTests compile` BUILD SUCCESS on API/IDE/MCP/Reporter.

## Test plan

- [ ] Adrian retests `robotframework-sikulixlibrary` against rc4 API standalone jar — confirm OCR resolves via Legerix tessdata path, no `/tessdataSX` fallback in logs
- [ ] Smoke run `mvn -pl IDE -am -Pcomplete-win-jar package` produces a working IDE fat-jar (already covered by existing `release-rc.yml` workflow)
- [ ] Verify `oculixapi-3.0.3-rc4-complete-{win,mac,lux}.jar` artifacts on the auto-published GitHub pre-release contain `tessdata/{fra,spa,chi_sim,hin}.traineddata`

