### PR TITLE
release: bump to v3.0.3 stable + CHANGELOG entry + stable release not…

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -119,16 +119,49 @@ jobs:
         echo "=== Release assets ==="
         ls -lh
 
+    - name: Extract release notes from CHANGELOG.md
+      id: notes
+      run: |
+        VERSION="${{ steps.version.outputs.VERSION }}"
+        NOTES_FILE="release-notes-${VERSION}.md"
+        FALLBACK="OculiX ${VERSION}"
+
+        if [ -f CHANGELOG.md ]; then
+          awk -v ver="$VERSION" -v vver="v$VERSION" '
+            /^## / {
+              if (found) exit
+              if (index($0, "[" vver "]") > 0 || index($0, "[" ver "]") > 0) {
+                found = 1
+                next
+              }
+            }
+            found { print }
+          ' CHANGELOG.md > "$NOTES_FILE"
+        fi
+
+        if [ ! -s "$NOTES_FILE" ]; then
+          echo "::warning::No section for $VERSION found in CHANGELOG.md, using fallback notes"
+          echo "$FALLBACK" > "$NOTES_FILE"
+        fi
+
+        echo "NOTES_FILE=$NOTES_FILE" >> "$GITHUB_OUTPUT"
+        echo "=== Release notes preview (first 40 lines) ==="
+        head -40 "$NOTES_FILE"
+
     - name: Create release if it does not exist
       env:
         GH_TOKEN: ${{ github.token }}
       run: |
-        TAG="v${{ steps.version.outputs.VERSION }}"
+        VERSION="${{ steps.version.outputs.VERSION }}"
+        TAG="v${VERSION}"
+        NOTES_FILE="${{ steps.notes.outputs.NOTES_FILE }}"
         if ! gh release view "$TAG" > /dev/null 2>&1; then
           gh release create "$TAG" \
-            --title "OculiX ${{ steps.version.outputs.VERSION }}" \
-            --notes "OculiX ${{ steps.version.outputs.VERSION }}" \
+            --title "OculiX ${VERSION}" \
+            --notes-file "$NOTES_FILE" \
             --target master
+        else
+          gh release edit "$TAG" --notes-file "$NOTES_FILE"
         fi
 
     - name: Upload assets to release

--- a/API/pom.xml
+++ b/API/pom.xml
@@ -10,7 +10,7 @@
 
   <groupId>io.github.oculix-org</groupId>
   <artifactId>oculixapi</artifactId>
-  <version>3.0.3-rc5</version>
+  <version>3.0.3</version>
 
   <packaging>jar</packaging>
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,79 @@ Format inspired by [Keep a Changelog](https://keepachangelog.com/).
 Versions follow [SemVer](https://semver.org/) with `-rcN` / `-betaN` / `-alphaN` suffixes for pre-releases.
 
 > Each `## [vX.Y.Z]` section is consumed verbatim by `.github/workflows/release-rc.yml`
-> and published as the GitHub Release body for the matching tag. Keep entries
-> reader-friendly — they ship as the public release notes.
+> (RC tags) and `.github/workflows/release.yml` (stable tags) and published as the
+> GitHub Release body for the matching tag. Keep entries reader-friendly — they
+> ship as the public release notes.
+
+---
+
+## [v3.0.3] - 2026-05-09
+
+![status](https://img.shields.io/badge/release-stable-brightgreen)
+![maven](https://img.shields.io/badge/maven_central-published-blue)
+![track](https://img.shields.io/badge/upgrade-drop--in_from_3.0.x-orange)
+
+> **Major evolution release** — visual rebrand, full multilingual typing,
+> slimmer fat-jars, MCP server matures. Drop-in upgrade from 3.0.x.
+
+### What's new for users
+
+- 🌏 **Universal typing** — write `region.type("你好")`, `region.type("こんにちは")`, `region.type("привет")` and it just works. ASCII path unchanged, non-ASCII routed automatically through clipboard. Asian-language and accented-Latin automation now first-class.
+
+- 🎨 **Polished IDE** — full visual rebrand with dark/light theme system, Welcome tab, sidebar redesign, theme-aware console + workspace explorer. The IDE now looks and feels like a 2026 tool.
+
+- 📦 **Lighter footprint** — fat-jars trimmed by **~50 MB on Linux** and **~114 MB on Windows**. Faster downloads, faster CI, lower bandwidth bill. Same API, same behavior.
+
+- 🚀 **CLI auto-run** — launch the IDE with a script preloaded and auto-executed: `java -jar oculixide.jar -l my-script.sikuli -e`. Cross-platform (Linux + WSL + Windows).
+
+- 🤖 **MCP server matured** — auditable visual-control server with Ed25519-signed action journal, ready for regulated environments (finance, health, defense). Plug any MCP-compatible AI agent on top of OculiX as its visual layer.
+
+- 🦎 **Build banner** — every `mvn` / `mvnd` invocation greets you with the OculiX gecko. Personality at the build level. Easter egg, but also a discreet brand marker.
+
+### Maven coordinates
+
+```xml
+<dependency>
+    <groupId>io.github.oculix-org</groupId>
+    <artifactId>oculixapi</artifactId>
+    <version>3.0.3</version>
+</dependency>
+```
+
+API, IDE, and MCP modules all available on Maven Central.
+
+### Upgrading from 3.0.x
+
+Drop-in. No breaking API changes. Bump the version in your pom and rebuild.
+
+### Known issues / not in this release
+
+We ship `3.0.3` knowing some things are still pending — preferring honesty over polish:
+
+- **Android device picker** (#229) — when multiple emulators / devices are connected via ADB, the selection prompt is missing. Workaround: stop other devices, or manually export `ANDROID_SERIAL`. Targeted for `3.0.4`.
+
+- **GNOME 3+ system tray icons** — IDE tray indicator (#223) not yet implemented. Linux KDE/XFCE/MATE/Cinnamon would already work; planned for `OculiX 4.0`. The Shift+Alt+C kill switch and the IDE message panel remain the canonical "is my script alive?" surfaces in the meantime.
+
+- **CLI args parser** (#226) — internal duplication between `Commons.hasArg` and the Apache Commons CLI `Options` API. No user-facing impact, but the cleanup is on the V4 tech-debt list.
+
+- **Visual Intelligence** (#160, #170-#179) — the natural-language `AItype("the red button below the menu")` API and the embedded ML pipeline are roadmap, not 3.0.x. They live on the [`OculiX 4.0`](https://github.com/oculix-org/Oculix/milestone/5) and [`OculiX 5.0 — Game Changers`](https://github.com/oculix-org/Oculix/milestone/6) milestones.
+
+Full open backlog: [oculix-org/Oculix/issues](https://github.com/oculix-org/Oculix/issues). Bug reports and field feedback drive the next cycle — open an issue, a fork, or a PR.
+
+### Contributors
+
+This release was made possible by:
+
+- [@julienmerconsulting](https://github.com/julienmerconsulting) — release lead
+- [@RaiMan](https://github.com/RaiMan) — `ScreenUnion` removal, Java 8 cleanup
+- [@kelvinkirima014](https://github.com/kelvinkirima014) — foundational EDT fix
+- [@adriancostin6](https://github.com/adriancostin6), [@blackball](https://github.com/blackball), [@micves](https://github.com/micves), [@roboraptor](https://github.com/roboraptor) — bug reports and field validation
+- [Claude](https://claude.com) (Anthropic) — pair-programming partner
+- And the testers who pulled every RC and stuck around 🦎
+
+### Detailed changelog
+
+Full per-RC technical breakdown is preserved in the [v3.0.3-rc5](#v303-rc5---2026-05-09) section below. This stable release aggregates rc1 through rc5.
 
 ---
 

--- a/IDE/pom.xml
+++ b/IDE/pom.xml
@@ -10,7 +10,7 @@
 
   <groupId>io.github.oculix-org</groupId>
   <artifactId>oculixide</artifactId>
-  <version>3.0.3-rc5</version>
+  <version>3.0.3</version>
 
   <name>OculiX IDE</name>
   <description>Visual automation IDE - edit and run OculiX scripts</description>

--- a/MCP/pom.xml
+++ b/MCP/pom.xml
@@ -10,7 +10,7 @@
 
   <groupId>io.github.oculix-org</groupId>
   <artifactId>oculixmcp</artifactId>
-  <version>3.0.3-rc5</version>
+  <version>3.0.3</version>
 
   <packaging>jar</packaging>
 
@@ -51,7 +51,7 @@
     <dependency>
       <groupId>io.github.oculix-org</groupId>
       <artifactId>oculixapi</artifactId>
-      <version>3.0.3-rc5</version>
+      <version>3.0.3</version>
     </dependency>
 
     <!-- JSON (already used by API, keep consistent) -->

--- a/Reporter/pom.xml
+++ b/Reporter/pom.xml
@@ -10,7 +10,7 @@
 
   <groupId>io.github.oculix-org</groupId>
   <artifactId>oculixreporter</artifactId>
-  <version>3.0.3-rc5</version>
+  <version>3.0.3</version>
 
   <packaging>jar</packaging>
 

--- a/build-extensions/pom.xml
+++ b/build-extensions/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>io.github.oculix-org</groupId>
     <artifactId>oculix</artifactId>
-    <version>3.0.3-rc5</version>
+    <version>3.0.3</version>
   </parent>
 
   <artifactId>oculix-build-extensions</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.github.oculix-org</groupId>
   <artifactId>oculix</artifactId>
-  <version>3.0.3-rc5</version>
+  <version>3.0.3</version>
   <name>OculiX</name>
   <description>Visual automation - if you can see it, you can automate it</description>
   <url>https://github.com/oculix-org/Oculix</url>


### PR DESCRIPTION
Bump from rc5 → 3.0.3 stable + CHANGELOG.md stable section + release.yml
patched to read from CHANGELOG.md (consistent with release-rc.yml).