### PR TITLE
fix(codeql): add hashCode() to 8 classes that override only equals()

### DIFF
--- a/API/src/main/java/org/sikuli/natives/GenericOsUtil.java
+++ b/API/src/main/java/org/sikuli/natives/GenericOsUtil.java
@@ -52,6 +52,11 @@ public abstract class GenericOsUtil implements OSUtil {
 		public boolean equals(Object other) {
 			return other != null && other instanceof OsProcess && this.getPid() == ((OsProcess) other).getPid();
 		}
+
+		@Override
+		public int hashCode() {
+			return Long.hashCode(getPid());
+		}
 	}
 
 	@Override

--- a/API/src/main/java/org/sikuli/natives/LinuxUtil.java
+++ b/API/src/main/java/org/sikuli/natives/LinuxUtil.java
@@ -110,6 +110,11 @@ public class LinuxUtil extends GenericOsUtil {
 		public boolean equals(Object other) {
 			return other != null && other instanceof LinuxWindow && this.id == (((LinuxWindow) other).id);
 		}
+
+		@Override
+		public int hashCode() {
+			return Long.hashCode(id);
+		}
 	}
 
 	private static boolean xdotoolAvailable = true;

--- a/API/src/main/java/org/sikuli/natives/MacUtil.java
+++ b/API/src/main/java/org/sikuli/natives/MacUtil.java
@@ -111,6 +111,11 @@ public class MacUtil extends GenericOsUtil {
     public boolean equals(Object other) {
       return other != null && other instanceof MacWindow && this.number == (((MacWindow) other).number);
     }
+
+    @Override
+    public int hashCode() {
+      return Long.hashCode(number);
+    }
   }
 
   @Override

--- a/API/src/main/java/org/sikuli/natives/WinUtil.java
+++ b/API/src/main/java/org/sikuli/natives/WinUtil.java
@@ -97,6 +97,11 @@ public class WinUtil extends GenericOsUtil {
 		public boolean equals(Object other) {
 			return other != null && other instanceof WinWindow && this.hWnd.equals(((WinWindow) other).hWnd);
 		}
+
+		@Override
+		public int hashCode() {
+			return hWnd != null ? hWnd.hashCode() : 0;
+		}
 	}
 
 	@Override

--- a/API/src/main/java/org/sikuli/script/ImagePath.java
+++ b/API/src/main/java/org/sikuli/script/ImagePath.java
@@ -220,6 +220,12 @@ public class ImagePath {
     }
 
     @Override
+    public int hashCode() {
+      // Matches equals(): pathURL is the identity; null URL == "no identity" so use 0.
+      return pathURL == null ? 0 : pathURL.toExternalForm().hashCode();
+    }
+
+    @Override
     public String toString() {
       return getPath();
     }

--- a/API/src/main/java/org/sikuli/script/Location.java
+++ b/API/src/main/java/org/sikuli/script/Location.java
@@ -13,6 +13,7 @@ import java.awt.Color;
 import java.awt.Point;
 import java.awt.Rectangle;
 import java.util.ArrayList;
+import java.util.Objects;
 
 /**
  * A point like AWT.Point using global coordinates (x, y).
@@ -570,6 +571,11 @@ public class Location implements Comparable<Location>{
     }
     Location that = (Location) oThat;
     return x == that.x && y == that.y;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(x, y);
   }
 
   /**

--- a/API/src/main/java/org/sikuli/script/Match.java
+++ b/API/src/main/java/org/sikuli/script/Match.java
@@ -6,8 +6,7 @@ package org.sikuli.script;
 import org.sikuli.support.devices.IScreen;
 
 import java.awt.*;
-
-import java.awt.*;
+import java.util.Objects;
 
 /**
  * The region on the screen or rectangle in the image,
@@ -281,6 +280,13 @@ public class Match extends Region implements Comparable<Match> {
     Match that = (Match) oThat;
     return x == that.x && y == that.y && w == that.w && h == that.h
         && Math.abs(simScore - that.simScore) < 1e-5 && getTarget().equals(that.getTarget());
+  }
+
+  @Override
+  public int hashCode() {
+    // Matches equals(): same fields, simScore rounded to integer scale to keep
+    // the 1e-5 tolerance consistent (two equal matches must produce the same hash).
+    return Objects.hash(x, y, w, h, Math.round(simScore * 100000.0), getTarget());
   }
 
   @Override

--- a/API/src/main/java/org/sikuli/script/ScreenImage.java
+++ b/API/src/main/java/org/sikuli/script/ScreenImage.java
@@ -16,6 +16,7 @@ import java.awt.*;
 import java.awt.image.*;
 import java.io.*;
 import java.util.Date;
+import java.util.Objects;
 import javax.imageio.ImageIO;
 
 /**
@@ -258,6 +259,15 @@ public class ScreenImage {
     Imgproc.cvtColor(Commons.makeMat(((ScreenImage) other).getImage()), otherGray, Imgproc.COLOR_BGR2GRAY);
     Core.absdiff(thisGray, otherGray, mDiffAbs);
     return Core.countNonZero(mDiffAbs) == 0;
+  }
+
+  @Override
+  public int hashCode() {
+    // equals() compares pixel-by-pixel, which is too expensive to hash fully.
+    // Two equal ScreenImages necessarily share the same dimensions, so hashing
+    // on (w, h) preserves the equals/hashCode contract (more hash collisions
+    // are acceptable; what matters is equal-objects-equal-hash).
+    return Objects.hash(w, h);
   }
 
   public double diffPercentage(ScreenImage scrImg) {


### PR DESCRIPTION
Resolves the **8 CodeQL Error-level "Inconsistent equals and hashCode"** findings flagged on master.

## Why this is real

Each class overrode `equals()` but inherited the default `Object.hashCode()`, violating the Java equals/hashCode contract. Two instances considered equal would compute different hash codes, breaking HashMap / HashSet / Collectors.groupingBy and any other collection relying on hashing. Subtle but real production bug.

## What changed

| File | Class | hashCode strategy |
|---|---|---|
| `script/Match.java` | `Match` | `Objects.hash(x, y, w, h, Math.round(simScore × 1e5), getTarget())` |
| `script/Location.java` | `Location` | `Objects.hash(x, y)` |
| `script/ImagePath.java` | `PathEntry` | `pathURL.toExternalForm().hashCode()` (0 if null) |
| `script/ScreenImage.java` | `ScreenImage` | `Objects.hash(w, h)` — see note below |
| `natives/LinuxUtil.java` | `LinuxWindow` | `Long.hashCode(id)` |
| `natives/WinUtil.java` | `WinWindow` | `hWnd.hashCode()` (0 if null) |
| `natives/MacUtil.java` | `MacWindow` | `Long.hashCode(number)` |
| `natives/GenericOsUtil.java` | `GenericOsProcess` | `Long.hashCode(getPid())` |

## Two non-obvious choices

**Match.simScore rounding**: `simScore` is a `double` with a 1e-5 tolerance window in `equals()`. The hash rounds to that same grain (`Math.round(simScore × 100000)`) so two matches the equals method considers equal share the same hash. Otherwise floating-point variance in the last bits would produce different hashes for equal objects.

**ScreenImage**: `equals()` does pixel-by-pixel OpenCV diff which is too expensive to hash fully. Hash uses `(w, h)` only — that's collision-tolerant (two same-size but different images hash the same), which is fine per the equals/hashCode contract (`a.equals(b) ⇒ a.hashCode() == b.hashCode()`, but the reverse is allowed to collide).

## Scope

- 8 files, +50 / -2 lines.
- No behavioral change to existing equals() methods.
- Java contract restored — these classes are now safe to use as HashMap/HashSet keys.

🦎