### PR TITLE
polish(macos): gate accessibility preflight to runningMac() only — builds on @nishantsir57's #234

### DIFF
--- a/API/src/main/java/org/sikuli/script/Screen.java
+++ b/API/src/main/java/org/sikuli/script/Screen.java
@@ -75,7 +75,15 @@ public class Screen extends Region implements IScreen, EventObserver {
       throw new SikuliXception(String.format("SikuliX: Init: running in headless environment"));
     }
     getGlobalRobot();
-    MouseDevice.start();
+    // macOS Accessibility preflight (originally introduced by @nishantsir57 in PR #234,
+    // cherry-picked as 397e9f7c into the integration branch). MouseDevice.start()
+    // performs a mouse-move dance that detects when Accessibility permission is
+    // denied — and on macOS, terminates the script early instead of letting it
+    // hang silently in keyboard-only flows. Gating to runningMac() avoids the
+    // cosmetic mouse-jump on Linux/Windows where the check is a no-op terminate-wise.
+    if (Commons.runningMac()) {
+      MouseDevice.start();
+    }
     log(logLevel, "initScreens: ending");
   }
 


### PR DESCRIPTION
[![Status](https://img.shields.io/badge/type-polish-3b82f6?style=flat-square)](.)
[![Builds on](https://img.shields.io/badge/builds_on-PR_%23234-10B981?style=flat-square)](https://github.com/oculix-org/Oculix/pull/234)
[![Author preserved](https://img.shields.io/badge/original_fix_author-%40nishantsir57-DC2626?style=flat-square&logo=github&logoColor=white)](https://github.com/nishantsir57)

## 🎯 What this is

**A 1-line polish on top of @nishantsir57's macOS Accessibility preflight fix** (originally PR #234, cherry-picked as commit `397e9f7c` onto `claude/i18n-phase3`).

@nishantsir57's fix correctly closes the silent-hang scenario on macOS when Accessibility permission is denied for keyboard-only scripts (e.g. `App.open()` + `type()` chain without any mouse action). The fix adds `MouseDevice.start()` to `Screen.initScreens()` so the existing macOS-gated `RunTime.terminate()` (in `MouseDevice.start()` itself) runs early on every script.

This polish refines the activation scope to **macOS only at the caller site**:

```diff
  getGlobalRobot();
- MouseDevice.start();
+ if (Commons.runningMac()) {
+     MouseDevice.start();
+ }
  log(logLevel, "initScreens: ending");
```

## 🤔 Why

`MouseDevice.start()` performs a "mouse-move dance" (move cursor to each screen center, move back) before checking usability. The actual `RunTime.terminate()` inside is **already gated to macOS** (`if (Commons.runningMac())` line ~63). So on Linux/Windows, the dance runs but provides zero value terminate-wise — only a cosmetic ~100ms cursor-jump at every script startup that some users might find surprising.

This change:
- ✅ Preserves the Mac fix exactly as @nishantsir57 designed it
- ✅ Eliminates the cosmetic mouse-jump on Linux/Windows
- ✅ Keeps the call site colocated with `getGlobalRobot()` so the order of init is clear
- ✅ Adds a comment block in `Screen.initScreens()` explaining the rationale + crediting @nishantsir57

## 🔬 Testing

- Compile passes (`mvn -pl API compile -am` → BUILD SUCCESS)
- macOS Accessibility-denied keyboard-only repro still terminates early (no behavior change for Mac)
- Linux/Windows: cursor stays put at script start (one less unexpected motion at startup)

## 👋 @nishantsir57

This builds directly on your fix. Authorship of the underlying logic is preserved on commit `397e9f7c` (your name + email on the cherry-pick), and you'll be credited in the **v3.0.4 release notes Contributors section** when the integration branch lands in master.

If you have other ideas for the macOS preflight area (or any OculiX surface), the cleanest base for your next contributions is now **`claude/i18n-phase3`** rather than `master` — the integration branch is ahead by ~60 commits (Phase 3 i18n + this fix + a Phase 1 follow-up wave). Branching from there avoids you re-doing conflict resolution at PR review time.

```bash
git fetch origin
git checkout -b your-next-feature origin/claude/i18n-phase3
# work...
git push origin your-next-feature
# open PR with base = claude/i18n-phase3
```

Thanks again for the original fix — keyboard-only macOS scripts had been hanging silently on denied Accessibility for years, and you ended that. 🦎

---
_Generated by [Claude Code](https://claude.ai/code/session_01QNEhJ4JtkMeNLd8S1Sf3B5)_