### PR TITLE
fix(security): enforce SikulixServer allowedIPs via Undertow + drop auto-localhost seed (#368)

### DIFF
--- a/API/src/main/java/org/sikuli/util/CommandArgsEnum.java
+++ b/API/src/main/java/org/sikuli/util/CommandArgsEnum.java
@@ -53,7 +53,9 @@ public enum CommandArgsEnum {
 	 */
 	SERVER("server", "s", "ip : port or spec file", "run as server", true),
 	GROUPS("groups", "g", "group name or spec file", "group names to run", true),
-	XTRAS("xtras", "x", "server extra or spec file", "server extra options", true),
+	XTRAS("xtras", "x", "ip,ip,...|file.txt",
+	      "server IP allow-list (strict, no auto-localhost). " +
+	      "Example: -x localhost,192.168.1.10 or -x /path/to/allowed-ips.txt", true),
 	/**
 	 * run the server for Python
 	 */

--- a/IDE/src/main/java/org/sikuli/support/runner/SikulixServer.java
+++ b/IDE/src/main/java/org/sikuli/support/runner/SikulixServer.java
@@ -193,18 +193,23 @@ public class SikulixServer {
   }
 
   private static List<String> allowedIPs = new ArrayList<>();
-  private static final String DEFAULT_ALLOWED_IP = "localhost";
   // Tracks whether the user explicitly opted into IP filtering via the -x
   // option. When false, the server accepts every connection (legacy behavior
-  // — the original 2020 implementation by RaiMan never validated IPs, see
-  // commit 1852f36e: "added: SikulixServer: options -g and -x full
+  // preserved — the original 2020 implementation by RaiMan never validated
+  // IPs, see commit 1852f36e: "added: SikulixServer: options -g and -x full
   // implementation (folders exist, IP's not validated)"). When true, an
-  // Undertow IPAddressAccessControlHandler enforces the allow-list, which
-  // finishes the TODO the original commit left open.
+  // Undertow IPAddressAccessControlHandler enforces the allow-list strictly,
+  // finishing the TODO the original commit left open.
+  //
+  // Note on the absence of an auto-seeded localhost: the original code added
+  // "localhost" to allowedIPs unconditionally, but this contradicted the
+  // explicit-allow-list intent and provided false security on shared hosts
+  // (multi-user servers, container co-tenants, etc.) where any local process
+  // can talk to 127.0.0.1. If the user wants localhost allowed, they include
+  // it explicitly in -x. No silent seed.
   private static boolean ipFilterRequested = false;
 
   private static void makeAllowedIPs(String option) {
-    allowedIPs.add(DEFAULT_ALLOWED_IP);
     File allowedIPsFile;
     if (null != (allowedIPsFile = Commons.asFile(option))) {
       if (FilenameUtils.getExtension(allowedIPsFile.getPath()).isEmpty() ||
@@ -349,8 +354,7 @@ public class SikulixServer {
     // Conditionally wrap the root handler with an Undertow IP access control
     // filter. Activated only when the user explicitly passes -x (opt-in), so
     // existing deployments that never configured -x see no change in
-    // behavior. When activated, the allow-list (which always includes the
-    // default "localhost" plus whatever -x supplied) is enforced and any
+    // behavior. When activated, the allow-list is enforced strictly and any
     // connection from a non-listed source IP gets rejected at the handler
     // level before reaching the routing layer.
     HttpHandler rootHandler = cmdRoot;
@@ -367,6 +371,25 @@ public class SikulixServer {
       }
       rootHandler = acl;
       dolog(3, "IP access control enabled: %d entries in allow-list", allowedIPs.size());
+
+      // Helpful guidance: if the user's allow-list does not contain any local
+      // loopback entry, warn them explicitly. This catches the common case
+      // where someone writes `-x 10.0.0.5` intending to allow a single
+      // remote host but forgets they themselves test from localhost first.
+      boolean localAllowed = false;
+      for (String entry : allowedIPs) {
+        String e = entry.trim().toLowerCase();
+        if (e.equals("localhost") || e.equals("127.0.0.1") || e.startsWith("127.")
+                || e.equals("0.0.0.0") || e.equals("::1")) {
+          localAllowed = true;
+          break;
+        }
+      }
+      if (!localAllowed) {
+        dolog(-1, "Note: your -x allow-list does NOT include localhost / 127.0.0.1 / 0.0.0.0. " +
+                "Connections from this machine will be rejected. " +
+                "If you intended to test locally, add 'localhost' to -x explicitly.");
+      }
     } else {
       dolog(3, "IP access control disabled: -x not provided, accepting all connections");
     }

--- a/IDE/src/main/java/org/sikuli/support/runner/SikulixServer.java
+++ b/IDE/src/main/java/org/sikuli/support/runner/SikulixServer.java
@@ -37,6 +37,7 @@ import io.undertow.server.HttpHandler;
 import io.undertow.server.HttpServerExchange;
 import io.undertow.server.RoutingHandler;
 import io.undertow.server.handlers.ExceptionHandler;
+import io.undertow.server.handlers.IPAddressAccessControlHandler;
 import io.undertow.server.handlers.form.EagerFormParsingHandler;
 import io.undertow.server.handlers.form.FormData;
 import io.undertow.server.handlers.form.FormDataParser;
@@ -193,6 +194,14 @@ public class SikulixServer {
 
   private static List<String> allowedIPs = new ArrayList<>();
   private static final String DEFAULT_ALLOWED_IP = "localhost";
+  // Tracks whether the user explicitly opted into IP filtering via the -x
+  // option. When false, the server accepts every connection (legacy behavior
+  // — the original 2020 implementation by RaiMan never validated IPs, see
+  // commit 1852f36e: "added: SikulixServer: options -g and -x full
+  // implementation (folders exist, IP's not validated)"). When true, an
+  // Undertow IPAddressAccessControlHandler enforces the allow-list, which
+  // finishes the TODO the original commit left open.
+  private static boolean ipFilterRequested = false;
 
   private static void makeAllowedIPs(String option) {
     allowedIPs.add(DEFAULT_ALLOWED_IP);
@@ -206,10 +215,12 @@ public class SikulixServer {
           allowedIPs.add(item);
           dolog(3, "allowed: %s", item);
         }
+        ipFilterRequested = true;
       }
     } else if (null != option) {
       allowedIPs.add(option);
       dolog(3, "allowed: %s", option);
+      ipFilterRequested = true;
     }
   }
 
@@ -335,10 +346,35 @@ public class SikulixServer {
     CommandRootHttpHandler cmdRoot = new CommandRootHttpHandler(commands);
     cmdRoot.addExceptionHandler(Throwable.class, AbstractCommand.getExceptionHttpHandler());
 
+    // Conditionally wrap the root handler with an Undertow IP access control
+    // filter. Activated only when the user explicitly passes -x (opt-in), so
+    // existing deployments that never configured -x see no change in
+    // behavior. When activated, the allow-list (which always includes the
+    // default "localhost" plus whatever -x supplied) is enforced and any
+    // connection from a non-listed source IP gets rejected at the handler
+    // level before reaching the routing layer.
+    HttpHandler rootHandler = cmdRoot;
+    if (ipFilterRequested) {
+      IPAddressAccessControlHandler acl = new IPAddressAccessControlHandler(cmdRoot)
+              .setDefaultAllow(false);
+      for (String entry : allowedIPs) {
+        try {
+          acl.addAllow(entry);
+        } catch (Exception e) {
+          dolog(-1, "ignoring invalid IP / pattern in allowed list: %s (%s)",
+                  entry, e.getMessage());
+        }
+      }
+      rootHandler = acl;
+      dolog(3, "IP access control enabled: %d entries in allow-list", allowedIPs.size());
+    } else {
+      dolog(3, "IP access control disabled: -x not provided, accepting all connections");
+    }
+
     Undertow server = Undertow.builder()
             .addHttpListener(port, ipAddr)
             .setServerOption(UndertowOptions.RECORD_REQUEST_START_TIME, true)
-            .setHandler(cmdRoot)
+            .setHandler(rootHandler)
             .build();
     return server;
   }


### PR DESCRIPTION
## Summary

Closes the silent failure of the `-x` IP allow-list on the SikuliX network server, plus two related UX refinements. Targets `claude/i18n-phase3` (current dev branch) — the legacy `pom.xml` versions are intentionally not updated, will reconcile at master merge time.

Related to #368 (allowedIPs not enforced) under epic #360 (SikulixIDE Server and Runner CLI options).

## What changed

### 1. Enforce `-x` via Undertow `IPAddressAccessControlHandler` (opt-in)

The 2020 implementation of `-x` parsed and stored allowed IPs but never consulted them at the connection level. The list was built, the option documented, and every connection was accepted regardless. RaiMan himself noted *"IP's not validated"* in the original commit message (1852f36e) — that TODO never got finished.

Now: when `-x` is passed at startup, the server wraps its root `HttpHandler` with `IPAddressAccessControlHandler.setDefaultAllow(false)` and adds each entry from the allow-list. Non-matching source IPs get rejected at the handler layer before reaching routing.

When `-x` is **not** passed, the server accepts every connection — legacy behavior preserved, no regression for users who never relied on the option.

### 2. Drop the silent `DEFAULT_ALLOWED_IP = "localhost"` seed

The original code unconditionally added `"localhost"` to `allowedIPs`. This contradicted the explicit-allow-list intent and provided **false security on shared hosts** (multi-user servers, container co-tenants, etc.) where any local process can talk to `127.0.0.1`. If the user wants localhost allowed, they now include it explicitly in `-x`.

### 3. Loopback-missing startup warning

When `-x` is configured but the resolved allow-list contains no loopback entry (`localhost` / `127.x` / `0.0.0.0` / `::1`), the server emits a clear warning at startup:

```
Note: your -x allow-list does NOT include localhost / 127.0.0.1 / 0.0.0.0.
Connections from this machine will be rejected.
If you intended to test locally, add 'localhost' to -x explicitly.
```

Catches the common footgun where someone configures `-x 10.0.0.5` to allow a single remote host but forgets to add localhost for their own tests.

### 4. Enriched `-x` description in `CommandArgsEnum.XTRAS`

The global `-h` output now documents the strict semantics:

```
-x ip,ip,...|file.txt   server IP allow-list (strict, no auto-localhost).
                        Example: -x localhost,192.168.1.10 or -x /path/to/allowed-ips.txt
```

No new CLI option (no `-s -h` subhelp) — the alphabet is already at 16 of 26 letters on the IDE, no point sub-divising help.

## Out of scope

- The mutual-exclusivity validation between modes (`-r` + `-s`, `-s` + `-l`, etc.) — that's its own sub-issue under the epic: #366
- The `pom.xml` version update — handled at master merge, not on phase3

## Test plan

- [ ] Local build OK: `mvn -pl IDE -am install -DskipTests`
- [ ] Manual runtime: launch with `-x 192.0.2.1`, curl `localhost:50001/scripts` → must return 403 (because localhost is not in the strict allow-list now that the default seed is removed). Verifies enforcement + drop-of-default-seed + warning emission in the same shot.
- [ ] CI `ide-compile` workflow stays green
- [ ] Manual launch without `-x` → server starts, accepts connections, log says *"IP access control disabled: -x not provided, accepting all connections"* — confirms legacy behavior preserved

🦎
