### PR TITLE
release: merge 3.0.4 stable → oculix-rc (triggers v3.0.4 release)

### DIFF
--- a/.github/workflows/api-compile.yml
+++ b/.github/workflows/api-compile.yml
@@ -15,7 +15,7 @@ permissions:
   contents: read
 
 jobs:
-  build:
+  api-compile:
 
     runs-on: ubuntu-latest
 

--- a/.github/workflows/api-compile.yml
+++ b/.github/workflows/api-compile.yml
@@ -2,6 +2,14 @@ name: Compile API
 
 on:
   workflow_dispatch:
+  pull_request:
+    branches:
+      - master
+      - release/oculix-rc
+    paths:
+      - 'API/**'
+      - 'pom.xml'
+      - '.github/workflows/api-compile.yml'
 
 permissions:
   contents: read
@@ -19,4 +27,6 @@ jobs:
         java-version: '17'
         distribution: 'temurin'
     - name: Build with Maven
-      run: mvn -B -pl API compile | egrep -v "^\[INFO\].*?Download.*?http"
+      run: |
+        set -o pipefail
+        mvn -B -pl API compile | egrep -v "^\[INFO\].*?Download.*?http"

--- a/.github/workflows/ide-compile.yml
+++ b/.github/workflows/ide-compile.yml
@@ -16,7 +16,7 @@ permissions:
   contents: read
 
 jobs:
-  build:
+  ide-compile:
 
     runs-on: ubuntu-latest
 

--- a/.github/workflows/ide-compile.yml
+++ b/.github/workflows/ide-compile.yml
@@ -2,6 +2,15 @@ name: Compile IDE
 
 on:
   workflow_dispatch:
+  pull_request:
+    branches:
+      - master
+      - release/oculix-rc
+    paths:
+      - 'API/**'
+      - 'IDE/**'
+      - 'pom.xml'
+      - '.github/workflows/ide-compile.yml'
 
 permissions:
   contents: read
@@ -19,4 +28,6 @@ jobs:
         java-version: '17'
         distribution: 'temurin'
     - name: Build with Maven
-      run: mvn -B -pl IDE compile | egrep -v "^\[INFO\].*?Download.*?http"
+      run: |
+        set -o pipefail
+        mvn -B -pl IDE -am compile | egrep -v "^\[INFO\].*?Download.*?http"

--- a/API/pom.xml
+++ b/API/pom.xml
@@ -10,7 +10,7 @@
 
   <groupId>io.github.oculix-org</groupId>
   <artifactId>oculixapi</artifactId>
-  <version>3.0.4-rc1</version>
+  <version>3.0.4</version>
 
   <packaging>jar</packaging>
 
@@ -170,7 +170,7 @@
     <dependency>
       <groupId>io.github.oculix-org</groupId>
       <artifactId>legerix</artifactId>
-      <version>5.5.0-4</version>
+      <version>5.5.0-6</version>
     </dependency>
   </dependencies>
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,42 @@ Versions follow [SemVer](https://semver.org/) with `-rcN` / `-betaN` / `-alphaN`
 
 ---
 
+## [v3.0.4] - 2026-05-20
+
+![status](https://img.shields.io/badge/release-stable-brightgreen)
+![maven](https://img.shields.io/badge/maven_central-pending-lightgrey)
+![track](https://img.shields.io/badge/upgrade-drop--in_from_3.0.x-orange)
+
+> **Security + Linux stability** — promotes `3.0.4-rc1` to stable, kills 10 transitive CVEs, and pulls in Legerix `5.5.0-6` with self-contained codec natives (resolves the Ubuntu 22 `libjpeg.so.62` mismatch, #350).
+
+### What's new for users
+
+- 🛡️ **10 CVEs killed** — `netty-codec*` pinned to `4.1.133`, `bouncycastle:bcprov-jdk18on` to `1.84`, `plexus-utils` to `3.6.1`. Removes all known transitive vulnerabilities flagged by the latest CodeQL / Dependabot run. No API change.
+
+- 🐧 **Linux codec stability (Legerix `5.5.0-6`)** — Legerix now ships self-contained codec runtime libraries (`libjpeg`, `libwebp`, `libtiff` with `libsharpyuv` / `lzma` / `zstd` / `jbig` / `Lerc` transitives) on Linux/macOS via the vcpkg modern bundle. Resolves the long-standing `libjpeg.so.62 not found` error on Ubuntu 22.04 containers (#350). Validated by Adrian Costin on a fresh Ubuntu 22.04 container.
+
+- 🔒 **Promotes `3.0.4-rc1` to stable** — All hardening from `3.0.4-rc1` (CodeQL `hashCode()` fixes, array OOB fix, workflow `contents: read` permissions, OpenSSF Best Practices badge, README modernization) is now stable. No behavior change vs `rc1` — pure version promotion + CVE patches + Legerix bump.
+
+- 🦎 **Reporter and build-extensions deploy skips** — `central-publishing-maven-plugin` now correctly skips the `oculixreporter` and `oculix-build-extensions` modules under the release profile, preventing the deployment failure observed during the `3.0.4-rc1` publish attempt.
+
+### Maven coordinates
+
+```xml
+<dependency>
+    <groupId>io.github.oculix-org</groupId>
+    <artifactId>oculixapi</artifactId>
+    <version>3.0.4</version>
+</dependency>
+```
+
+### Deferred to 3.0.5 / 4.0
+
+- CodeQL triage bugs identified at `rc1` time: #358 (`Runner` self-assignment), #360 (`allowedIPs`), #361 (`RecordedEventsFlow`), #362 (`ButtonGenCommand`)
+- Android `ADBDevice` cleanup #297 — branch ready, awaiting cross-OS validation (Linux/macOS) before merge
+- SikuliX1 community PRs #345, #346 (EPIC #344)
+
+---
+
 ## [v3.0.4-rc1] - 2026-05-18
 
 ![status](https://img.shields.io/badge/release-pre--release-yellow)

--- a/IDE/pom.xml
+++ b/IDE/pom.xml
@@ -10,7 +10,7 @@
 
   <groupId>io.github.oculix-org</groupId>
   <artifactId>oculixide</artifactId>
-  <version>3.0.4-rc1</version>
+  <version>3.0.4</version>
 
   <name>OculiX IDE</name>
   <description>Visual automation IDE - edit and run OculiX scripts</description>

--- a/MCP/pom.xml
+++ b/MCP/pom.xml
@@ -10,7 +10,7 @@
 
   <groupId>io.github.oculix-org</groupId>
   <artifactId>oculixmcp</artifactId>
-  <version>3.0.4-rc1</version>
+  <version>3.0.4</version>
 
   <packaging>jar</packaging>
 
@@ -51,7 +51,7 @@
     <dependency>
       <groupId>io.github.oculix-org</groupId>
       <artifactId>oculixapi</artifactId>
-      <version>3.0.4-rc1</version>
+      <version>3.0.4</version>
     </dependency>
 
     <!-- JSON (already used by API, keep consistent) -->

--- a/Reporter/pom.xml
+++ b/Reporter/pom.xml
@@ -122,4 +122,17 @@
     </plugins>
   </build>
 
+  <profiles>
+    <!-- Reporter is consumed in-tree by OculiX users but not published to
+         Maven Central. Skip the deploy step only when the release profile
+         is active (i.e. during the publish-maven workflow), so local
+         `mvn install` and the release-rc workflow are unaffected. -->
+    <profile>
+      <id>release</id>
+      <properties>
+        <maven.deploy.skip>true</maven.deploy.skip>
+      </properties>
+    </profile>
+  </profiles>
+
 </project>

--- a/Reporter/pom.xml
+++ b/Reporter/pom.xml
@@ -10,7 +10,7 @@
 
   <groupId>io.github.oculix-org</groupId>
   <artifactId>oculixreporter</artifactId>
-  <version>3.0.4-rc1</version>
+  <version>3.0.4</version>
 
   <packaging>jar</packaging>
 

--- a/build-extensions/pom.xml
+++ b/build-extensions/pom.xml
@@ -50,4 +50,17 @@
       <scope>provided</scope>
     </dependency>
   </dependencies>
+
+  <profiles>
+    <!-- Build extensions is a cosmetic Maven core extension (gecko banner).
+         Not a public OculiX artifact and Maven Central does not need it.
+         Skip the deploy step under the release profile so Sonatype does
+         not complain about missing sources/javadocs jars. -->
+    <profile>
+      <id>release</id>
+      <properties>
+        <maven.deploy.skip>true</maven.deploy.skip>
+      </properties>
+    </profile>
+  </profiles>
 </project>

--- a/build-extensions/pom.xml
+++ b/build-extensions/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>io.github.oculix-org</groupId>
     <artifactId>oculix</artifactId>
-    <version>3.0.4-rc1</version>
+    <version>3.0.4</version>
   </parent>
 
   <artifactId>oculix-build-extensions</artifactId>

--- a/build-extensions/pom.xml
+++ b/build-extensions/pom.xml
@@ -54,13 +54,27 @@
   <profiles>
     <!-- Build extensions is a cosmetic Maven core extension (gecko banner).
          Not a public OculiX artifact and Maven Central does not need it.
-         Skip the deploy step under the release profile so Sonatype does
-         not complain about missing sources/javadocs jars. -->
+         Skip both the standard maven-deploy-plugin (maven.deploy.skip) AND
+         the inherited central-publishing-maven-plugin from the parent's
+         release profile (skipPublishing). Without the latter, Sonatype
+         still receives build-extensions in the bundle and complains about
+         missing sources/javadocs jars. -->
     <profile>
       <id>release</id>
       <properties>
         <maven.deploy.skip>true</maven.deploy.skip>
       </properties>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.sonatype.central</groupId>
+            <artifactId>central-publishing-maven-plugin</artifactId>
+            <configuration>
+              <skipPublishing>true</skipPublishing>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
     </profile>
   </profiles>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.github.oculix-org</groupId>
   <artifactId>oculix</artifactId>
-  <version>3.0.4-rc1</version>
+  <version>3.0.4</version>
   <name>OculiX</name>
   <description>Visual automation - if you can see it, you can automate it</description>
   <url>https://github.com/oculix-org/Oculix</url>

--- a/pom.xml
+++ b/pom.xml
@@ -46,6 +46,45 @@
     <module>Reporter</module>
   </modules>
 
+  <!-- Security: force transitive versions to kill known CVEs (mostly brought by Jython 2.7.4).
+       Refresh quarterly or whenever Scorecard / Dependency-Check flags new ones. -->
+  <dependencyManagement>
+    <dependencies>
+      <!-- Netty: 5 GHSAs killed at once via the BOM (transitive from jython-slim 2.7.4) -->
+      <dependency>
+        <groupId>io.netty</groupId>
+        <artifactId>netty-bom</artifactId>
+        <version>4.1.133.Final</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+
+      <!-- Bouncy Castle: 4 GHSAs killed (transitive from jython-slim 2.7.4) -->
+      <dependency>
+        <groupId>org.bouncycastle</groupId>
+        <artifactId>bcprov-jdk18on</artifactId>
+        <version>1.84</version>
+      </dependency>
+      <dependency>
+        <groupId>org.bouncycastle</groupId>
+        <artifactId>bcpkix-jdk18on</artifactId>
+        <version>1.84</version>
+      </dependency>
+      <dependency>
+        <groupId>org.bouncycastle</groupId>
+        <artifactId>bcutil-jdk18on</artifactId>
+        <version>1.84</version>
+      </dependency>
+
+      <!-- plexus-utils: 1 GHSA killed (transitive from maven-core in build-extensions, provided scope) -->
+      <dependency>
+        <groupId>org.codehaus.plexus</groupId>
+        <artifactId>plexus-utils</artifactId>
+        <version>3.6.1</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
   <profiles>
     <profile>
       <id>release</id>


### PR DESCRIPTION
## Summary

Promotes the merged `3.0.4` stable from `master` into `release/oculix-rc` to trigger the release pipeline.

This merge brings in all 7 commits since the last `oculix-rc` sync:

| Commit | Description |
|---|---|
| `c4ab7332` | Merge pull request #372 (release/3.0.4-stable) |
| `a02ecbcd` | release: bump to 3.0.4 stable + Legerix 5.5.0-6 |
| `58882d7f` | merge: chore/deps-bump-cves |
| `928e2944` | release: skip central-publishing-plugin on build-extensions |
| `b3f17b65` | release: skip build-extensions deploy under -P release profile |
| `578995f4` | release: skip Reporter deploy under -P release profile only |
| `46cf2d65` | chore(deps): pin Netty 4.1.133, BC 1.84, plexus-utils 3.6.1 |

## What happens on merge

`release-rc.yml` workflow triggers and produces:
- Tag `v3.0.4`
- GitHub Release `v3.0.4` with CHANGELOG body
- Build artifacts attached (fat jars, native bundles)

After that, manually trigger `Publish to Maven Central` workflow on tag `v3.0.4`.

## Context

See PR #372 for the detailed scope of `3.0.4` stable (CVE bumps + Legerix `5.5.0-6` Linux codec fix + version drop from `-rc1`).

Safety net: tag `archive/master-pre-3.0.4-stable` snapshots master state before the 3.0.4 work, recoverable if needed.
