### PR TITLE
release: 3.0.4 stable + Legerix 5.5.0-6

### DIFF
--- a/API/pom.xml
+++ b/API/pom.xml
@@ -10,7 +10,7 @@
 
   <groupId>io.github.oculix-org</groupId>
   <artifactId>oculixapi</artifactId>
-  <version>3.0.4-rc1</version>
+  <version>3.0.4</version>
 
   <packaging>jar</packaging>
 
@@ -170,7 +170,7 @@
     <dependency>
       <groupId>io.github.oculix-org</groupId>
       <artifactId>legerix</artifactId>
-      <version>5.5.0-4</version>
+      <version>5.5.0-6</version>
     </dependency>
   </dependencies>
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,42 @@ Versions follow [SemVer](https://semver.org/) with `-rcN` / `-betaN` / `-alphaN`
 
 ---
 
+## [v3.0.4] - 2026-05-20
+
+![status](https://img.shields.io/badge/release-stable-brightgreen)
+![maven](https://img.shields.io/badge/maven_central-pending-lightgrey)
+![track](https://img.shields.io/badge/upgrade-drop--in_from_3.0.x-orange)
+
+> **Security + Linux stability** — promotes `3.0.4-rc1` to stable, kills 10 transitive CVEs, and pulls in Legerix `5.5.0-6` with self-contained codec natives (resolves the Ubuntu 22 `libjpeg.so.62` mismatch, #350).
+
+### What's new for users
+
+- 🛡️ **10 CVEs killed** — `netty-codec*` pinned to `4.1.133`, `bouncycastle:bcprov-jdk18on` to `1.84`, `plexus-utils` to `3.6.1`. Removes all known transitive vulnerabilities flagged by the latest CodeQL / Dependabot run. No API change.
+
+- 🐧 **Linux codec stability (Legerix `5.5.0-6`)** — Legerix now ships self-contained codec runtime libraries (`libjpeg`, `libwebp`, `libtiff` with `libsharpyuv` / `lzma` / `zstd` / `jbig` / `Lerc` transitives) on Linux/macOS via the vcpkg modern bundle. Resolves the long-standing `libjpeg.so.62 not found` error on Ubuntu 22.04 containers (#350). Validated by Adrian Costin on a fresh Ubuntu 22.04 container.
+
+- 🔒 **Promotes `3.0.4-rc1` to stable** — All hardening from `3.0.4-rc1` (CodeQL `hashCode()` fixes, array OOB fix, workflow `contents: read` permissions, OpenSSF Best Practices badge, README modernization) is now stable. No behavior change vs `rc1` — pure version promotion + CVE patches + Legerix bump.
+
+- 🦎 **Reporter and build-extensions deploy skips** — `central-publishing-maven-plugin` now correctly skips the `oculixreporter` and `oculix-build-extensions` modules under the release profile, preventing the deployment failure observed during the `3.0.4-rc1` publish attempt.
+
+### Maven coordinates
+
+```xml
+<dependency>
+    <groupId>io.github.oculix-org</groupId>
+    <artifactId>oculixapi</artifactId>
+    <version>3.0.4</version>
+</dependency>
+```
+
+### Deferred to 3.0.5 / 4.0
+
+- CodeQL triage bugs identified at `rc1` time: #358 (`Runner` self-assignment), #360 (`allowedIPs`), #361 (`RecordedEventsFlow`), #362 (`ButtonGenCommand`)
+- Android `ADBDevice` cleanup #297 — branch ready, awaiting cross-OS validation (Linux/macOS) before merge
+- SikuliX1 community PRs #345, #346 (EPIC #344)
+
+---
+
 ## [v3.0.4-rc1] - 2026-05-18
 
 ![status](https://img.shields.io/badge/release-pre--release-yellow)

--- a/IDE/pom.xml
+++ b/IDE/pom.xml
@@ -10,7 +10,7 @@
 
   <groupId>io.github.oculix-org</groupId>
   <artifactId>oculixide</artifactId>
-  <version>3.0.4-rc1</version>
+  <version>3.0.4</version>
 
   <name>OculiX IDE</name>
   <description>Visual automation IDE - edit and run OculiX scripts</description>

--- a/MCP/pom.xml
+++ b/MCP/pom.xml
@@ -10,7 +10,7 @@
 
   <groupId>io.github.oculix-org</groupId>
   <artifactId>oculixmcp</artifactId>
-  <version>3.0.4-rc1</version>
+  <version>3.0.4</version>
 
   <packaging>jar</packaging>
 
@@ -51,7 +51,7 @@
     <dependency>
       <groupId>io.github.oculix-org</groupId>
       <artifactId>oculixapi</artifactId>
-      <version>3.0.4-rc1</version>
+      <version>3.0.4</version>
     </dependency>
 
     <!-- JSON (already used by API, keep consistent) -->

--- a/Reporter/pom.xml
+++ b/Reporter/pom.xml
@@ -10,7 +10,7 @@
 
   <groupId>io.github.oculix-org</groupId>
   <artifactId>oculixreporter</artifactId>
-  <version>3.0.4-rc1</version>
+  <version>3.0.4</version>
 
   <packaging>jar</packaging>
 

--- a/build-extensions/pom.xml
+++ b/build-extensions/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>io.github.oculix-org</groupId>
     <artifactId>oculix</artifactId>
-    <version>3.0.4-rc1</version>
+    <version>3.0.4</version>
   </parent>
 
   <artifactId>oculix-build-extensions</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.github.oculix-org</groupId>
   <artifactId>oculix</artifactId>
-  <version>3.0.4-rc1</version>
+  <version>3.0.4</version>
   <name>OculiX</name>
   <description>Visual automation - if you can see it, you can automate it</description>
   <url>https://github.com/oculix-org/Oculix</url>

--- a/pom.xml
+++ b/pom.xml
@@ -46,6 +46,45 @@
     <module>Reporter</module>
   </modules>
 
+  <!-- Security: force transitive versions to kill known CVEs (mostly brought by Jython 2.7.4).
+       Refresh quarterly or whenever Scorecard / Dependency-Check flags new ones. -->
+  <dependencyManagement>
+    <dependencies>
+      <!-- Netty: 5 GHSAs killed at once via the BOM (transitive from jython-slim 2.7.4) -->
+      <dependency>
+        <groupId>io.netty</groupId>
+        <artifactId>netty-bom</artifactId>
+        <version>4.1.133.Final</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+
+      <!-- Bouncy Castle: 4 GHSAs killed (transitive from jython-slim 2.7.4) -->
+      <dependency>
+        <groupId>org.bouncycastle</groupId>
+        <artifactId>bcprov-jdk18on</artifactId>
+        <version>1.84</version>
+      </dependency>
+      <dependency>
+        <groupId>org.bouncycastle</groupId>
+        <artifactId>bcpkix-jdk18on</artifactId>
+        <version>1.84</version>
+      </dependency>
+      <dependency>
+        <groupId>org.bouncycastle</groupId>
+        <artifactId>bcutil-jdk18on</artifactId>
+        <version>1.84</version>
+      </dependency>
+
+      <!-- plexus-utils: 1 GHSA killed (transitive from maven-core in build-extensions, provided scope) -->
+      <dependency>
+        <groupId>org.codehaus.plexus</groupId>
+        <artifactId>plexus-utils</artifactId>
+        <version>3.6.1</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
   <profiles>
     <profile>
       <id>release</id>


### PR DESCRIPTION
## Summary

Promotes `3.0.4-rc1` to **`3.0.4` stable**, with two security/stability additions on top:

1. **10 transitive CVEs killed** — pin Netty `4.1.133`, BouncyCastle `1.84`, plexus-utils `3.6.1` (via merge of `chore/deps-bump-cves`)
2. **Legerix `5.5.0-4` → `5.5.0-6`** — ships self-contained codec native libraries (`libjpeg`, `libwebp`, `libtiff` + transitives) on Linux/macOS via vcpkg modern bundle. Addresses #350 (Ubuntu 22 `libjpeg.so.62` mismatch), validated by @adriancostin6 on a fresh Ubuntu 22.04 container earlier today.

No behavior change vs `3.0.4-rc1` beyond the CVE patches and Legerix bump. The CodeQL hardening, OpenSSF badge, workflow `contents: read` permissions, and README modernization from `rc1` carry over unchanged.

## What changed in this branch

| File | Change |
|---|---|
| `pom.xml` (parent) | `3.0.4-rc1` → `3.0.4` |
| `API/pom.xml` | `3.0.4-rc1` → `3.0.4` + Legerix `5.5.0-4` → `5.5.0-6` |
| `IDE/pom.xml` | `3.0.4-rc1` → `3.0.4` |
| `MCP/pom.xml` | `3.0.4-rc1` → `3.0.4` (artifact + oculixapi dep) |
| `Reporter/pom.xml` | `3.0.4-rc1` → `3.0.4` |
| `build-extensions/pom.xml` | `3.0.4-rc1` → `3.0.4` (parent ref) |
| `CHANGELOG.md` | `## [v3.0.4]` entry added |
| (merged) `chore/deps-bump-cves` | Netty / BC / plexus-utils CVE pins |

## Deferred to 3.0.5 / 4.0 (explicitly out of scope here)

- CodeQL triage bugs identified at rc1 time: #358, #360, #361, #362
- Android `ADBDevice` cleanup #297 — branch ready but Linux + macOS validation still missing (no PR opened yet)
- SikuliX1 community PRs #345, #346 under EPIC #344

## Safety net

Tag `archive/master-pre-3.0.4-stable` was pushed before this branch started — `master` HEAD as of `2026-05-20T13:30Z` is recoverable from that tag if rollback is ever needed.

## Release pipeline after merge

1. Merge this PR into `master`
2. PR `master → oculix-rc` to trigger `release-rc.yml` and the GitHub Release at tag `v3.0.4`
3. Manually trigger `Publish to Maven Central` workflow on tag `v3.0.4`
4. Verify `https://repo1.maven.org/maven2/io/github/oculix-org/oculixapi/3.0.4/` returns 200

---

Related to: #350, #297 (context only)
