### PR TITLE
chore(workflows): add top-level contents:read permissions

### DIFF
--- a/.github/workflows/api-compile.yml
+++ b/.github/workflows/api-compile.yml
@@ -3,6 +3,9 @@ name: Compile API
 on:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   build:
 

--- a/.github/workflows/api-snapshot.yml
+++ b/.github/workflows/api-snapshot.yml
@@ -3,6 +3,9 @@ name: API Snapshot
 on:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/ide-compile.yml
+++ b/.github/workflows/ide-compile.yml
@@ -3,6 +3,9 @@ name: Compile IDE
 on:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   build:
 

--- a/.github/workflows/plublish-maven.yml
+++ b/.github/workflows/plublish-maven.yml
@@ -3,6 +3,9 @@ name: Publish to Maven Central
 on:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   publish:
     needs: []  # à brancher sur build_dist si tu veux chaîner avec le build existant

--- a/.github/workflows/release-rc.yml
+++ b/.github/workflows/release-rc.yml
@@ -15,6 +15,9 @@ on:
     branches:
       - 'release/oculix-rc'
 
+permissions:
+  contents: read
+
 jobs:
   build-windows:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,9 @@ on:
     branches:
       - 'release/oculix'
 
+permissions:
+  contents: read
+
 jobs:
   build-windows:
     runs-on: ubuntu-latest

--- a/.github/workflows/test-macos-launch.yml
+++ b/.github/workflows/test-macos-launch.yml
@@ -3,6 +3,9 @@ name: Test OculiX macOS Launch
 on:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   test-mac:
     runs-on: macos-latest


### PR DESCRIPTION
## Summary

Adds `permissions: contents: read` at the top of every workflow that was missing one, per OpenSSF Scorecard `Token-Permissions` guidance.

Existing job-level overrides (`contents: write` on release jobs in `release.yml` and `release-rc.yml`) remain in place and continue to work — they now override the restrictive top-level baseline only where actually needed.

## Files touched

- `api-compile.yml`
- `api-snapshot.yml`
- `ide-compile.yml`
- `plublish-maven.yml`
- `release-rc.yml`
- `release.yml`
- `test-macos-launch.yml`

`project-status-sync.yml` and `strip-status-on-close.yml` already had top-level permissions defined and are untouched.

## Test plan

- [ ] Verify CI workflows still pass on this PR (`api-compile`, `ide-compile` triggered)
- [ ] Verify release workflows would still work — the `release` job in `release.yml` keeps its `contents: write` job-level override, build jobs only need `contents: read` for checkout

## Scorecard impact

Expected: `Token-Permissions` 0/10 → ~9-10/10.

🤖 Co-authored by Claude