### PR TITLE
fix(release): bump remaining poms (build-extensions + Reporter) to 3.0.3-rc5

### DIFF
--- a/Reporter/pom.xml
+++ b/Reporter/pom.xml
@@ -10,7 +10,7 @@
 
   <groupId>io.github.oculix-org</groupId>
   <artifactId>oculixreporter</artifactId>
-  <version>3.0.3-rc4</version>
+  <version>3.0.3-rc5</version>
 
   <packaging>jar</packaging>
 

--- a/build-extensions/pom.xml
+++ b/build-extensions/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>io.github.oculix-org</groupId>
     <artifactId>oculix</artifactId>
-    <version>3.0.3-rc4</version>
+    <version>3.0.3-rc5</version>
   </parent>
 
   <artifactId>oculix-build-extensions</artifactId>


### PR DESCRIPTION
## Hotfix for #239 build failure

Two POMs were missed in the rc4 → rc5 bump pass:

- `build-extensions/pom.xml` — parent ref to `oculix:3.0.3-rc4`
- `Reporter/pom.xml` — standalone

The Maven reactor failed at the `mvn help:evaluate` step in `release-rc.yml` with:

```
Could not find artifact io.github.oculix-org:oculix:pom:3.0.3-rc4 in central
```

This PR brings both POMs to `3.0.3-rc5` and unblocks the build/release pipeline. Merging this triggers a fresh `release-rc.yml` run that should succeed end-to-end and publish `v3.0.3-rc5` with the CHANGELOG.md notes.

Single commit: `73bc3b04`

---
_Generated by [Claude Code](https://claude.ai/code/session_01QNEhJ4JtkMeNLd8S1Sf3B5)_