### PR TITLE
Fix macOS accessibility preflight for keyboard-only scripts

### DIFF
--- a/API/src/main/java/org/sikuli/script/Screen.java
+++ b/API/src/main/java/org/sikuli/script/Screen.java
@@ -75,6 +75,7 @@ public class Screen extends Region implements IScreen, EventObserver {
       throw new SikuliXception(String.format("SikuliX: Init: running in headless environment"));
     }
     getGlobalRobot();
+    MouseDevice.start();
     log(logLevel, "initScreens: ending");
   }
 


### PR DESCRIPTION
This fixes a hang scenario on macOS when Accessibility permission is missing and a script uses keyboard actions (for example type()) before any mouse action. Previously, the accessibility usability check was only triggered via Mouse initialization, so keyboard-only flows could bypass preflight and continue until they blocked later (often around waitForIdle during typing). This change runs MouseDevice.start() during Screen.initScreens(), ensuring permission checks run early for both mouse and keyboard-driven scripts and fail fast when access is blocked.