### PR TITLE
fix(codeql): array index OOB on pair-formatted arrays

### DIFF
--- a/API/src/main/java/org/sikuli/hotkey/Keys.java
+++ b/API/src/main/java/org/sikuli/hotkey/Keys.java
@@ -481,7 +481,8 @@ public class Keys {
 
   public static Map<String, Integer> getKeyNames() {
     Map<String, Integer> keyNames = new HashMap<>();
-    for (int i = 0; i < keyVK.length; i += 2) {
+    // keyVK is laid out in (name, vkCode) pairs; guard against an odd length
+    for (int i = 0; i + 1 < keyVK.length; i += 2) {
       keyNames.put(keyVK[i].substring(3), Integer.decode(keyVK[i + 1]));
     }
     Map<String, Integer> sortedKeyNames = new TreeMap<>(keyNames);

--- a/API/src/main/java/org/sikuli/script/Key.java
+++ b/API/src/main/java/org/sikuli/script/Key.java
@@ -492,7 +492,8 @@ public class Key {
 
   public static void dump() {
     Map<Integer, String> namesVK = new HashMap<Integer, String>();
-    for (int i = 0; i < keyVK.length; i += 2) {
+    // keyVK is laid out in (name, vkCode) pairs; guard against an odd length
+    for (int i = 0; i + 1 < keyVK.length; i += 2) {
       namesVK.put(Integer.decode(keyVK[i+1]), keyVK[i].substring(3));
     }
     Map<String, Integer> sortedNames = new TreeMap<String, Integer>(keyTexts);
@@ -884,7 +885,8 @@ public class Key {
    */
   public static void createKeyTable() {
     Map<String, String> namesVK = new HashMap<String, String>();
-    for (int i = 0; i < keyVK.length; i += 2) {
+    // keyVK is laid out in (name, vkCode) pairs; guard against an odd length
+    for (int i = 0; i + 1 < keyVK.length; i += 2) {
       namesVK.put(keyVK[i+1], keyVK[i].substring(3));
     }
 

--- a/IDE/src/main/java/org/sikuli/support/ide/autocomplete/AbstractCompleter.java
+++ b/IDE/src/main/java/org/sikuli/support/ide/autocomplete/AbstractCompleter.java
@@ -100,9 +100,10 @@ public abstract class AbstractCompleter implements IAutoCompleter {
   private List<String> getCommandMenu() {
     String[][] CommandsOnToolbar = getMenuCommands();
     List<String> menu = new ArrayList<>();
-    for (int i = 0; i < CommandsOnToolbar.length; i++) {
-      String cmd = CommandsOnToolbar[i++][0];
-      String[] params = CommandsOnToolbar[i];
+    // CommandsOnToolbar is laid out in (command, params) pairs; iterate explicitly by 2
+    for (int i = 0; i + 1 < CommandsOnToolbar.length; i += 2) {
+      String cmd = CommandsOnToolbar[i][0];
+      String[] params = CommandsOnToolbar[i + 1];
       if (cmd.equals("----")) {
         menu.add("_" + params[0]);
       } else {


### PR DESCRIPTION
Resolves the 4 CodeQL **Error**-level Array Index Out of Bounds findings flagged on `master` right after CodeQL activation.

## What

Four loops over pair-formatted arrays could OOB if the backing array had an odd length:

| File | Method |
|---|---|
| `API/.../hotkey/Keys.java:484` | `getKeyNames()` |
| `API/.../script/Key.java:495` | `dump()` |
| `API/.../script/Key.java:887` | `createKeyTable()` |
| `IDE/.../autocomplete/AbstractCompleter.java:103` | `getCommandMenu()` |

## How

- 3 loops fixed via the explicit `i + 1 < length` guard + invariant comment.
- `AbstractCompleter.getCommandMenu()` also had a subtle anti-pattern (`i++` inside the loop body alongside the for loop's `i++`), refactored to a clean `i += 2` with explicit `[i]` and `[i+1]` access — same behavior, much harder to misread.

## Scope

- 3 files modified, 10 lines added, 6 deleted.
- Pure surgical fix, no functional change in the success path (the OOB only manifests if the static arrays are ever shipped with an odd count — they're not today, but the guard makes the contract explicit).
- No tests change because these are static configuration tables.

## Verification

- Build green locally (`mvn -pl API,IDE compile -DskipTests`)
- CodeQL will re-scan on merge; the 4 Error findings should drop to 0.

🦎