### PR TITLE
Fix OpenCV loader for parallel Oculix execution

### DIFF
--- a/API/src/main/java/org/sikuli/support/Commons.java
+++ b/API/src/main/java/org/sikuli/support/Commons.java
@@ -28,6 +28,8 @@ import java.lang.reflect.Method;
 import java.net.*;
 import java.nio.ByteBuffer;
 import java.nio.IntBuffer;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.security.CodeSource;
 import java.util.*;
 import java.util.List;
@@ -143,6 +145,8 @@ public class Commons {
         runShutdownHook();
       }
     });
+
+    cleanStaleTempDirs();
 
     // Load OpenCV native library eagerly when Commons is initialized.
     // Any class (Pattern, ScreenImage, PatternValidator, Finder, ...) that calls
@@ -1457,6 +1461,28 @@ public static void loadOpenCV() {
     return extracted > 0 ? target : null;
   }
 
+  private static void cleanStaleTempDirs() {
+    File tmpDir = getTempFolder();
+    if (tmpDir == null) {
+        tmpDir = new File(System.getProperty("java.io.tmpdir"));
+    }
+    File[] staleDirs = tmpDir.listFiles(file ->
+        file.isDirectory() && file.getName().startsWith("oculix-opencv-"));
+    if (staleDirs == null) return;
+    long dayElapsedMillis = 24L * 60 * 60 * 1000;
+    long cutoff = System.currentTimeMillis() - dayElapsedMillis;
+    for (File dir : staleDirs) {
+      if (dir.lastModified() < cutoff) {
+        try {
+          Debug.log("Removing stale OpenCV temp directory: %s", dir.toString());
+          FileUtils.deleteDirectory(dir);
+        } catch (IOException e) {
+          Debug.error("cleanStaleTempDirs: failed to delete %s: %s", dir, e.getMessage());
+        }
+      }
+    }
+  }
+
   /**
    * Extract a classpath resource to the temp folder and System.load() it.
    * Returns true on success. Caller is responsible for setting libOpenCVloaded
@@ -1473,11 +1499,12 @@ public static void loadOpenCV() {
         System.err.println("[OculiX] jar resource not found on classpath: " + resourcePath);
         return false;
       }
-      File tempDir = getTempFolder();
-      if (tempDir == null) {
-        tempDir = new File(System.getProperty("java.io.tmpdir"));
-      }
-      File tempLib = new File(tempDir, fileName);
+      String pid = String.valueOf(ProcessHandle.current().pid());
+      Path tempDir = Files.createTempDirectory("oculix-opencv-" + pid + "-");
+      File tempLib = tempDir.resolve("libopencv_java4100.so").toFile();
+      tempDir.toFile().deleteOnExit();  // 2nd: delete folder
+      tempLib.deleteOnExit();           // 1st: delete file
+      Debug.log("Creating OpenCV temp lib: %s", tempLib.toString());
       try (java.io.FileOutputStream fos = new java.io.FileOutputStream(tempLib)) {
         byte[] buf = new byte[8192];
         int len;


### PR DESCRIPTION
When opening multiple instances of Oculix in parallel, the shared /tmp/libopencv shared object was being corrupted by subsequent instances, since it was overwritten each time.

This fix creates a unique extraction directory each time so that newly extracted OpenCV shared object coming from other Oculix instances don't overwrite/corrupt the old ones, as proposed in #348.

The directories are registered for cleanup on JVM exit, and to cover the case of a JVM crash, upon initial startup we remove all stale directories that are older than 24h.

<!--
  Thanks for opening a PR! 🦎
  This template mirrors the checklist documented in CONTRIBUTING.md.
  Delete this comment block before submitting (or don't — we don't mind).
  Sections marked (optional) can be skipped if not applicable.
-->

## Linked issue

Closes #348 

## Root cause

/tmp/libopencv is overwritten by subsequent instances of Oculix, when we run multiple in parallel. This triggers a JVM error in prior processes.

## What changed

Commons.java extractAndLoad() now creates a unique tempdir based on PID, to avoid previously caused clashes.
Also covers stale directories by adding a new function cleanStaleTempDirs() called on startup, prior to loadOpenCv, to ensure that in case of a JVM crash, dirs older than 24 hours get purged.

## How you tested it


As requested on original issue #348 


### Linux

Validation was done on Ubuntu 22 and 24 containers.

- [x] Single-instance smoke test — verify nothing regressed on the normal path (existing tests pass)
- [x] Multi-instance stress test — spawn 10 parallel java -jar processes, all doing image matching for 5 minutes, no crash
- [x] Shutdown cleanup — verify /tmp/oculix-opencv-<pid>-* dirs are removed on graceful JVM exit
- [x] Crash cleanup — verify stale dirs older than 24 h get purged on next startup 
    - [x] reduced stale cleanup time and ran a test that produces stale files, and then another one to verify the instance cleans the stale files before running.
- [x] Linux glibc 2.39 (your repro env, Ubuntu 24.04) and glibc < 2.38 (older tier of Apertix dual-build)
    -  [x] switched dockerfile to Ubuntu 22 and ran the same tests

During manual validation with the container at least, I can say that the tests pass on Linux. All green ✅

#### Test files + Dockerfile

- [clash.sh](https://github.com/user-attachments/files/27855985/clash.sh)
- [env.sh](https://github.com/user-attachments/files/27855987/env.sh)
- [FiveMinStressTest.java](https://github.com/user-attachments/files/27855988/FiveMinStressTest.java)
- <img width="155" height="31" alt="image" src="https://github.com/user-attachments/assets/bb1caef2-7162-4700-b65f-d049dc744a9b" />
- [multi-instance-stress.sh](https://github.com/user-attachments/files/27855990/multi-instance-stress.sh)
- [single-instance-smoke.sh](https://github.com/user-attachments/files/27855991/single-instance-smoke.sh)
- [Test.java](https://github.com/user-attachments/files/27855992/Test.java)
- [test-crash-stale.sh](https://github.com/user-attachments/files/27855993/test-crash-stale.sh)
- [TestCrashStaleTest.java](https://github.com/user-attachments/files/27855994/TestCrashStaleTest.java)

Files attached above are used to build a docker container where I ran the tests: 

``` Docker
FROM ubuntu:22.04

RUN apt-get update \
    && DEBIAN_FRONTEND=noninteractive apt-get install -y \
    openjdk-21-jdk \
    wget

RUN mkdir -p /opencv-clash
WORKDIR /opencv-clash

COPY Test.java .
COPY FiveMinStressTest.java .
COPY TestCrashStaleTest.java .
COPY oculixapi-3.0.3-complete-lux.jar . 

RUN javac -cp ".:oculixapi-3.0.3-complete-lux.jar" Test.java
RUN javac -cp ".:oculixapi-3.0.3-complete-lux.jar" FiveMinStressTest.java
RUN javac -cp ".:oculixapi-3.0.3-complete-lux.jar" TestCrashStaleTest.java

COPY env.sh .
COPY image.png .

COPY clash.sh .
RUN chmod +x clash.sh

COPY test-crash-stale.sh .
RUN chmod +x test-crash-stale.sh

COPY single-instance-smoke.sh .
RUN chmod +x single-instance-smoke.sh

COPY multi-instance-stress.sh .
RUN chmod +x multi-instance-stress.sh

ENTRYPOINT ["/bin/bash"]

```

Test steps: 
1. Copy all files + Dockerfile to a directory
2. Build oculix API and place it in the same directory
3. Docker build 
4. Docker run
5. Execute test script to verify each case
    - clash.sh: original test
    - test-crash-stale: crashes the JVM to avoid file cleanu. any other test can be run after the stale timeout to verify if the stale files are cleaned up
    - single-instance-smoke: verify that the single instance case still works
    - multi-instance-stress: runs 10 processes, as requested, that do image matching for 5 mins each
6. Verify that the tests run, and that no leftover files are produced in /tmp
7. Verify that stale files are cleaned from /tmp
  
### Others

- [ ] macOS (no /tmp/ issue but ensure path logic still works)
    - Can't test on Mac unfortunately ❌
- [x] Windows (different temp path mechanics, verify Java's Files.createTempDirectory behaves correctly on NTFS)
    - IDE opens fine, basic script with text/image matching also works. OpenCV loaded correctly ✅

After building, I spawned multiple instances to run each script. Manual validation using container on Linux shows ✅

## Regressions considered

Cannot see any other clear regressions. Test results/logs on Linux are huge. Could also integrate some test for this into the CI if needed, but relied on manual testing for now

---

### Checklist

- [x] PR scope is **one concern**. No drive-by reformatting / renames / unrelated cleanups.
    - Changes hit Commons.java only, mainly OpenCV loading ✅
- [x] Commit messages are short, imperative, no `feat:`/`fix:`/`chore:` prefixes (we reference tickets in the PR body, not the subject).
- [x] I built locally (`mvn clean install -DskipTests`) and ran the tests for the modules I touched.
    - build works, manual smoke tests make me confident that the fix works ✅
- [x] If I touched the IDE, I launched it and exercised the feature manually — a compile-green PR that crashes on open wastes everyone's time.
    - IDE works ✅
- [x] If this is AI-assisted, I read and understood every line I'm submitting and can explain why this approach.
- [x] No new runtime dependency added (or, if so, justified in the issue first).
- [x] No CI / build / release workflow change (or, if so, agreed in the issue first).

<!--
  Quality bar reminder (from CONTRIBUTING.md):
  > We'd rather merge one careful PR a month than triage ten half-baked ones.
  Push one careful PR. Then push another.
-->
