### PR TITLE
ci: fix compile-API/IDE workflows — auto-trigger on PR + real fail signal + -am

### DIFF
--- a/.github/workflows/api-compile.yml
+++ b/.github/workflows/api-compile.yml
@@ -15,7 +15,7 @@ permissions:
   contents: read
 
 jobs:
-  build:
+  api-compile:
 
     runs-on: ubuntu-latest
 

--- a/.github/workflows/api-compile.yml
+++ b/.github/workflows/api-compile.yml
@@ -2,6 +2,14 @@ name: Compile API
 
 on:
   workflow_dispatch:
+  pull_request:
+    branches:
+      - master
+      - release/oculix-rc
+    paths:
+      - 'API/**'
+      - 'pom.xml'
+      - '.github/workflows/api-compile.yml'
 
 permissions:
   contents: read
@@ -19,4 +27,6 @@ jobs:
         java-version: '17'
         distribution: 'temurin'
     - name: Build with Maven
-      run: mvn -B -pl API compile | egrep -v "^\[INFO\].*?Download.*?http"
+      run: |
+        set -o pipefail
+        mvn -B -pl API compile | egrep -v "^\[INFO\].*?Download.*?http"

--- a/.github/workflows/ide-compile.yml
+++ b/.github/workflows/ide-compile.yml
@@ -16,7 +16,7 @@ permissions:
   contents: read
 
 jobs:
-  build:
+  ide-compile:
 
     runs-on: ubuntu-latest
 

--- a/.github/workflows/ide-compile.yml
+++ b/.github/workflows/ide-compile.yml
@@ -2,6 +2,15 @@ name: Compile IDE
 
 on:
   workflow_dispatch:
+  pull_request:
+    branches:
+      - master
+      - release/oculix-rc
+    paths:
+      - 'API/**'
+      - 'IDE/**'
+      - 'pom.xml'
+      - '.github/workflows/ide-compile.yml'
 
 permissions:
   contents: read
@@ -19,4 +28,6 @@ jobs:
         java-version: '17'
         distribution: 'temurin'
     - name: Build with Maven
-      run: mvn -B -pl IDE compile | egrep -v "^\[INFO\].*?Download.*?http"
+      run: |
+        set -o pipefail
+        mvn -B -pl IDE -am compile | egrep -v "^\[INFO\].*?Download.*?http"


### PR DESCRIPTION
## Summary

Fixes three latent bugs on the two pre-merge "required" compile workflows that have been blocking PR #373 (and would block every future PR towards `master` / `release/oculix-rc`).

## The three bugs

### 1. No auto-trigger on PR

Both `api-compile.yml` and `ide-compile.yml` only had `workflow_dispatch:` (manual). So the required-check entries in branch protection (`api-compile`, `ide-compile`) sat in `"Waiting for status to be reported"` forever, blocking every PR. PR #373 had to be unblocked by manually firing the workflows.

**Fix**: added `pull_request:` trigger scoped to `master` and `release/oculix-rc`, with `paths:` filter to skip CI on irrelevant changes (docs-only, etc.).

### 2. Pipe swallows mvn exit code

The step was:
```yaml
run: mvn -B -pl IDE compile | egrep -v "^\[INFO\].*?Download.*?http"
```

Bash returns the last pipe stage's exit code by default. `egrep` always succeeds (filtering ≠ failing). So even when `mvn` produced `BUILD FAILURE`, the step exited `0` and the check turned green.

This was confirmed live on the manual trigger that "unblocked" PR #373 — workflow run was `success` but the log showed `ERROR Failed to execute goal on project oculixide`.

**Fix**: added `set -o pipefail` so the step exits with `mvn`'s non-zero code.

### 3. IDE compile without `-am`

`mvn -B -pl IDE compile` tries to resolve `oculixapi:$VERSION` from Maven Central. During a PR cycle the not-yet-published version is unresolvable → `BUILD FAILURE` (hidden by bug #2). Adding `-am` (also-make) builds the API module locally first.

**Fix**: `mvn -B -pl IDE -am compile`.

## ⚠️ Branch protection mismatch (action needed from Julien)

Even with this fix, the required checks in branch protection are still named `api-compile` and `ide-compile`, but the actual check name produced by GitHub Actions is `Compile API / build` and `Compile IDE / build` (workflow name + job name).

That mismatch is why the manual triggers earlier today ran green but the PR #373 page still showed `"Waiting for status to be reported"`.

**Two options** to fix that:
- **A** (recommended): edit branch protection on `master` and `release/oculix-rc` to require `Compile API / build` and `Compile IDE / build` instead of `api-compile` / `ide-compile`.
- **B**: drop these checks from required entirely — the `release-rc.yml` workflow runs a full build after merge to `oculix-rc` anyway, so a pre-merge `mvn -pl IDE compile` adds limited value compared to the post-merge full build.

Either option is yours to choose, Julien — but until one is done, no PR can satisfy these required checks just by passing CI.

## Test plan

Once merged, future PRs to `master` and `release/oculix-rc` will auto-trigger these workflows and the green/red status will be reliable. No more manual `gh workflow run` dance.

---

Related to: PR #373 (release: merge 3.0.4 stable → oculix-rc)
