### PR TITLE
Chore/global bug fixes

### DIFF
--- a/.github/workflows/verify-app-launcher.yml
+++ b/.github/workflows/verify-app-launcher.yml
@@ -1,0 +1,74 @@
+name: Verify App Launcher (cross-OS)
+
+# Manual dispatch only — this workflow installs Firefox on each runner
+# and boots a real GUI, so it doesn't belong on every PR push. Trigger
+# it deliberately when validating changes to WinUtil.open / MacUtil.open
+# / GenericOsUtil.open or App.focus name resolution.
+on:
+  workflow_dispatch:
+    inputs:
+      app-name:
+        description: 'App name to open (must be installable via choco / brew / apt on all three runners)'
+        required: false
+        default: 'firefox'
+
+jobs:
+  verify:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '21'
+          cache: maven
+
+      - name: Install Firefox (Ubuntu)
+        if: matrix.os == 'ubuntu-latest'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y firefox xvfb xdotool
+
+      - name: Install Firefox (macOS)
+        if: matrix.os == 'macos-latest'
+        run: brew install --cask firefox
+
+      - name: Install Firefox (Windows)
+        if: matrix.os == 'windows-latest'
+        run: choco install firefox -y --no-progress
+
+      - name: Build API jar
+        run: mvn -pl API -am package -DskipTests -B
+
+      - name: Locate API jar
+        id: jar
+        shell: bash
+        run: |
+          JAR=$(ls API/target/oculixapi-*.jar | grep -v sources | grep -v javadoc | head -1)
+          echo "path=$JAR" >> "$GITHUB_OUTPUT"
+          echo "Selected jar: $JAR"
+
+      - name: Compile VerifyAppLauncher
+        shell: bash
+        run: javac -cp "${{ steps.jar.outputs.path }}" scripts/VerifyAppLauncher.java
+
+      - name: Run VerifyAppLauncher (Ubuntu, xvfb)
+        if: matrix.os == 'ubuntu-latest'
+        run: xvfb-run -a java -cp "${{ steps.jar.outputs.path }}:scripts" VerifyAppLauncher "${{ inputs.app-name || 'firefox' }}"
+
+      - name: Run VerifyAppLauncher (macOS)
+        if: matrix.os == 'macos-latest'
+        run: java -cp "${{ steps.jar.outputs.path }}:scripts" VerifyAppLauncher "${{ inputs.app-name || 'firefox' }}"
+
+      - name: Run VerifyAppLauncher (Windows)
+        if: matrix.os == 'windows-latest'
+        shell: bash
+        run: java -cp "${{ steps.jar.outputs.path }};scripts" VerifyAppLauncher "${{ inputs.app-name || 'firefox' }}"

--- a/API/src/main/java/org/sikuli/natives/MacUtil.java
+++ b/API/src/main/java/org/sikuli/natives/MacUtil.java
@@ -4,10 +4,13 @@
 package org.sikuli.natives;
 
 import java.awt.Rectangle;
+import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
+
+import org.apache.commons.lang3.StringUtils;
 
 import org.sikuli.natives.mac.jna.CoreGraphics;
 import org.sikuli.natives.mac.jna.ObjC;
@@ -19,6 +22,60 @@ import com.sun.jna.platform.mac.CoreFoundation.CFNumberRef;
 import com.sun.jna.platform.mac.CoreFoundation.CFStringRef;
 
 public class MacUtil extends GenericOsUtil {
+
+  @Override
+  public OsProcess open(String[] cmd, String workDir) {
+    if (cmd == null || cmd.length == 0 || StringUtils.isBlank(cmd[0])) {
+      return super.open(cmd, workDir);
+    }
+
+    // Wrap with 'open -a <name> [--args ...]' so macOS resolves the target
+    // via LaunchServices (bundle name, display name, bundle identifier,
+    // aliases). Users can pass a short name like "Firefox" instead of the
+    // full path /Applications/Firefox.app/Contents/MacOS/firefox.
+    String[] wrapped;
+    if (cmd.length == 1) {
+      wrapped = new String[] { "open", "-a", cmd[0] };
+    } else {
+      // open -a NAME --args ARG1 ARG2 ...
+      wrapped = new String[cmd.length + 3];
+      wrapped[0] = "open";
+      wrapped[1] = "-a";
+      wrapped[2] = cmd[0];
+      wrapped[3] = "--args";
+      System.arraycopy(cmd, 1, wrapped, 4, cmd.length - 1);
+    }
+
+    try {
+      ProcessBuilder pb = new ProcessBuilder(wrapped);
+      if (StringUtils.isNotBlank(workDir)) {
+        pb.directory(new File(workDir));
+      }
+      pb.start();
+
+      // 'open' returns before the target app process is fully up, so we poll
+      // findProcesses(cmd[0]) for up to 3 seconds to grab the real PID.
+      long deadline = System.currentTimeMillis() + 3000L;
+      while (System.currentTimeMillis() < deadline) {
+        List<OsProcess> found = findProcesses(cmd[0]);
+        if (!found.isEmpty()) {
+          return found.get(0);
+        }
+        try {
+          Thread.sleep(100);
+        } catch (InterruptedException ie) {
+          Thread.currentThread().interrupt();
+          break;
+        }
+      }
+    } catch (Exception e) {
+      System.out.println("[error] MacUtil.open (open -a wrapper):\n" + e.getMessage());
+    }
+
+    // Fallback to direct ProcessBuilder spawn — handles absolute paths and
+    // edge cases where 'open' silently succeeded without a matching process.
+    return super.open(cmd, workDir);
+  }
 
   // NSApplicationActivationOptions — see Apple docs for NSRunningApplication.
   private static final int NS_ACTIVATE_ALL_WINDOWS          = 1 << 0;

--- a/API/src/main/java/org/sikuli/natives/MacUtil.java
+++ b/API/src/main/java/org/sikuli/natives/MacUtil.java
@@ -6,8 +6,10 @@ package org.sikuli.natives;
 import java.awt.Rectangle;
 import java.io.File;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import org.apache.commons.lang3.StringUtils;
@@ -25,19 +27,32 @@ public class MacUtil extends GenericOsUtil {
 
   @Override
   public OsProcess open(String[] cmd, String workDir) {
+    // Back-compat entry: callers who don't know about the wait budget get 3 s.
+    return open(cmd, workDir, 3);
+  }
+
+  @Override
+  public OsProcess open(String[] cmd, String workDir, int waitSeconds) {
     if (cmd == null || cmd.length == 0 || StringUtils.isBlank(cmd[0])) {
       return super.open(cmd, workDir);
     }
 
-    // Wrap with 'open -a <name> [--args ...]' so macOS resolves the target
-    // via LaunchServices (bundle name, display name, bundle identifier,
-    // aliases). Users can pass a short name like "Firefox" instead of the
-    // full path /Applications/Firefox.app/Contents/MacOS/firefox.
+    // 'open -a NAME' delegates resolution to LaunchServices (bundle name,
+    // display name, bundle identifier, aliases). It only returns a status,
+    // never the PID of the launched app — same design constraint that
+    // ShellExecuteEx solves on Windows. We compensate by snapshotting the
+    // PIDs already alive under this name BEFORE launch, then waiting for
+    // 'open' to hand off and picking the fresh PID that wasn't in the
+    // snapshot. Deterministic (delta identifies THE new instance), not the
+    // "any process with this name" lottery the previous poll played.
+    Set<Long> priorPids = findProcesses(cmd[0]).stream()
+            .map(OsProcess::getPid)
+            .collect(Collectors.toCollection(HashSet::new));
+
     String[] wrapped;
     if (cmd.length == 1) {
       wrapped = new String[] { "open", "-a", cmd[0] };
     } else {
-      // open -a NAME --args ARG1 ARG2 ...
       wrapped = new String[cmd.length + 3];
       wrapped[0] = "open";
       wrapped[1] = "-a";
@@ -51,18 +66,25 @@ public class MacUtil extends GenericOsUtil {
       if (StringUtils.isNotBlank(workDir)) {
         pb.directory(new File(workDir));
       }
-      pb.start();
+      Process openProc = pb.start();
+      int exit = openProc.waitFor();
+      if (exit != 0) {
+        // LaunchServices refused to resolve — genuine miss.
+        return super.open(cmd, workDir);
+      }
 
-      // 'open' returns before the target app process is fully up, so we poll
-      // findProcesses(cmd[0]) for up to 3 seconds to grab the real PID.
-      long deadline = System.currentTimeMillis() + 3000L;
+      // 'open' returned success, so LaunchServices has spawned the target.
+      // The kernel needs a beat to publish the new PID in ProcessHandle
+      // enumeration. Bounded poll on the DELTA against priorPids.
+      long deadline = System.currentTimeMillis() + Math.max(1, waitSeconds) * 1000L;
       while (System.currentTimeMillis() < deadline) {
-        List<OsProcess> found = findProcesses(cmd[0]);
-        if (!found.isEmpty()) {
-          return found.get(0);
+        for (OsProcess proc : findProcesses(cmd[0])) {
+          if (!priorPids.contains(proc.getPid())) {
+            return proc;
+          }
         }
         try {
-          Thread.sleep(100);
+          Thread.sleep(50);
         } catch (InterruptedException ie) {
           Thread.currentThread().interrupt();
           break;
@@ -72,8 +94,8 @@ public class MacUtil extends GenericOsUtil {
       System.out.println("[error] MacUtil.open (open -a wrapper):\n" + e.getMessage());
     }
 
-    // Fallback to direct ProcessBuilder spawn — handles absolute paths and
-    // edge cases where 'open' silently succeeded without a matching process.
+    // Absolute paths that skipped LaunchServices, or the app was
+    // single-instance and reused an existing PID (already in priorPids).
     return super.open(cmd, workDir);
   }
 

--- a/API/src/main/java/org/sikuli/natives/OSUtil.java
+++ b/API/src/main/java/org/sikuli/natives/OSUtil.java
@@ -57,5 +57,13 @@ public interface OSUtil {
 
 	OsProcess open(String[] cmd, String workDir);
 
+	// Overload with an explicit wait budget (seconds). Default routes to the
+	// timeout-agnostic signature above — implementations that shell out via
+	// launchers (WinUtil 'start', MacUtil 'open -a') override this to size
+	// their internal PID-lookup poll instead of using a hardcoded 3 s.
+	default OsProcess open(String[] cmd, String workDir, int waitSeconds) {
+		return open(cmd, workDir);
+	}
+
 	OsWindow getFocusedWindow();
 }

--- a/API/src/main/java/org/sikuli/natives/WinUtil.java
+++ b/API/src/main/java/org/sikuli/natives/WinUtil.java
@@ -4,6 +4,7 @@
 package org.sikuli.natives;
 
 import java.awt.Rectangle;
+import java.io.File;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -102,6 +103,57 @@ public class WinUtil extends GenericOsUtil {
 		public int hashCode() {
 			return hWnd != null ? hWnd.hashCode() : 0;
 		}
+	}
+
+	@Override
+	public OsProcess open(String[] cmd, String workDir) {
+		if (cmd == null || cmd.length == 0 || StringUtils.isBlank(cmd[0])) {
+			return super.open(cmd, workDir);
+		}
+
+		// Wrap with 'cmd /c start "" <target> [args...]' so Windows resolves the
+		// target via the App Paths registry, PATH, and Start Menu shortcuts.
+		// Users can pass a short app name like "Firefox" instead of a full path.
+		// The empty "" is the window title placeholder required by 'start' syntax
+		// — otherwise start would interpret cmd[0] as the title.
+		String[] wrapped = new String[cmd.length + 4];
+		wrapped[0] = "cmd";
+		wrapped[1] = "/c";
+		wrapped[2] = "start";
+		wrapped[3] = "";
+		System.arraycopy(cmd, 0, wrapped, 4, cmd.length);
+
+		try {
+			ProcessBuilder pb = new ProcessBuilder(wrapped);
+			if (StringUtils.isNotBlank(workDir)) {
+				pb.directory(new File(workDir));
+			}
+			pb.start();
+
+			// 'start' shells out and returns immediately, so the real app PID must
+			// be looked up separately. Poll allProcesses() for up to 3 seconds
+			// looking for a process whose base name matches cmd[0].
+			long deadline = System.currentTimeMillis() + 3000L;
+			while (System.currentTimeMillis() < deadline) {
+				List<OsProcess> found = findProcesses(cmd[0]);
+				if (!found.isEmpty()) {
+					return found.get(0);
+				}
+				try {
+					Thread.sleep(100);
+				} catch (InterruptedException ie) {
+					Thread.currentThread().interrupt();
+					break;
+				}
+			}
+		} catch (Exception e) {
+			System.out.println("[error] WinUtil.open (start wrapper):\n" + e.getMessage());
+		}
+
+		// Fallback to direct ProcessBuilder spawn: handles absolute paths and
+		// any case where 'start' silently succeeded but no matching process
+		// showed up within the polling window.
+		return super.open(cmd, workDir);
 	}
 
 	@Override

--- a/API/src/main/java/org/sikuli/natives/WinUtil.java
+++ b/API/src/main/java/org/sikuli/natives/WinUtil.java
@@ -14,6 +14,8 @@ import java.util.stream.Collectors;
 import org.apache.commons.lang3.StringUtils;
 import com.sun.jna.Pointer;
 import com.sun.jna.platform.win32.Kernel32;
+import com.sun.jna.platform.win32.Shell32;
+import com.sun.jna.platform.win32.ShellAPI.SHELLEXECUTEINFO;
 import com.sun.jna.platform.win32.User32;
 import com.sun.jna.platform.win32.WinDef.DWORD;
 import com.sun.jna.platform.win32.WinDef.HWND;
@@ -107,53 +109,42 @@ public class WinUtil extends GenericOsUtil {
 
 	@Override
 	public OsProcess open(String[] cmd, String workDir) {
+		// Back-compat entry: callers who don't know about the wait budget get 3 s.
+		return open(cmd, workDir, 3);
+	}
+
+	@Override
+	public OsProcess open(String[] cmd, String workDir, int waitSeconds) {
 		if (cmd == null || cmd.length == 0 || StringUtils.isBlank(cmd[0])) {
 			return super.open(cmd, workDir);
 		}
 
-		// Wrap with 'cmd /c start "" <target> [args...]' so Windows resolves the
-		// target via the App Paths registry, PATH, and Start Menu shortcuts.
-		// Users can pass a short app name like "Firefox" instead of a full path.
-		// The empty "" is the window title placeholder required by 'start' syntax
-		// — otherwise start would interpret cmd[0] as the title.
-		String[] wrapped = new String[cmd.length + 4];
-		wrapped[0] = "cmd";
-		wrapped[1] = "/c";
-		wrapped[2] = "start";
-		wrapped[3] = "";
-		System.arraycopy(cmd, 0, wrapped, 4, cmd.length);
+		// Delegate to Windows' own ShellExecuteEx — the same API Explorer uses
+		// to launch things. It resolves the target via App Paths registry, PATH,
+		// .lnk files, and default verbs, and returns hProcess directly. No 'cmd
+		// /c start' quoting land-mines (JDK-6518827 drops empty title placeholders
+		// on ProcessBuilder) and no "poll allProcesses and hope" band-aid.
+		SHELLEXECUTEINFO info = new SHELLEXECUTEINFO();
+		info.fMask = 0x00000040; // SEE_MASK_NOCLOSEPROCESS — keep hProcess alive
+		info.lpFile = cmd[0];
+		if (cmd.length > 1) {
+			info.lpParameters = String.join(" ", Arrays.copyOfRange(cmd, 1, cmd.length));
+		}
+		if (StringUtils.isNotBlank(workDir)) {
+			info.lpDirectory = workDir;
+		}
+		info.nShow = WinUser.SW_SHOWDEFAULT;
 
-		try {
-			ProcessBuilder pb = new ProcessBuilder(wrapped);
-			if (StringUtils.isNotBlank(workDir)) {
-				pb.directory(new File(workDir));
-			}
-			pb.start();
-
-			// 'start' shells out and returns immediately, so the real app PID must
-			// be looked up separately. Poll allProcesses() for up to 3 seconds
-			// looking for a process whose base name matches cmd[0].
-			long deadline = System.currentTimeMillis() + 3000L;
-			while (System.currentTimeMillis() < deadline) {
-				List<OsProcess> found = findProcesses(cmd[0]);
-				if (!found.isEmpty()) {
-					return found.get(0);
-				}
-				try {
-					Thread.sleep(100);
-				} catch (InterruptedException ie) {
-					Thread.currentThread().interrupt();
-					break;
-				}
-			}
-		} catch (Exception e) {
-			System.out.println("[error] WinUtil.open (start wrapper):\n" + e.getMessage());
+		if (!Shell32.INSTANCE.ShellExecuteEx(info) || info.hProcess == null) {
+			// DDE-only apps, UWP single-instance where the shell reused an
+			// existing process, or genuine miss — fall back to POSIX-style spawn.
+			return super.open(cmd, workDir);
 		}
 
-		// Fallback to direct ProcessBuilder spawn: handles absolute paths and
-		// any case where 'start' silently succeeded but no matching process
-		// showed up within the polling window.
-		return super.open(cmd, workDir);
+		int pid = Kernel32.INSTANCE.GetProcessId(info.hProcess);
+		return ProcessHandle.of(pid)
+				.map(h -> (OsProcess) new GenericOsProcess(h))
+				.orElse(null);
 	}
 
 	@Override

--- a/API/src/main/java/org/sikuli/script/App.java
+++ b/API/src/main/java/org/sikuli/script/App.java
@@ -444,7 +444,9 @@ public class App {
 
   private boolean openAndWait(int waitTime) {
     if (!isRunning(0)) {
-      process = osUtil.open(cmd.toStrings(), workDir);
+      // Pass waitTime down so WinUtil / MacUtil size their PID-lookup poll
+      // to the same budget the user asked for — no hidden 3 s ceiling.
+      process = osUtil.open(cmd.toStrings(), workDir, waitTime);
 
       if (process != null) {
         do {

--- a/API/src/main/java/org/sikuli/script/App.java
+++ b/API/src/main/java/org/sikuli/script/App.java
@@ -617,6 +617,20 @@ public class App {
       return app;
     }
 
+    // Fallback: when no window title matched, try matching by process name.
+    // Aligns the implementation with the docstring "name or (part of) window
+    // title" and covers apps whose window title carries varying data
+    // (e.g. "Manual.pdf - Adobe Acrobat Reader") while a process-name focus
+    // stays stable ("Acrobat"). Refs #342.
+    List<App> apps = getApps(title).stream()
+            .filter(a -> a.isUserProcess() && a.hasWindow())
+            .collect(Collectors.toList());
+    if (apps.size() > index) {
+      App app = apps.get(index);
+      app.focus();
+      return app;
+    }
+
     return new App();
   }
 

--- a/IDE/src/main/java/org/sikuli/support/runner/JythonRunner.java
+++ b/IDE/src/main/java/org/sikuli/support/runner/JythonRunner.java
@@ -88,7 +88,7 @@ public class JythonRunner extends AbstractLocalFileScriptRunner {
       jythonSupport = JythonSupport.get();
       jythonSupport.getSysPath();
       if (!Commons.isRunningFromJar()) {
-        jythonSupport.putSysPath(new File(Commons.getMainClassLocation(), "LIB").getAbsolutePath(), 0);
+        jythonSupport.putSysPath(new File(Commons.getMainClassLocation(), "Lib").getAbsolutePath(), 0);
       }
       jythonSupport.addSitePackages();
       jythonSupport.showSysPath();

--- a/MCP/README.md
+++ b/MCP/README.md
@@ -90,7 +90,13 @@ Restart Claude Desktop. The nine OculiX tools should now appear in the model's t
 java -jar oculix-mcp-server.jar verify
 ```
 
-Walks every `audit-*.jsonl` file in `~/.oculix-mcp/journal/`, re-computes hashes, verifies signatures, and checks chain continuity. Outputs `OK` / `FAIL` per file.
+Runs a full chain sweep by default: every `audit-*.jsonl` in `~/.oculix-mcp/journal/` is checked per-file (entry hashes recomputed, Ed25519 signatures verified, `seq` and `prev_hash` chained), cross-file rotation links are resolved by hash lookup (not filename order), file heads must start at genesis or at a resolved `rotation_begin`, and the signed high-water-mark anchor at `~/.oculix-mcp/journal.hwm` is confronted to catch tail truncation.
+
+Exit codes are deterministic: `0` clean, `2` soft warning (anchor lags queue after a write-then-crash), `1` hard fail (tamper, truncation, orphan file, unresolved cross-file link). Precedence is `1 > 2 > 0` — the ordering of files in the report never changes the exit code.
+
+Use `verify --per-file` for the legacy single-file mode (or pass explicit paths). Handy when debugging one file in isolation, or in Phase 1 for files signed by an archived key: `verify` under the current key only.
+
+See [Verify: chain mode and coverage](#verify-chain-mode-and-coverage) below for the exact list of attacks that are detected and the ones that are not.
 
 ---
 
@@ -129,7 +135,11 @@ oculix-mcp serve [flags]          Start over HTTP (Streamable HTTP)
 oculix-mcp rotate-key             Rotate the Ed25519 audit signing key
 oculix-mcp rotate-session-key     Rotate the HMAC keyring for session tokens
 oculix-mcp recover                Record an unsigned-gap and start a fresh chain
-oculix-mcp verify [FILES...]      Verify audit journals (all by default)
+oculix-mcp verify [--per-file] [FILES...]
+                                  Default: full chain verification with anchor
+                                  --per-file: legacy single-file mode
+                                  Named FILES imply per-file mode
+                                  Exit codes: 0 clean, 2 warn (soft), 1 fail
 oculix-mcp --help                 Show usage
 ```
 
@@ -156,7 +166,46 @@ If the private key is genuinely lost (disk failure, operator error) and the chai
 oculix-mcp recover
 ```
 
-This writes an `UNSIGNED_GAP` marker and starts a fresh chain under a new key. The discontinuity is explicit and visible to `verify`.
+The command wipes the key files, generates a fresh Ed25519 pair, and writes a signed `RECOVERY_GAP` entry as the first line of a new `audit-*.jsonl` under the new key. The entry's `prev_hash` is forced back to genesis so the chain verifier identifies it as a legitimate fresh start. The high-water-mark anchor is re-signed under the new key at the same time.
+
+A human-readable `UNSIGNED_GAP-*.txt` artefact is left in the journal directory for operators skimming with a file browser, but the verifier ignores it entirely — the anchor of trust is the signed `RECOVERY_GAP` entry, not a plain text file. This matters: if the verifier honoured `.txt` markers, an attacker with write access to the journal directory could delete an `audit-*.jsonl` and drop a fake `.txt` to explain the gap. Trusting only the signed entry keeps the level of proof at "control of the private key".
+
+### Verify: chain mode and coverage
+
+The default `verify` runs a full sweep across the journal directory plus a confrontation with a signed high-water-mark anchor. Four passes plus an anchor check:
+
+1. **Per-file** — every `audit-*.jsonl` is checked line by line: entry hash recomputed, Ed25519 signature verified, `seq` monotonic, `prev_hash` chained, `ts_utc` monotonic.
+2. **Index** — every `rotation_end` entry's `entry_hash` is indexed into a map. This is the source of truth for chain order, not filename order: `openNewFile` suffixes millisecond collisions with `-1`, `-2`, and lexicographic order places `audit-...-000-1.jsonl` before `audit-...-000.jsonl` even though the suffixed file was created later. The hash chain does not lie.
+3. **Resolve** — every `rotation_begin` entry's `previous_marker_hash` is resolved against the index. A missing predecessor surfaces here as an unresolvable reference.
+4. **Genesis-anchored heads** — any file whose first entry has `prev_hash != genesis` and whose type is not `rotation_begin` is orphaned (attacker-injected, or predecessor missing). Legitimate starts are the very first file, a post-`recover` file (whose first entry is a `RECOVERY_GAP` at genesis), and a rotation successor whose predecessor was resolved above.
+
+The high-water-mark anchor lives at `~/.oculix-mcp/journal.hwm`, outside the journal directory so a cosmetic wipe of `journal/` leaves it behind. It is signed by the current key and holds `{last_entry_hash, last_seq, last_file, last_ts_utc}` — all four fields under the signature, including `last_file` (a rename must invalidate the anchor, otherwise a verifier resolving `last_file` → path could be misled without any signature failure to flag it). Every write to the journal updates the anchor; every key rotation or recovery re-signs it under the new key.
+
+Coverage:
+
+| Attack | Detected by |
+|---|---|
+| Modify an entry inside a file | Per-file entry hash + Ed25519 signature |
+| Delete an entry mid-file | Per-file `prev_hash` chain |
+| Delete a file in the middle of the directory | Cross-file `rotation_end`/`rotation_begin` hash resolution |
+| Rewrite a `rotation_begin.previous_marker_hash` | Same, plus per-file entry hash |
+| Inject an orphan `audit-*.jsonl` | Genesis-anchored head check |
+| Delete the last `audit-*.jsonl` file(s) | Signed anchor references a file that no longer exists |
+| Wipe of `journal/` alone | Anchor lives in `oculixDir`, references a missing file |
+| Rename `last_file` in the anchor | `last_file` sits under the anchor's signature |
+| Drop a fake `UNSIGNED_GAP-*.txt` to explain a deletion | Verifier ignores `.txt` entirely; only signed `RECOVERY_GAP` entries count |
+| Wipe of the whole `oculixDir` (key + journal + anchor) | Not detected in Phase 1 — Phase 2 issue tracks an external anchor (other volume, syslog forward, notary) |
+| Attacker with the private key | Not detectable by design — this is the security boundary the anchor and chain both rely on |
+
+Exit codes:
+
+| Code | Level | Meaning |
+|---|---|---|
+| `0` | OK | Chain intact, anchor agrees |
+| `2` | WARN | Soft deviation: anchor lags actual queue (write reached disk, anchor update crashed) — chain itself intact |
+| `1` | FAIL | Tamper, truncation, orphan, or unresolved cross-file link |
+
+Precedence is `1 > 2 > 0` — the ordering of files in the report never changes the exit code.
 
 ---
 

--- a/MCP/src/main/java/org/sikuli/mcp/audit/ArgsRedactor.java
+++ b/MCP/src/main/java/org/sikuli/mcp/audit/ArgsRedactor.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright (c) 2010-2026, sikuli.org, sikulix.com, oculix-org - MIT license
+ */
+package org.sikuli.mcp.audit;
+
+import org.json.JSONArray;
+import org.json.JSONObject;
+import org.sikuli.mcp.crypto.Hashing;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Set;
+
+/**
+ * Redact sensitive values in a tool-call {@code args} object before it
+ * is written to the append-only, forever-signed audit journal.
+ *
+ * <p>The journal is a Ed25519-signed record of every action. Once an
+ * entry is on disk it stays on disk in that exact form — a plaintext
+ * password embedded in a {@code type_text} call would live in the
+ * journal for the lifetime of the deployment. That is a compliance
+ * problem (GDPR, PCI, banking secrecy) and a straightforward
+ * information-disclosure risk on backup exfiltration.
+ *
+ * <p>The redactor walks the {@link JSONObject} recursively, replacing
+ * the value of any key whose name matches a sensitive pattern (case-
+ * insensitive substring match against {@link #SENSITIVE_KEY_PATTERNS})
+ * with a short SHA-256 fingerprint of the original value. The
+ * fingerprint preserves auditability: two entries that carried the
+ * same secret will show the same fingerprint, so an investigator can
+ * still correlate them without ever reading the plaintext.
+ *
+ * <p>Nested objects and arrays are traversed. Non-sensitive keys pass
+ * through unchanged. The original {@link JSONObject} is not mutated —
+ * a fresh tree is returned.
+ *
+ * <p>The predicate is deliberately conservative (loose substring match)
+ * so that {@code apiKey}, {@code api_key}, {@code x-api-key},
+ * {@code my_secret_thing} all land in the redacted bucket. False
+ * positives are cheap (a key called {@code "authorized"} would be
+ * redacted); false negatives are what actually leak PII, so we err on
+ * the side of over-redacting.
+ *
+ * @author Julien Mer (julienmerconsulting)
+ * @author Claude (Anthropic)
+ * @since 4.0.1
+ */
+public final class ArgsRedactor {
+
+  /**
+   * Substrings (case-insensitive) that mark a key as sensitive. If a key
+   * name contains any of these, its value is replaced with a fingerprint.
+   */
+  private static final Set<String> SENSITIVE_KEY_PATTERNS = Set.of(
+      "password", "passwd",
+      "secret",
+      "api_key", "apikey", "api-key",
+      "token",
+      "auth",
+      "credential",
+      "private_key", "privatekey",
+      "pin",
+      "ssn",
+      "iban",
+      "cvv",
+      "creditcard", "credit_card", "credit-card",
+      "session_id"
+  );
+
+  private static final String REDACTED_MARKER = "***REDACTED";
+
+  private ArgsRedactor() {}
+
+  /**
+   * Return a redacted deep copy of {@code original}. Sensitive-keyed
+   * values (see class Javadoc) become a fingerprint string; every
+   * other value is copied unchanged. Nested objects and arrays are
+   * traversed.
+   *
+   * @return a fresh {@link JSONObject}, or {@code null} if the input
+   *         was {@code null}
+   */
+  public static JSONObject redact(JSONObject original) {
+    if (original == null) return null;
+    JSONObject out = new JSONObject();
+    for (String key : original.keySet()) {
+      Object val = original.opt(key);
+      out.put(key, redactValue(key, val));
+    }
+    return out;
+  }
+
+  private static Object redactValue(String key, Object val) {
+    if (isSensitive(key)) {
+      return redactedFingerprint(val);
+    }
+    if (val instanceof JSONObject) {
+      return redact((JSONObject) val);
+    }
+    if (val instanceof JSONArray) {
+      return redactArray((JSONArray) val);
+    }
+    return val;
+  }
+
+  private static JSONArray redactArray(JSONArray in) {
+    JSONArray out = new JSONArray();
+    for (int i = 0; i < in.length(); i++) {
+      Object v = in.opt(i);
+      if (v instanceof JSONObject) {
+        out.put(redact((JSONObject) v));
+      } else if (v instanceof JSONArray) {
+        out.put(redactArray((JSONArray) v));
+      } else {
+        out.put(v);
+      }
+    }
+    return out;
+  }
+
+  /**
+   * Case-insensitive substring match. A key like {@code "x-api-key"}
+   * or {@code "MyPassword123"} both trip.
+   */
+  static boolean isSensitive(String key) {
+    if (key == null) return false;
+    String lower = key.toLowerCase();
+    for (String pat : SENSITIVE_KEY_PATTERNS) {
+      if (lower.contains(pat)) return true;
+    }
+    return false;
+  }
+
+  /**
+   * Replace a value with a fingerprint string. {@code null} is spelled
+   * out so the redacted entry stays informative — an operator scanning
+   * the journal can see that the field was present but null.
+   */
+  private static String redactedFingerprint(Object val) {
+    if (val == null || val == JSONObject.NULL) {
+      return REDACTED_MARKER + " (null)***";
+    }
+    String s = val.toString();
+    if (s.isEmpty()) {
+      return REDACTED_MARKER + " (empty)***";
+    }
+    String hash = Hashing.sha256Hex(s.getBytes(StandardCharsets.UTF_8));
+    return REDACTED_MARKER + " sha256=" + hash.substring(0, 12) + "***";
+  }
+}

--- a/MCP/src/main/java/org/sikuli/mcp/audit/ClockGuard.java
+++ b/MCP/src/main/java/org/sikuli/mcp/audit/ClockGuard.java
@@ -3,18 +3,28 @@
  */
 package org.sikuli.mcp.audit;
 
+import java.time.Clock;
 import java.time.Instant;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
+import java.util.function.LongSupplier;
 
 /**
- * Combines wall-clock UTC timestamps with a monotonic reference from
- * {@link System#nanoTime()} to detect clock regressions (NTP sync going
- * backward, VM pause, operator tampering).
+ * Combines wall-clock UTC timestamps with a monotonic reference to
+ * detect clock regressions (NTP sync going backward, VM pause,
+ * operator tampering).
  *
- * <p>On regression, the caller is expected to emit a {@code clock_regression}
- * audit entry before the next real tool call entry. This {@code ClockGuard}
- * flags the event but never throws — the audit trail must keep running.
+ * <p>Both clocks are injectable so tests can drive them independently:
+ * the wall clock via {@link Clock}, the monotonic reference via a
+ * {@link LongSupplier} of nanoseconds. Production callers pass
+ * {@link Clock#systemUTC()} and {@link System#nanoTime}; tests pass
+ * a {@code Clock.fixed}/{@code Clock.offset} and a synthetic
+ * {@code AtomicLong::get}.
+ *
+ * <p>On regression, the caller is expected to emit a
+ * {@code clock_regression} audit entry before the next real tool call
+ * entry. This {@code ClockGuard} flags the event but never throws — the
+ * audit trail must keep running.
  * @author Julien Mer (julienmerconsulting)
  * @author Claude (Anthropic)
  * @since 3.0.3
@@ -24,19 +34,33 @@ public final class ClockGuard {
   private static final DateTimeFormatter ISO_MICRO =
       DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSSSSS'Z'").withZone(ZoneOffset.UTC);
 
+  private final Clock wallClock;
+  private final LongSupplier monotonicNano;
+
   private long refNano;
   private Instant refWall;
 
+  /** Production default: system UTC wall clock plus {@link System#nanoTime}. */
   public ClockGuard() {
-    this.refNano = System.nanoTime();
-    this.refWall = Instant.now();
+    this(Clock.systemUTC(), System::nanoTime);
+  }
+
+  /**
+   * @param wallClock       source of wall-clock instants (injectable for tests)
+   * @param monotonicNano   source of monotonic nanoseconds (injectable for tests)
+   */
+  public ClockGuard(Clock wallClock, LongSupplier monotonicNano) {
+    this.wallClock = wallClock;
+    this.monotonicNano = monotonicNano;
+    this.refNano = monotonicNano.getAsLong();
+    this.refWall = wallClock.instant();
   }
 
   /**
    * Compute the current UTC wall-clock timestamp with microsecond precision.
    */
   public String nowIso() {
-    return ISO_MICRO.format(Instant.now());
+    return ISO_MICRO.format(wallClock.instant());
   }
 
   /**
@@ -46,8 +70,8 @@ public final class ClockGuard {
    * normal jitter.
    */
   public boolean hasRegressed() {
-    long nowNano = System.nanoTime();
-    Instant nowWall = Instant.now();
+    long nowNano = monotonicNano.getAsLong();
+    Instant nowWall = wallClock.instant();
 
     long nanoDeltaMillis = (nowNano - refNano) / 1_000_000L;
     long wallDeltaMillis = nowWall.toEpochMilli() - refWall.toEpochMilli();
@@ -60,8 +84,8 @@ public final class ClockGuard {
    * Reset the reference point after a regression has been logged.
    */
   public void acknowledge() {
-    this.refNano = System.nanoTime();
-    this.refWall = Instant.now();
+    this.refNano = monotonicNano.getAsLong();
+    this.refWall = wallClock.instant();
   }
 
   public Instant refWall() { return refWall; }

--- a/MCP/src/main/java/org/sikuli/mcp/audit/HighWaterMark.java
+++ b/MCP/src/main/java/org/sikuli/mcp/audit/HighWaterMark.java
@@ -1,0 +1,247 @@
+/*
+ * Copyright (c) 2010-2026, sikuli.org, sikulix.com, oculix-org - MIT license
+ */
+package org.sikuli.mcp.audit;
+
+import org.json.JSONObject;
+import org.sikuli.mcp.crypto.CanonicalJson;
+import org.sikuli.mcp.crypto.Hashing;
+import org.sikuli.mcp.crypto.KeyManager;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.AtomicMoveNotSupportedException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.nio.file.StandardOpenOption;
+import java.nio.file.attribute.PosixFileAttributeView;
+import java.nio.file.attribute.PosixFilePermissions;
+import java.security.PublicKey;
+import java.util.Optional;
+
+/**
+ * Signed anchor pointing at the last entry of the journal chain.
+ *
+ * <p>Purpose: close the tail-truncation hole. The intra-file {@code prev_hash}
+ * chain and the cross-file {@code rotation_end}/{@code rotation_begin} pair
+ * detect modification and mid-chain deletion. Neither detects an attacker
+ * lopping off the last N files: nothing after them points at them, so their
+ * absence leaves no trace. The high-water-mark is that trace, kept outside
+ * the journal directory and signed with the current Ed25519 key.
+ *
+ * <p>Anchor payload (four business fields, all under the signature):
+ * <ul>
+ *   <li>{@code last_entry_hash} — {@code entry_hash} of the most recent write</li>
+ *   <li>{@code last_seq} — its per-file sequence number</li>
+ *   <li>{@code last_file} — the journal file it landed in</li>
+ *   <li>{@code last_ts_utc} — its ISO-8601 UTC timestamp</li>
+ * </ul>
+ *
+ * <p>{@code last_file} is included in the signed payload deliberately: a
+ * renamed file must invalidate the anchor, otherwise a resolver mapping
+ * {@code last_file} to an actual on-disk path could be misled without any
+ * signature failure to flag it.
+ *
+ * <p>The anchor path is injected at construction so a future phase can move
+ * it to a genuinely external location (other volume, syslog forward,
+ * notary). In phase 1 it lives next to {@code KeyManager}'s key files in
+ * {@code oculixDir}, which survives a cosmetic wipe of {@code journalDir}
+ * but not a wipe of the whole {@code oculixDir}. That limit is documented,
+ * not hidden.
+ *
+ * <p>Threading: {@link #update} and {@link #reset} are {@code synchronized};
+ * {@link #load} is too so callers can read a consistent snapshot even under
+ * concurrent writes. On-disk atomicity is provided by a tmp-and-move
+ * sequence with {@link StandardCopyOption#ATOMIC_MOVE} where the filesystem
+ * supports it.
+ *
+ * @author Julien Mer (julienmerconsulting)
+ * @author Claude (Anthropic)
+ * @since 4.0.1
+ */
+public final class HighWaterMark {
+
+  /**
+   * Immutable snapshot of the four business fields plus their signature.
+   * The canonical form used for signing excludes {@code signature} itself
+   * so the four fields hash and sign identically on both write and verify.
+   */
+  public static final class Snapshot {
+    public final String lastEntryHash;
+    public final long lastSeq;
+    public final String lastFile;
+    public final String lastTsUtc;
+    public final String signature;
+
+    public Snapshot(String lastEntryHash, long lastSeq,
+                    String lastFile, String lastTsUtc, String signature) {
+      this.lastEntryHash = lastEntryHash;
+      this.lastSeq = lastSeq;
+      this.lastFile = lastFile;
+      this.lastTsUtc = lastTsUtc;
+      this.signature = signature;
+    }
+
+    /**
+     * Canonical form under the signature: all four business fields,
+     * signature deliberately absent. Serialised via
+     * {@link CanonicalJson#serialize} for deterministic bytes.
+     */
+    public JSONObject toCanonicalJson() {
+      JSONObject o = new JSONObject();
+      o.put("last_entry_hash", lastEntryHash);
+      o.put("last_seq", lastSeq);
+      o.put("last_file", lastFile);
+      o.put("last_ts_utc", lastTsUtc);
+      return o;
+    }
+
+    /**
+     * Full on-disk form: canonical fields plus the hex signature.
+     */
+    public JSONObject toJson() {
+      JSONObject o = toCanonicalJson();
+      o.put("signature", signature);
+      return o;
+    }
+  }
+
+  private static final String ANCHOR_TMP_SUFFIX = ".tmp";
+
+  private final Path anchorPath;
+  private final KeyManager keys;
+
+  /**
+   * @param anchorPath absolute path of the anchor file; the parent
+   *                   directory is created on write if missing.
+   * @param keys       key manager whose private key signs updates; expected
+   *                   to hold the current key after any rotation or recovery.
+   */
+  public HighWaterMark(Path anchorPath, KeyManager keys) {
+    this.anchorPath = anchorPath;
+    this.keys = keys;
+  }
+
+  public Path anchorPath() {
+    return anchorPath;
+  }
+
+  /**
+   * Sign the four business fields with the currently-configured key and
+   * write the anchor atomically. Called after each journal write.
+   */
+  public synchronized void update(String lastEntryHash, long lastSeq,
+                                  String lastFile, String lastTsUtc) throws IOException {
+    Snapshot unsigned = new Snapshot(lastEntryHash, lastSeq, lastFile, lastTsUtc, null);
+    String canonical = CanonicalJson.serialize(unsigned.toCanonicalJson());
+    byte[] sig = keys.sign(canonical.getBytes(StandardCharsets.UTF_8));
+    Snapshot signed = new Snapshot(
+        lastEntryHash, lastSeq, lastFile, lastTsUtc, Hashing.toHex(sig));
+    writeAtomic(signed);
+  }
+
+  /**
+   * Semantically identical to {@link #update} but named to make the intent
+   * of the caller explicit: a key promotion (rotate-key, recover) has just
+   * happened and the anchor must be re-signed by the new key. Without a
+   * reset after promotion the next {@code verify} would read an anchor
+   * signed by the archived key and report a bogus tamper.
+   */
+  public synchronized void reset(String lastEntryHash, long lastSeq,
+                                 String lastFile, String lastTsUtc) throws IOException {
+    update(lastEntryHash, lastSeq, lastFile, lastTsUtc);
+  }
+
+  /**
+   * Read the anchor from disk. Returns {@link Optional#empty()} if the
+   * anchor does not exist (fresh install, no queue to anchor yet).
+   * Signature is <em>not</em> verified here so the caller can decide
+   * whether a bad signature is a warning or a hard fail. Use
+   * {@link #verify(Snapshot, PublicKey)} for the crypto check.
+   *
+   * @throws IOException if the anchor exists but is unparseable
+   */
+  public synchronized Optional<Snapshot> load() throws IOException {
+    if (!Files.exists(anchorPath)) {
+      return Optional.empty();
+    }
+    String content = Files.readString(anchorPath, StandardCharsets.UTF_8);
+    JSONObject o;
+    try {
+      o = new JSONObject(content);
+    } catch (Exception e) {
+      throw new IOException(
+          "HWM anchor at " + anchorPath + " is not valid JSON: " + e.getMessage(), e);
+    }
+    try {
+      return Optional.of(new Snapshot(
+          o.getString("last_entry_hash"),
+          o.getLong("last_seq"),
+          o.getString("last_file"),
+          o.getString("last_ts_utc"),
+          o.getString("signature")));
+    } catch (Exception e) {
+      throw new IOException(
+          "HWM anchor at " + anchorPath + " is missing required fields: " + e.getMessage(), e);
+    }
+  }
+
+  /**
+   * Ed25519-verify the given snapshot against a public key. Returns
+   * {@code false} on any failure (bad hex, wrong length, invalid signature)
+   * rather than throwing so the caller can decide the escalation policy.
+   */
+  public static boolean verify(Snapshot snapshot, PublicKey publicKey) {
+    if (snapshot == null || snapshot.signature == null) {
+      return false;
+    }
+    byte[] sig;
+    try {
+      sig = Hashing.fromHex(snapshot.signature);
+    } catch (Exception e) {
+      return false;
+    }
+    String canonical = CanonicalJson.serialize(snapshot.toCanonicalJson());
+    return KeyManager.verify(canonical.getBytes(StandardCharsets.UTF_8), sig, publicKey);
+  }
+
+  private void writeAtomic(Snapshot signed) throws IOException {
+    Path parent = anchorPath.getParent();
+    if (parent != null) {
+      Files.createDirectories(parent);
+    }
+    Path tmp = anchorPath.resolveSibling(anchorPath.getFileName() + ANCHOR_TMP_SUFFIX);
+    Files.writeString(tmp, signed.toJson().toString(),
+        StandardCharsets.UTF_8,
+        StandardOpenOption.CREATE,
+        StandardOpenOption.WRITE,
+        StandardOpenOption.TRUNCATE_EXISTING);
+    try {
+      Files.move(tmp, anchorPath,
+          StandardCopyOption.ATOMIC_MOVE, StandardCopyOption.REPLACE_EXISTING);
+    } catch (AtomicMoveNotSupportedException e) {
+      // Cross-filesystem tmp/anchor. Rare when tmp sits next to the anchor,
+      // but not impossible on exotic mounts. Fall back to a non-atomic move.
+      Files.move(tmp, anchorPath, StandardCopyOption.REPLACE_EXISTING);
+    }
+    tryLockDownPermissions(anchorPath);
+  }
+
+  /**
+   * Best-effort {@code 0600} on POSIX. Windows silently skips: NTFS ACLs
+   * are richer than POSIX bits and the correct-answer there is inherited
+   * from {@code oculixDir}, which {@code KeyManager} already restricts.
+   */
+  private static void tryLockDownPermissions(Path p) {
+    try {
+      PosixFileAttributeView view =
+          Files.getFileAttributeView(p, PosixFileAttributeView.class);
+      if (view != null) {
+        view.setPermissions(PosixFilePermissions.fromString("rw-------"));
+      }
+    } catch (Exception ignore) {
+      // POSIX view unavailable — nothing to do here.
+    }
+  }
+}

--- a/MCP/src/main/java/org/sikuli/mcp/audit/JournalVerifier.java
+++ b/MCP/src/main/java/org/sikuli/mcp/audit/JournalVerifier.java
@@ -11,31 +11,55 @@ import org.sikuli.mcp.crypto.KeyManager;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
-import java.nio.file.*;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.security.KeyFactory;
 import java.security.PublicKey;
 import java.security.spec.X509EncodedKeySpec;
 import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 /**
  * Standalone verifier for JSONL audit journals.
  *
- * <p>Walks every line of a journal file, re-computes {@code entry_hash},
- * checks the Ed25519 signature against the provided public key, and ensures
- * that {@code prev_hash} chains correctly from one entry to the next.
- *
- * <p>Also verifies invariants on {@code seq}:
+ * <p>Three levels of scrutiny are exposed:
  * <ul>
- *   <li>starts at 0 for the first entry of the file</li>
- *   <li>strictly increments by 1 per entry</li>
- *   <li>{@code (ts_utc, seq)} is strictly increasing</li>
+ *   <li>{@link #verify(Path, PublicKey)} — legacy per-file entry check
+ *       (unchanged behaviour). Every entry's {@code entry_hash} is
+ *       recomputed, its Ed25519 signature verified, {@code seq}
+ *       monotonicity and {@code prev_hash} chain enforced, and
+ *       {@code ts_utc} monotonicity checked.</li>
+ *   <li>{@link #verifyFile(Path, PublicKey)} — same per-file check but
+ *       also captures the first and last entry meta, needed to resolve
+ *       cross-file links.</li>
+ *   <li>{@link #verifyChain(Path, PublicKey, Path)} — full sweep across
+ *       the journal directory: per-file verification, cross-file link
+ *       resolution via {@code rotation_end}/{@code rotation_begin} hash
+ *       lookup (not filename order — filename collisions on the
+ *       millisecond stamp suffix as {@code -1}/{@code -2} would lie
+ *       about creation order), genesis-anchored file-head validation,
+ *       and confrontation with the {@link HighWaterMark} anchor to
+ *       detect tail truncation.</li>
  * </ul>
+ *
+ * <p>The chain result reports at three levels: {@code OK} if everything
+ * lined up, {@code WARN} if a soft deviation was detected (anchor lags
+ * queue after a write-then-crash, empty journal dir), {@code FAIL} for
+ * anything that breaks the tamper-detection claim.
+ *
  * @author Julien Mer (julienmerconsulting)
  * @author Claude (Anthropic)
  * @since 3.0.3
  */
 public final class JournalVerifier {
+
+  private static final String GENESIS = "0".repeat(64);
 
   public static final class Result {
     public final boolean ok;
@@ -48,12 +72,102 @@ public final class JournalVerifier {
     }
   }
 
+  /**
+   * Structural summary of a single entry, enough to resolve cross-file
+   * links without re-parsing the file.
+   */
+  public static final class EntryMeta {
+    public final String type;       // lower-case (tool_call, rotation_begin, ...)
+    public final long seq;
+    public final String tsUtc;
+    public final String prevHash;
+    public final String entryHash;
+    public final JSONObject extra;  // may be null
+    public EntryMeta(String type, long seq, String tsUtc,
+                     String prevHash, String entryHash, JSONObject extra) {
+      this.type = type;
+      this.seq = seq;
+      this.tsUtc = tsUtc;
+      this.prevHash = prevHash;
+      this.entryHash = entryHash;
+      this.extra = extra;
+    }
+  }
+
+  /** Per-file verification result plus first and last entry meta. */
+  public static final class FileVerification {
+    public final Path file;
+    public final Result result;
+    public final EntryMeta first;  // null if the file has no entries
+    public final EntryMeta last;   // null if the file has no entries
+    public FileVerification(Path file, Result result, EntryMeta first, EntryMeta last) {
+      this.file = file;
+      this.result = result;
+      this.first = first;
+      this.last = last;
+    }
+  }
+
+  /**
+   * Aggregate result of a chain verification.
+   *
+   * <p>{@code level}:
+   * <ul>
+   *   <li>{@code OK} — all files clean, all cross-file links resolved,
+   *       anchor agrees with the last file.</li>
+   *   <li>{@code WARN} — a soft deviation (e.g. anchor lags the queue
+   *       after a write succeeded but the anchor update failed) that
+   *       does not compromise the tamper claim. Exit code 2.</li>
+   *   <li>{@code FAIL} — per-file error, broken cross-file link, orphan
+   *       file, missing anchor with existing queue, or truncation
+   *       detected. Exit code 1.</li>
+   * </ul>
+   */
+  public static final class ChainResult {
+    public enum Level { OK, WARN, FAIL }
+
+    public final Level level;
+    public final int filesChecked;
+    public final int entriesChecked;
+    public final List<FileVerification> perFile;
+    public final List<String> issues;
+    public final List<String> warnings;
+
+    public ChainResult(Level level, int filesChecked, int entriesChecked,
+                       List<FileVerification> perFile,
+                       List<String> issues, List<String> warnings) {
+      this.level = level;
+      this.filesChecked = filesChecked;
+      this.entriesChecked = entriesChecked;
+      this.perFile = perFile;
+      this.issues = issues;
+      this.warnings = warnings;
+    }
+
+    public boolean ok() { return level == Level.OK; }
+  }
+
+  /**
+   * Legacy per-file verifier. Preserved so existing callers and tests
+   * that only want a single-file check keep the exact same API.
+   */
   public static Result verify(Path file, PublicKey publicKey) throws IOException {
+    return verifyFile(file, publicKey).result;
+  }
+
+  /**
+   * Verify one file and return both the pass/fail plus the first and
+   * last entry meta so cross-file resolution can be done without
+   * re-parsing.
+   */
+  public static FileVerification verifyFile(Path file, PublicKey publicKey) throws IOException {
     List<String> issues = new ArrayList<>();
     int lineNo = 0;
     long expectedSeq = 0;
     String expectedPrev = null;
     String lastTs = null;
+    EntryMeta first = null;
+    EntryMeta last = null;
 
     try (BufferedReader in = Files.newBufferedReader(file, StandardCharsets.UTF_8)) {
       String line;
@@ -68,11 +182,14 @@ public final class JournalVerifier {
           continue;
         }
 
+        String type = o.getString("type");
         long seq = o.getLong("seq");
         String ts = o.getString("ts_utc");
         String prev = o.getString("prev_hash");
         String entryHash = o.getString("entry_hash");
         String sigHex = o.getString("signature");
+        JSONObject extra = (o.has("extra") && !o.isNull("extra"))
+            ? o.getJSONObject("extra") : null;
 
         // Canonical re-serialisation: strip entry_hash + signature, re-hash
         JSONObject canonical = new JSONObject(line);
@@ -106,10 +223,222 @@ public final class JournalVerifier {
               + " after " + lastTs + ")");
         }
         lastTs = ts;
+
+        EntryMeta meta = new EntryMeta(type, seq, ts, prev, entryHash, extra);
+        if (first == null) first = meta;
+        last = meta;
       }
     }
 
-    return new Result(issues.isEmpty(), lineNo, issues);
+    Result result = new Result(issues.isEmpty(), lineNo, issues);
+    return new FileVerification(file, result, first, last);
+  }
+
+  /**
+   * Chain verification across every {@code audit-*.jsonl} file in
+   * {@code journalDir}, cross-checked against the {@link HighWaterMark}
+   * anchor at {@code anchorPath}.
+   *
+   * <p>The cross-file link check does <strong>not</strong> rely on
+   * filename order. Filename collisions on the millisecond stamp are
+   * suffixed with {@code -1}, {@code -2}, and lexicographic order
+   * places {@code audit-...-000-1.jsonl} before {@code audit-...-000.jsonl}
+   * even though the suffixed file was created after. The hash chain
+   * does not lie — {@code rotation_end.entry_hash} of file N is
+   * carried into {@code rotation_begin.previous_marker_hash} of file
+   * N+1, so we index all {@code rotation_end} hashes and resolve every
+   * {@code rotation_begin} against that index. A missing predecessor
+   * surfaces as an unresolvable reference.
+   *
+   * @param journalDir directory scanned for {@code audit-*.jsonl} files
+   * @param publicKey  key used to check both entry signatures and the
+   *                   HWM signature
+   * @param anchorPath location of the {@link HighWaterMark} anchor,
+   *                   or {@code null} to skip HWM confrontation
+   */
+  public static ChainResult verifyChain(Path journalDir, PublicKey publicKey,
+                                        Path anchorPath) throws IOException {
+    List<String> issues = new ArrayList<>();
+    List<String> warnings = new ArrayList<>();
+    List<FileVerification> perFile = new ArrayList<>();
+    int totalEntries = 0;
+
+    if (!Files.isDirectory(journalDir)) {
+      issues.add("journal directory does not exist: " + journalDir);
+      return new ChainResult(ChainResult.Level.FAIL, 0, 0, perFile, issues, warnings);
+    }
+
+    List<Path> files;
+    try (Stream<Path> s = Files.list(journalDir)) {
+      files = s.filter(p -> {
+        String name = p.getFileName().toString();
+        return name.startsWith("audit-") && name.endsWith(".jsonl");
+      }).sorted(Comparator.naturalOrder()).collect(Collectors.toList());
+    }
+
+    // Pass 1 — per-file verification + meta capture
+    for (Path f : files) {
+      FileVerification fv = verifyFile(f, publicKey);
+      perFile.add(fv);
+      totalEntries += fv.result.entriesChecked;
+      if (!fv.result.ok) {
+        for (String iss : fv.result.issues) {
+          issues.add(f.getFileName() + ": " + iss);
+        }
+      }
+    }
+
+    // Pass 2 — index rotation_end by entry_hash. This is the truth
+    // source for chain order: hash resolution, not filename order.
+    Map<String, Path> endsByHash = new HashMap<>();
+    for (FileVerification fv : perFile) {
+      if (fv.last != null && "rotation_end".equals(fv.last.type)) {
+        endsByHash.put(fv.last.entryHash, fv.file);
+      }
+    }
+
+    // Pass 3 — resolve rotation_begin.previous_marker_hash. Missing
+    // files between rotations surface here as unresolvable references.
+    for (FileVerification fv : perFile) {
+      if (fv.first != null && "rotation_begin".equals(fv.first.type)) {
+        JSONObject ex = fv.first.extra;
+        if (ex == null || !ex.has("previous_marker_hash")) {
+          issues.add(fv.file.getFileName()
+              + ": rotation_begin missing previous_marker_hash");
+          continue;
+        }
+        String prevMarker = ex.getString("previous_marker_hash");
+        if (!endsByHash.containsKey(prevMarker)) {
+          issues.add(fv.file.getFileName()
+              + ": rotation_begin references unknown previous_marker_hash="
+              + prevMarker + " — missing file between rotations");
+        }
+      }
+    }
+
+    // Pass 4 — genesis-anchored head check. A legitimate chain start
+    // has first.prev_hash == GENESIS. That covers: the very first
+    // file (initial install), a fresh RECOVERY_GAP file (chain reset),
+    // and any legitimate migration. Anything else must be a
+    // rotation_begin whose predecessor resolved above. Otherwise the
+    // file is orphaned — injected by an attacker, or its predecessor
+    // was removed.
+    for (FileVerification fv : perFile) {
+      if (fv.first == null) continue; // empty file, covered by per-file layer
+      boolean genesisAnchored = GENESIS.equals(fv.first.prevHash);
+      boolean rotationBegin = "rotation_begin".equals(fv.first.type);
+      if (!genesisAnchored && !rotationBegin) {
+        issues.add(fv.file.getFileName()
+            + ": file does not begin at genesis (prev_hash=" + fv.first.prevHash
+            + ") and does not start with rotation_begin — orphan or predecessor missing");
+      }
+    }
+
+    // HWM confrontation
+    if (anchorPath != null) {
+      HwmVerdict v = checkAnchor(anchorPath, publicKey, perFile);
+      if (v.fail != null) issues.add(v.fail);
+      if (v.warn != null) warnings.add(v.warn);
+    }
+
+    ChainResult.Level level;
+    if (!issues.isEmpty())        level = ChainResult.Level.FAIL;
+    else if (!warnings.isEmpty()) level = ChainResult.Level.WARN;
+    else                          level = ChainResult.Level.OK;
+
+    return new ChainResult(level, files.size(), totalEntries, perFile, issues, warnings);
+  }
+
+  private static final class HwmVerdict {
+    final String fail;
+    final String warn;
+    HwmVerdict(String fail, String warn) { this.fail = fail; this.warn = warn; }
+  }
+
+  /**
+   * Compare the on-disk anchor against the observed journal state.
+   * Reads and parses the anchor inline (no {@link KeyManager} needed
+   * here — {@link HighWaterMark#verify} is a static crypto check).
+   */
+  private static HwmVerdict checkAnchor(Path anchorPath, PublicKey publicKey,
+                                        List<FileVerification> perFile) {
+    if (!Files.exists(anchorPath)) {
+      // Absent anchor plus present queue: possible tail wipe (attacker
+      // took the anchor along with the last files). Absent anchor plus
+      // empty queue: legitimate fresh install. We warn on the first
+      // case, stay silent on the second.
+      if (perFile.isEmpty()) {
+        return new HwmVerdict(null, null);
+      }
+      return new HwmVerdict(null,
+          "HWM anchor missing at " + anchorPath + " while "
+          + perFile.size() + " journal file(s) exist — "
+          + "verify the anchor was not wiped along with a truncated tail");
+    }
+
+    HighWaterMark.Snapshot snap;
+    try {
+      String content = Files.readString(anchorPath, StandardCharsets.UTF_8);
+      JSONObject o = new JSONObject(content);
+      snap = new HighWaterMark.Snapshot(
+          o.getString("last_entry_hash"),
+          o.getLong("last_seq"),
+          o.getString("last_file"),
+          o.getString("last_ts_utc"),
+          o.getString("signature"));
+    } catch (Exception e) {
+      return new HwmVerdict("HWM anchor at " + anchorPath
+          + " is unparseable: " + e.getMessage(), null);
+    }
+
+    if (!HighWaterMark.verify(snap, publicKey)) {
+      return new HwmVerdict(
+          "HWM signature invalid — anchor tampered, signed by a foreign key, "
+          + "or archived-key file signed by an older Ed25519 pair (Phase 2)",
+          null);
+    }
+
+    Optional<FileVerification> referenced = perFile.stream()
+        .filter(fv -> fv.file.getFileName().toString().equals(snap.lastFile))
+        .findFirst();
+    if (referenced.isEmpty()) {
+      return new HwmVerdict("HWM references last_file=" + snap.lastFile
+          + " which is missing from the journal directory — tail truncation detected",
+          null);
+    }
+    FileVerification refFv = referenced.get();
+
+    if (refFv.last == null) {
+      return new HwmVerdict("HWM references " + snap.lastFile
+          + " but that file has no entries", null);
+    }
+
+    if (refFv.last.seq < snap.lastSeq) {
+      return new HwmVerdict("HWM says last_seq=" + snap.lastSeq
+          + " in " + snap.lastFile + " but the file only reaches seq="
+          + refFv.last.seq + " — partial truncation of the last file",
+          null);
+    }
+    if (refFv.last.seq == snap.lastSeq
+        && !refFv.last.entryHash.equals(snap.lastEntryHash)) {
+      return new HwmVerdict("HWM says last_entry_hash=" + snap.lastEntryHash
+          + " at seq=" + snap.lastSeq + " in " + snap.lastFile
+          + " but the actual hash is " + refFv.last.entryHash
+          + " — the last entry was rewritten",
+          null);
+    }
+    if (refFv.last.seq > snap.lastSeq) {
+      // Legitimate lag: writeLine succeeded but the follow-up HWM
+      // update failed (disk full, permissions), or the queue advanced
+      // between the anchor write and this verify. Chain itself is
+      // intact, warn only.
+      return new HwmVerdict(null,
+          "HWM lags actual queue in " + snap.lastFile
+          + ": anchor at seq=" + snap.lastSeq
+          + ", file reaches seq=" + refFv.last.seq);
+    }
+
+    return new HwmVerdict(null, null);
   }
 
   public static PublicKey loadPublicKey(Path pubPath) throws Exception {

--- a/MCP/src/main/java/org/sikuli/mcp/audit/JournalWriter.java
+++ b/MCP/src/main/java/org/sikuli/mcp/audit/JournalWriter.java
@@ -95,12 +95,27 @@ public final class JournalWriter implements AutoCloseable {
                                                 String toolName,
                                                 JSONObject args,
                                                 String resultSha256) throws IOException {
-    maybeEmitClockRegression();
+    // Order matters: rotate BEFORE emitting a clock regression, not
+    // after. If the wall clock has regressed and we emit the marker
+    // first, the marker lands in the old file — then rotate opens a
+    // new file where the very next tsUtc may still be regressive
+    // against nothing (empty new file), but hides the regression
+    // relative to the old file's tail. Rotating first anchors the
+    // regression marker in the new file, so both files stay internally
+    // monotonic and the invariant the guard exists to protect holds.
     maybeRotate();
+    maybeEmitClockRegression();
+
+    // Redact sensitive values in args before signing. The journal is
+    // append-only and signed for life — a password in a tool_call arg
+    // would live forever in plaintext. ArgsRedactor keeps structure
+    // and marks redacted values with a short SHA-256 fingerprint so
+    // auditors can still correlate identical values across entries.
+    JSONObject safeArgs = ArgsRedactor.redact(args);
 
     AuditEntry entry = buildEntry(
         AuditEntry.Type.TOOL_CALL, sessionId, clientInfo, llmInfo,
-        toolName, args, resultSha256, null);
+        toolName, safeArgs, resultSha256, null);
     writeLine(entry);
     return entry;
   }

--- a/MCP/src/main/java/org/sikuli/mcp/audit/JournalWriter.java
+++ b/MCP/src/main/java/org/sikuli/mcp/audit/JournalWriter.java
@@ -30,6 +30,13 @@ import java.util.concurrent.atomic.AtomicLong;
  * marker whose {@code prev_hash} chains to the previous marker.
  *
  * <p>Thread-safety: all public methods are synchronized on {@code this}.
+ *
+ * <p>An optional {@link HighWaterMark} anchor can be injected: when present,
+ * it is updated after every successful line write so an external verifier
+ * can detect tail truncation (removal of the last N files) that neither
+ * intra-file {@code prev_hash} nor cross-file rotation markers can catch.
+ * Passing {@code null} keeps the legacy behaviour and is honoured by the
+ * pre-existing four-argument constructor for backward compatibility.
  * @author Julien Mer (julienmerconsulting)
  * @author Claude (Anthropic)
  * @since 3.0.3
@@ -43,6 +50,7 @@ public final class JournalWriter implements AutoCloseable {
   private final KeyManager keys;
   private final long maxEntries;
   private final long maxAgeMillis;
+  private final HighWaterMark hwm;
 
   private final ClockGuard clock = new ClockGuard();
   private final AtomicLong seq = new AtomicLong(0);
@@ -52,12 +60,29 @@ public final class JournalWriter implements AutoCloseable {
   private String prevHash = "0".repeat(64); // genesis
   private long fileStartMillis;
 
+  /**
+   * Legacy constructor without HWM. Delegates to the five-argument form
+   * with {@code hwm = null}; behaviour is bit-identical to the pre-HWM
+   * writer so existing tests and callers keep passing unchanged.
+   */
   public JournalWriter(Path journalDir, KeyManager keys,
                        long maxEntries, long maxAgeMillis) throws IOException {
+    this(journalDir, keys, maxEntries, maxAgeMillis, null);
+  }
+
+  /**
+   * @param hwm optional anchor updated after each write. May be {@code null};
+   *            wire an instance in production so tail truncation becomes
+   *            detectable.
+   */
+  public JournalWriter(Path journalDir, KeyManager keys,
+                       long maxEntries, long maxAgeMillis,
+                       HighWaterMark hwm) throws IOException {
     this.journalDir = journalDir;
     this.keys = keys;
     this.maxEntries = maxEntries;
     this.maxAgeMillis = maxAgeMillis;
+    this.hwm = hwm;
     Files.createDirectories(journalDir);
     openNewFile();
   }
@@ -88,6 +113,40 @@ public final class JournalWriter implements AutoCloseable {
         null, null, null, extra);
     writeLine(entry);
     clock.acknowledge();
+    return entry;
+  }
+
+  /**
+   * Emit a signed {@code RECOVERY_GAP} entry declaring that the previous
+   * chain is unrecoverable and that a fresh chain starts here under the
+   * currently-configured key. The entry's {@code prev_hash} is forced back
+   * to genesis so a chain verifier can identify a legitimate cold restart
+   * without having to trust any file next to the journal.
+   *
+   * <p>Intended to be called immediately after key promotion by
+   * {@code cmdRecover}, as the first line of a new journal file. It skips
+   * both {@code maybeEmitClockRegression} and {@code maybeRotate} because
+   * neither is meaningful on a chain that has just been declared lost.
+   *
+   * @param reason               short operator-facing motive (e.g. {@code "key_lost"})
+   * @param brokenAt             ISO-8601 timestamp of the last known good
+   *                             state, or {@code null} if unknown
+   * @param previousChainStatus  one of {@code "lost"}, {@code "corrupted"},
+   *                             {@code "abandoned"}; free-form for now
+   */
+  public synchronized AuditEntry appendRecoveryGap(String reason,
+                                                   String brokenAt,
+                                                   String previousChainStatus) throws IOException {
+    this.prevHash = "0".repeat(64);
+    JSONObject extra = new JSONObject()
+        .put("reason", reason == null ? JSONObject.NULL : reason)
+        .put("broken_at", brokenAt == null ? JSONObject.NULL : brokenAt)
+        .put("previous_chain_status",
+            previousChainStatus == null ? JSONObject.NULL : previousChainStatus);
+    AuditEntry entry = buildEntry(
+        AuditEntry.Type.RECOVERY_GAP, null, null, null,
+        null, null, null, extra);
+    writeLine(entry);
     return entry;
   }
 
@@ -160,6 +219,15 @@ public final class JournalWriter implements AutoCloseable {
     out.write(entry.toJsonLine());
     out.newLine();
     out.flush();
+    if (hwm != null) {
+      // The anchor tracks the last successfully-written entry. If this call
+      // fails (disk full, permissions), the exception propagates and the
+      // anchor stays one entry behind — a state a chain verifier can spot
+      // as "queue extends past HWM" and surface as a warning, not a fatal
+      // tamper. Silent swallow here would defeat the point.
+      hwm.update(entry.entryHash, entry.seq,
+          currentFile.getFileName().toString(), entry.tsUtc);
+    }
   }
 
   private void maybeEmitClockRegression() throws IOException {

--- a/MCP/src/main/java/org/sikuli/mcp/cli/Main.java
+++ b/MCP/src/main/java/org/sikuli/mcp/cli/Main.java
@@ -99,8 +99,9 @@ public final class Main {
 
     OcrBootstrap.applyDefaultLanguage();
 
+    HighWaterMark hwm = new HighWaterMark(defaultHwmPath(oculixDir), keys);
     try (JournalWriter journal = new JournalWriter(journalDir, keys,
-             MAX_ENTRIES_PER_FILE, MAX_AGE_MILLIS)) {
+             MAX_ENTRIES_PER_FILE, MAX_AGE_MILLIS, hwm)) {
       McpServer server = new McpServer(
           ToolRegistry.defaultRegistry(),
           new AutoApproveGate(),
@@ -176,8 +177,9 @@ public final class Main {
     ToolRegistry.Mode mode = ToolRegistry.Mode.fromEnv();
     ToolRegistry registry = ToolRegistry.defaultRegistry(mode);
 
+    HighWaterMark hwm = new HighWaterMark(defaultHwmPath(oculixDir), keys);
     try (JournalWriter journal = new JournalWriter(journalDir, keys,
-             MAX_ENTRIES_PER_FILE, MAX_AGE_MILLIS)) {
+             MAX_ENTRIES_PER_FILE, MAX_AGE_MILLIS, hwm)) {
       McpDispatcher dispatcher = new McpDispatcher(
           registry, new AutoApproveGate(), journal);
       SessionStore sessions = new SessionStore();
@@ -262,9 +264,18 @@ public final class Main {
     Path stagingDir = oculixDir.resolve("staging-" + System.currentTimeMillis());
     KeyManager newKeys = KeyManager.generateAndStore(stagingDir);
 
+    // Anchor lives in oculixDir so it survives the archive/promote below.
+    // The rotate() call writes rotation_end + rotation_begin — the HWM
+    // hook re-signs the anchor after each writeLine with the outgoing key.
+    // We resign it with the incoming key at the end of this method so the
+    // next verify sees a chain-anchor pair that agrees on the current
+    // public key.
+    Path anchorPath = defaultHwmPath(oculixDir);
+    HighWaterMark hwmOld = new HighWaterMark(anchorPath, oldKeys);
+
     // Write rotation_end marker to the current journal, signed by the OLD key
     try (JournalWriter journal = new JournalWriter(journalDir, oldKeys,
-             Long.MAX_VALUE, Long.MAX_VALUE)) {
+             Long.MAX_VALUE, Long.MAX_VALUE, hwmOld)) {
       journal.rotate("manual_rotation", newKeys.publicKeySha256Hex());
     }
 
@@ -281,8 +292,20 @@ public final class Main {
     KeyManager.restrictPrivate(privKey);
     Files.deleteIfExists(stagingDir);
 
+    // Re-sign the anchor under the newly-promoted key. Same four fields
+    // as the rotate() call wrote — we are not moving the anchor, just
+    // switching whose signature vouches for it. Without this step the
+    // next verify would read a HWM signed by the archived key and
+    // misread the fresh chain as tampered.
+    HighWaterMark.Snapshot afterRotate = hwmOld.load().orElseThrow(() ->
+        new IllegalStateException("HWM disappeared between rotate write and re-sign"));
+    HighWaterMark hwmNew = new HighWaterMark(anchorPath, KeyManager.loadOrInit(oculixDir));
+    hwmNew.reset(afterRotate.lastEntryHash, afterRotate.lastSeq,
+        afterRotate.lastFile, afterRotate.lastTsUtc);
+
     System.out.println("Key rotated successfully.");
     System.out.println("Old key archived to " + archiveDir);
+    System.out.println("Anchor re-signed under new key: " + anchorPath);
     System.out.println("New public key SHA-256: " + newKeys.publicKeySha256Hex());
   }
 

--- a/MCP/src/main/java/org/sikuli/mcp/cli/Main.java
+++ b/MCP/src/main/java/org/sikuli/mcp/cli/Main.java
@@ -21,6 +21,7 @@ import org.sikuli.mcp.transport.TokenIssuer;
 
 import java.nio.file.*;
 import java.security.PublicKey;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Comparator;
 import java.util.List;
@@ -365,18 +366,113 @@ public final class Main {
 
   // ── verify ──
 
+  /**
+   * Verify the audit chain.
+   *
+   * <p>Default mode (no flags): full chain verification via
+   * {@link JournalVerifier#verifyChain}. Every {@code audit-*.jsonl} in
+   * the journal directory is checked per-file, cross-file rotation
+   * links are resolved by hash lookup (not filename order), file heads
+   * are checked to start at genesis or at a resolved
+   * {@code rotation_begin}, and the {@link HighWaterMark} anchor is
+   * confronted to catch tail truncation.
+   *
+   * <p>{@code --per-file}: legacy single-file check only. Useful when
+   * debugging one file in isolation, or in Phase 1 when some files
+   * were signed by an archived key that {@code verify} does not yet
+   * load — those would fail signature under the current key but are
+   * clean under their original key.
+   *
+   * <p>Explicit paths after the command switch straight to per-file
+   * mode on the named files, whether or not {@code --per-file} is
+   * passed.
+   *
+   * <p>Exit codes (default chain mode): {@code 0} clean, {@code 2}
+   * soft warnings (anchor lags queue, empty dir with anchor present),
+   * {@code 1} hard fail (tamper, truncation, orphan file, unresolved
+   * cross-file link). Precedence is deterministic: {@code 1 > 2 > 0}.
+   * Legacy per-file mode exits {@code 1} on any failure.
+   */
   private static void cmdVerify(String[] args) throws Exception {
     Path oculixDir = StartupCheck.defaultOculixDir();
     Path pubKeyPath = oculixDir.resolve(KeyManager.PUBLIC_KEY_FILENAME);
 
-    List<Path> files;
-    if (args.length == 0) {
-      Path journalDir = StartupCheck.defaultJournalDir();
-      if (!Files.isDirectory(journalDir)) {
-        System.err.println("No journal directory at " + journalDir);
-        System.exit(5);
+    boolean perFileMode = false;
+    List<String> pathArgs = new ArrayList<>();
+    for (String a : args) {
+      if ("--per-file".equals(a)) {
+        perFileMode = true;
+      } else if (a.startsWith("--")) {
+        System.err.println("Unknown verify flag: " + a);
+        System.exit(1);
         return;
+      } else {
+        pathArgs.add(a);
       }
+    }
+
+    Path journalDir = StartupCheck.defaultJournalDir();
+    if (!Files.isDirectory(journalDir) && pathArgs.isEmpty()) {
+      System.err.println("No journal directory at " + journalDir);
+      System.exit(5);
+      return;
+    }
+
+    PublicKey pub = JournalVerifier.loadPublicKey(pubKeyPath);
+
+    if (perFileMode || !pathArgs.isEmpty()) {
+      runPerFileMode(journalDir, pathArgs, pub);
+      return;
+    }
+
+    // Default: chain verification with HWM confrontation.
+    Path anchorPath = defaultHwmPath(oculixDir);
+    JournalVerifier.ChainResult r =
+        JournalVerifier.verifyChain(journalDir, pub, anchorPath);
+
+    System.out.println("Chain verification of " + journalDir);
+    System.out.println("  files checked:   " + r.filesChecked);
+    System.out.println("  entries checked: " + r.entriesChecked);
+    System.out.println("  anchor:          " + anchorPath);
+    System.out.println();
+    for (JournalVerifier.FileVerification fv : r.perFile) {
+      String tag = fv.result.ok ? "OK  " : "FAIL";
+      System.out.println("  " + tag + "  " + fv.file.getFileName()
+          + "  (" + fv.result.entriesChecked + " entries)");
+    }
+    if (!r.warnings.isEmpty()) {
+      System.out.println();
+      System.out.println("WARNINGS:");
+      for (String w : r.warnings) System.out.println("  ! " + w);
+    }
+    if (!r.issues.isEmpty()) {
+      System.out.println();
+      System.out.println("ISSUES:");
+      for (String iss : r.issues) System.out.println("  X " + iss);
+    }
+
+    System.out.println();
+    switch (r.level) {
+      case OK:
+        System.out.println("VERDICT: OK — chain intact, anchor agrees.");
+        System.exit(0);
+        break;
+      case WARN:
+        System.out.println("VERDICT: WARN — soft deviation, chain structurally intact.");
+        System.exit(2);
+        break;
+      case FAIL:
+        System.out.println("VERDICT: FAIL — tamper, truncation, or orphan file detected.");
+        System.out.println("(Rerun `verify --per-file <file>` on individual files for detail.)");
+        System.exit(1);
+        break;
+    }
+  }
+
+  private static void runPerFileMode(Path journalDir, List<String> pathArgs,
+                                     PublicKey pub) throws Exception {
+    List<Path> files;
+    if (pathArgs.isEmpty()) {
       try (Stream<Path> s = Files.list(journalDir)) {
         files = s.filter(p -> p.getFileName().toString().startsWith("audit-")
                            && p.getFileName().toString().endsWith(".jsonl"))
@@ -384,10 +480,9 @@ public final class Main {
                  .collect(Collectors.toList());
       }
     } else {
-      files = Arrays.stream(args).map(Paths::get).collect(Collectors.toList());
+      files = pathArgs.stream().map(Paths::get).collect(Collectors.toList());
     }
 
-    PublicKey pub = JournalVerifier.loadPublicKey(pubKeyPath);
     boolean allOk = true;
     for (Path f : files) {
       JournalVerifier.Result r = JournalVerifier.verify(f, pub);
@@ -401,7 +496,7 @@ public final class Main {
         }
       }
     }
-    if (!allOk) System.exit(6);
+    if (!allOk) System.exit(1);
   }
 
   private static void printUsage() {
@@ -422,8 +517,11 @@ public final class Main {
     System.out.println("  oculix-mcp rotate-key            Rotate the Ed25519 audit signing key");
     System.out.println("  oculix-mcp rotate-session-key    Rotate the HMAC keyring for session tokens");
     System.out.println("  oculix-mcp recover      Record an unsigned gap and start a fresh chain");
-    System.out.println("  oculix-mcp verify [FILES...]");
-    System.out.println("                          Verify journal files (all by default)");
+    System.out.println("  oculix-mcp verify [--per-file] [FILES...]");
+    System.out.println("                          Default: full chain verification with anchor check");
+    System.out.println("                          --per-file: legacy single-file mode (opt-in)");
+    System.out.println("                          Named FILES imply per-file mode");
+    System.out.println("                          Exit codes: 0 clean, 2 warn (soft), 1 fail (hard)");
     System.out.println();
     System.out.println("Config dir: " + StartupCheck.defaultOculixDir());
     System.out.println("Journal dir: " + StartupCheck.defaultJournalDir());

--- a/MCP/src/main/java/org/sikuli/mcp/cli/Main.java
+++ b/MCP/src/main/java/org/sikuli/mcp/cli/Main.java
@@ -25,6 +25,10 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Set;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -189,8 +193,33 @@ public final class Main {
           oculixDir.resolve("session-hmac-keyring.json"));
       TokenIssuer issuer = new TokenIssuer(keyring);
 
+      // Session purge scheduler. Without this, in an HTTP long-running
+      // process every `initialize` adds an entry to the SessionStore's
+      // ConcurrentHashMap and only DELETE /mcp removes it. Any client
+      // that crashes, kill -9s, or drops the socket leaves an entry
+      // behind for good — the RAM grows monotonically. We sweep
+      // expired sessions every 5 minutes.
+      ScheduledExecutorService purgeExec = Executors.newSingleThreadScheduledExecutor(r -> {
+        Thread t = new Thread(r, "oculix-mcp-session-purge");
+        t.setDaemon(true);
+        return t;
+      });
+      purgeExec.scheduleAtFixedRate(() -> {
+        try {
+          int dropped = sessions.purgeExpired(System.currentTimeMillis() / 1000L);
+          if (dropped > 0) {
+            System.err.println("[oculix-mcp] purged " + dropped + " expired session(s)");
+          }
+        } catch (Throwable t) {
+          // Never let a purge failure kill the scheduler thread.
+          System.err.println("[oculix-mcp] session purge error: " + t);
+        }
+      }, 5, 5, TimeUnit.MINUTES);
+
+      Set<String> allowedOrigins = parseAllowedOrigins(
+          System.getenv("OCULIX_MCP_ALLOWED_ORIGINS"));
       HttpTransport http = new HttpTransport(dispatcher, sessions, issuer,
-          clientToken, host, port);
+          clientToken, host, port, allowedOrigins);
       http.start();
 
       int bound = http.boundPort();
@@ -201,16 +230,36 @@ public final class Main {
       System.err.println("[oculix-mcp] session tokens: HMAC-SHA256, kid=" + keyring.currentKid()
           + " (" + keyring.size() + " kid(s) in ring)");
       System.err.println("[oculix-mcp] token TTL: " + HttpTransport.DEFAULT_TOKEN_TTL_SECONDS + "s");
+      System.err.println("[oculix-mcp] Origin allowlist: "
+          + (allowedOrigins.isEmpty()
+              ? "empty (any non-null Origin will be refused)"
+              : allowedOrigins.toString()));
+      System.err.println("[oculix-mcp] session purge: every 5 min");
 
       // Block the main thread; shutdown on Ctrl-C / SIGTERM.
       Thread shutdown = new Thread(() -> {
         try { http.close(); } catch (Exception ignored) {}
+        purgeExec.shutdownNow();
       }, "oculix-mcp-shutdown");
       Runtime.getRuntime().addShutdownHook(shutdown);
 
       // Park forever.
       synchronized (http) { http.wait(); }
     }
+  }
+
+  /**
+   * Parse a comma-separated allowlist of Origin values from an env var.
+   * Whitespace around entries is trimmed; empty entries dropped. An empty
+   * or null env var yields an empty set — the strictest possible policy
+   * (any non-null Origin will be refused by the transport).
+   */
+  static Set<String> parseAllowedOrigins(String envValue) {
+    if (envValue == null || envValue.isBlank()) return Set.of();
+    return Arrays.stream(envValue.split(","))
+        .map(String::trim)
+        .filter(s -> !s.isEmpty())
+        .collect(Collectors.toUnmodifiableSet());
   }
 
   // ── rotate-session-key ──

--- a/MCP/src/main/java/org/sikuli/mcp/cli/Main.java
+++ b/MCP/src/main/java/org/sikuli/mcp/cli/Main.java
@@ -3,6 +3,7 @@
  */
 package org.sikuli.mcp.cli;
 
+import org.sikuli.mcp.audit.HighWaterMark;
 import org.sikuli.mcp.audit.JournalVerifier;
 import org.sikuli.mcp.audit.JournalWriter;
 import org.sikuli.mcp.crypto.KeyManager;
@@ -46,6 +47,17 @@ public final class Main {
   // Rotation thresholds — can be tuned later via env vars
   private static final long MAX_ENTRIES_PER_FILE = 10_000L;
   private static final long MAX_AGE_MILLIS = 24 * 60 * 60 * 1000L; // 24h
+
+  // Signed anchor file. Lives in oculixDir (next to the key files), not in
+  // journalDir: a cosmetic wipe of journalDir alone leaves the HWM behind
+  // so the missing tail becomes detectable. A wipe of the whole oculixDir
+  // takes the HWM with it and cannot be caught in Phase 1 — documented in
+  // the README, external anchor is the Phase 2 answer.
+  static final String HWM_ANCHOR_FILENAME = "journal.hwm";
+
+  static Path defaultHwmPath(Path oculixDir) {
+    return oculixDir.resolve(HWM_ANCHOR_FILENAME);
+  }
 
   public static void main(String[] rawArgs) throws Exception {
     String[] args = rawArgs == null ? new String[0] : rawArgs;
@@ -281,12 +293,18 @@ public final class Main {
     Path journalDir = StartupCheck.defaultJournalDir();
 
     Files.createDirectories(journalDir);
+
+    // Human-readable artefact only — the verifier ignores .txt files and
+    // anchors solely on the signed RECOVERY_GAP entry written below. Kept
+    // for operators skimming the directory with a file browser.
     String ts = String.valueOf(System.currentTimeMillis());
     Path gap = journalDir.resolve("UNSIGNED_GAP-" + ts + ".txt");
     Files.writeString(gap,
         "Audit chain broken at " + java.time.Instant.now() + ".\n"
             + "Reason: operator-initiated recovery (key lost or chain corruption).\n"
-            + "Subsequent entries start a fresh chain under a new Ed25519 key pair.\n",
+            + "Subsequent entries start a fresh chain under a new Ed25519 key pair.\n"
+            + "The verifier anchors on the signed RECOVERY_GAP entry in the next\n"
+            + "audit-*.jsonl, not on this file.\n",
         StandardOpenOption.CREATE_NEW);
 
     // Wipe existing keys if any — recovery means we accept the break
@@ -298,8 +316,26 @@ public final class Main {
     // Generate a fresh pair
     KeyManager fresh = KeyManager.generateAndStore(oculixDir);
 
+    // Anchor + journal writer are both bound to the NEW key. The
+    // appendRecoveryGap call below writes the signed break declaration
+    // AND re-signs the HWM under the new key via the writer's HWM hook,
+    // so the next verify reads a fully-consistent chain and anchor.
+    Path anchorPath = defaultHwmPath(oculixDir);
+    HighWaterMark hwm = new HighWaterMark(anchorPath, fresh);
+    Path recoveryJournal;
+    try (JournalWriter writer = new JournalWriter(
+        journalDir, fresh, MAX_ENTRIES_PER_FILE, MAX_AGE_MILLIS, hwm)) {
+      writer.appendRecoveryGap(
+          "operator_recovery",
+          java.time.Instant.now().toString(),
+          "lost");
+      recoveryJournal = writer.currentFile();
+    }
+
     System.out.println("Recovery complete.");
-    System.out.println("Unsigned gap marker: " + gap);
+    System.out.println("Signed RECOVERY_GAP written to: " + recoveryJournal);
+    System.out.println("Informational artefact:         " + gap);
+    System.out.println("Anchor re-signed under new key: " + anchorPath);
     System.out.println("Fresh key pair generated.");
     System.out.println("New public key SHA-256: " + fresh.publicKeySha256Hex());
   }

--- a/MCP/src/main/java/org/sikuli/mcp/server/McpDispatcher.java
+++ b/MCP/src/main/java/org/sikuli/mcp/server/McpDispatcher.java
@@ -12,6 +12,9 @@ import org.sikuli.mcp.tools.ScreenLock;
 import org.sikuli.mcp.tools.Tool;
 import org.sikuli.mcp.tools.ToolRegistry;
 
+import java.io.InputStream;
+import java.util.Properties;
+
 /**
  * Transport-agnostic dispatcher for MCP JSON-RPC messages.
  *
@@ -31,7 +34,35 @@ public final class McpDispatcher {
 
   public static final String PROTOCOL_VERSION = "2024-11-05";
   public static final String SERVER_NAME = "oculix-mcp-server";
-  public static final String SERVER_VERSION = "3.0.1";
+  /**
+   * Runtime-detected server version, sourced from the Maven-generated
+   * {@code META-INF/maven/.../pom.properties} that ships in every jar
+   * (falls back to the JAR manifest's {@code Implementation-Version},
+   * then to a dev sentinel). Prevents the class from drifting away
+   * from the pom version by hand-editing.
+   */
+  public static final String SERVER_VERSION = detectServerVersion();
+
+  static String detectServerVersion() {
+    // 1. Maven auto-generated pom.properties (present in every packaged jar)
+    try (InputStream in = McpDispatcher.class.getResourceAsStream(
+        "/META-INF/maven/io.github.oculix-org/oculixmcp/pom.properties")) {
+      if (in != null) {
+        Properties p = new Properties();
+        p.load(in);
+        String v = p.getProperty("version");
+        if (v != null && !v.isBlank()) return v;
+      }
+    } catch (Exception ignored) { }
+    // 2. Manifest Implementation-Version (also present in every jar)
+    Package pkg = McpDispatcher.class.getPackage();
+    if (pkg != null) {
+      String v = pkg.getImplementationVersion();
+      if (v != null && !v.isBlank()) return v;
+    }
+    // 3. Dev/test sentinel
+    return "0.0.0-dev";
+  }
 
   private final ToolRegistry tools;
   private final ActionGate gate;
@@ -73,6 +104,17 @@ public final class McpDispatcher {
       return JsonRpc.error(id, JsonRpc.INVALID_REQUEST, "Missing 'method'");
     }
 
+    // Any tools/* call before initialize must be rejected — it used to
+    // slip through under a random UUID minted by SessionContext.empty(),
+    // which polluted the audit journal with phantom sessions that never
+    // existed at the protocol level. initialize, ping and notifications
+    // are always allowed (ping = heartbeat, notifications are one-way).
+    if (method.startsWith("tools/") && !handle.get().initialized) {
+      return JsonRpc.error(id, JsonRpc.INVALID_REQUEST,
+          "Call " + method + " received before initialize; "
+          + "call initialize first per MCP protocol.");
+    }
+
     switch (method) {
       case "initialize":
         return handleInitialize(id, params, handle);
@@ -95,8 +137,15 @@ public final class McpDispatcher {
     JSONObject clientInfo = params.optJSONObject("clientInfo");
     handle.set(SessionContext.newSession(clientInfo, extractLlmInfo(params)));
 
+    // Protocol version negotiation: honour the client's proposal if we
+    // support it, otherwise fall back to our own and warn so the operator
+    // sees the mismatch. Silent divergence is the silent failure this
+    // fix removes.
+    String clientProposed = params.optString("protocolVersion", null);
+    String negotiated = negotiateProtocolVersion(clientProposed);
+
     JSONObject result = new JSONObject()
-        .put("protocolVersion", PROTOCOL_VERSION)
+        .put("protocolVersion", negotiated)
         .put("serverInfo", new JSONObject()
             .put("name", SERVER_NAME)
             .put("version", SERVER_VERSION))
@@ -104,6 +153,29 @@ public final class McpDispatcher {
             .put("tools", new JSONObject()));
     return JsonRpc.result(id, result);
   }
+
+  /**
+   * Return the version to advertise back to the client. If the client
+   * proposed one we support, we echo it back (that is what MCP clients
+   * expect for the negotiated response). Otherwise fall back to our
+   * canonical version and log a warning to stderr so operators see the
+   * skew instead of it happening silently.
+   */
+  public static String negotiateProtocolVersion(String clientProposed) {
+    if (clientProposed == null || clientProposed.isBlank()) {
+      return PROTOCOL_VERSION;
+    }
+    for (String supported : SUPPORTED_PROTOCOL_VERSIONS) {
+      if (supported.equals(clientProposed)) return clientProposed;
+    }
+    System.err.println("[oculix-mcp] WARN: client proposed protocolVersion=\""
+        + clientProposed + "\" which we do not support; responding with \""
+        + PROTOCOL_VERSION + "\". A future MCP client bump may need this "
+        + "server updated.");
+    return PROTOCOL_VERSION;
+  }
+
+  private static final String[] SUPPORTED_PROTOCOL_VERSIONS = { PROTOCOL_VERSION };
 
   private JSONObject handleToolsCall(Object id, JSONObject params, SessionHandle handle) {
     String toolName = params.optString("name", null);

--- a/MCP/src/main/java/org/sikuli/mcp/server/McpDispatcher.java
+++ b/MCP/src/main/java/org/sikuli/mcp/server/McpDispatcher.java
@@ -3,12 +3,14 @@
  */
 package org.sikuli.mcp.server;
 
+import org.json.JSONArray;
 import org.json.JSONObject;
 import org.sikuli.mcp.audit.JournalWriter;
 import org.sikuli.mcp.crypto.Hashing;
 import org.sikuli.mcp.gate.ActionGate;
 import org.sikuli.mcp.gate.GateDecision;
 import org.sikuli.mcp.tools.ScreenLock;
+import org.sikuli.mcp.tools.SubstitutionVault;
 import org.sikuli.mcp.tools.Tool;
 import org.sikuli.mcp.tools.ToolRegistry;
 
@@ -104,12 +106,13 @@ public final class McpDispatcher {
       return JsonRpc.error(id, JsonRpc.INVALID_REQUEST, "Missing 'method'");
     }
 
-    // Any tools/* call before initialize must be rejected — it used to
-    // slip through under a random UUID minted by SessionContext.empty(),
-    // which polluted the audit journal with phantom sessions that never
-    // existed at the protocol level. initialize, ping and notifications
+    // Any tools/* or vault/* call before initialize must be rejected —
+    // tools/* used to slip through under a random UUID minted by
+    // SessionContext.empty(), and vault/* would leak into a phantom
+    // session with no lifecycle. initialize, ping and notifications
     // are always allowed (ping = heartbeat, notifications are one-way).
-    if (method.startsWith("tools/") && !handle.get().initialized) {
+    if ((method.startsWith("tools/") || method.startsWith("vault/"))
+        && !handle.get().initialized) {
       return JsonRpc.error(id, JsonRpc.INVALID_REQUEST,
           "Call " + method + " received before initialize; "
           + "call initialize first per MCP protocol.");
@@ -127,6 +130,8 @@ public final class McpDispatcher {
         return JsonRpc.result(id, new JSONObject().put("tools", tools.listAsJson()));
       case "tools/call":
         return handleToolsCall(id, params, handle);
+      case "vault/wrap":
+        return handleVaultWrap(id, params, handle);
       default:
         if (method.startsWith("notifications/")) return null;
         return JsonRpc.error(id, JsonRpc.METHOD_NOT_FOUND, "Unknown method: " + method);
@@ -204,10 +209,16 @@ public final class McpDispatcher {
       return JsonRpc.result(id, denied);
     }
 
+    // Resolve vault tokens (info1, info2, ...) into real values at the
+    // very last moment. The tool sees the real value; the journal (below)
+    // still logs the pre-resolve args so tokens — not secrets — end up
+    // signed on disk.
+    JSONObject resolvedArgs = resolveVaultTokens(args, handle.vault());
+
     JSONObject result;
     screenLock.lock();
     try {
-      result = tool.call(args);
+      result = tool.call(resolvedArgs);
     } catch (Exception e) {
       result = Tool.errorResult(e.getClass().getSimpleName() + ": " + e.getMessage());
     } finally {
@@ -216,6 +227,62 @@ public final class McpDispatcher {
 
     auditSafely(handle.get(), toolName, args, result);
     return JsonRpc.result(id, result);
+  }
+
+  /**
+   * Handle a {@code vault/wrap} JSON-RPC request. The client (a data-
+   * driven test harness) passes a real value that must never enter the
+   * LLM. The server stores it in the session-scoped vault and returns
+   * the opaque token the harness will inject into the LLM prompt
+   * instead. See {@link SubstitutionVault} for the threat model.
+   */
+  private JSONObject handleVaultWrap(Object id, JSONObject params, SessionHandle handle) {
+    if (!params.has("value")) {
+      return JsonRpc.error(id, JsonRpc.INVALID_PARAMS,
+          "vault/wrap requires params.value");
+    }
+    Object raw = params.opt("value");
+    if (raw == null || raw == JSONObject.NULL) {
+      return JsonRpc.error(id, JsonRpc.INVALID_PARAMS,
+          "vault/wrap params.value must not be null");
+    }
+    String token = handle.vault().wrap(raw.toString());
+    return JsonRpc.result(id, new JSONObject().put("token", token));
+  }
+
+  /**
+   * Deep-walk {@code args} and substitute any string that is a
+   * registered vault token with its real value. Non-string leaves and
+   * unregistered strings pass through unchanged. Returns a fresh
+   * {@link JSONObject} — the input is not mutated so the journal can
+   * still log the pre-resolve form.
+   */
+  static JSONObject resolveVaultTokens(JSONObject args, SubstitutionVault vault) {
+    if (args == null || vault == null) return args;
+    JSONObject out = new JSONObject();
+    for (String key : args.keySet()) {
+      out.put(key, resolveOne(args.opt(key), vault));
+    }
+    return out;
+  }
+
+  private static Object resolveOne(Object val, SubstitutionVault vault) {
+    if (val instanceof String) {
+      String s = (String) val;
+      return vault.isKnownToken(s) ? vault.resolve(s) : s;
+    }
+    if (val instanceof JSONObject) {
+      return resolveVaultTokens((JSONObject) val, vault);
+    }
+    if (val instanceof JSONArray) {
+      JSONArray in = (JSONArray) val;
+      JSONArray outArr = new JSONArray();
+      for (int i = 0; i < in.length(); i++) {
+        outArr.put(resolveOne(in.opt(i), vault));
+      }
+      return outArr;
+    }
+    return val;
   }
 
   private void auditSafely(SessionContext session, String toolName,

--- a/MCP/src/main/java/org/sikuli/mcp/server/SessionContext.java
+++ b/MCP/src/main/java/org/sikuli/mcp/server/SessionContext.java
@@ -27,30 +27,42 @@ public final class SessionContext {
   public final String sessionId;
   public final JSONObject clientInfo;   // from MCP handshake
   public final JSONObject llmInfo;      // optional, from request _meta
+  public final boolean initialized;     // true once initialize has run
 
-  private SessionContext(String sessionId, JSONObject clientInfo, JSONObject llmInfo) {
+  private SessionContext(String sessionId, JSONObject clientInfo,
+                         JSONObject llmInfo, boolean initialized) {
     this.sessionId = sessionId;
     this.clientInfo = clientInfo;
     this.llmInfo = llmInfo;
+    this.initialized = initialized;
   }
 
   /** Factory that mints a fresh {@code sessionId} — used at initialize time. */
   public static SessionContext newSession(JSONObject clientInfo, JSONObject llmInfo) {
-    return new SessionContext(UUID.randomUUID().toString(), clientInfo, llmInfo);
+    return new SessionContext(UUID.randomUUID().toString(), clientInfo, llmInfo, true);
   }
 
-  /** Empty context for the pre-initialize window. */
+  /**
+   * Empty context for the pre-initialize window. The dispatcher checks
+   * {@link #initialized} rather than trusting a session id: previously
+   * {@code empty()} minted a random UUID, which meant a stray
+   * {@code tools/call} before {@code initialize} would be audited under
+   * a phantom session that never existed at the protocol level.
+   * {@code sessionId} is now {@code null} for the empty context so an
+   * accidental leak stands out.
+   */
   public static SessionContext empty() {
-    return new SessionContext(UUID.randomUUID().toString(), null, null);
+    return new SessionContext(null, null, null, false);
   }
 
   /**
    * Return a copy with {@code llmInfo} replaced, preserving the original
-   * {@code sessionId} and {@code clientInfo}. Crucially, this never mints
-   * a new session id — otherwise every per-request {@code _meta.llm}
-   * would shred session continuity in the audit chain.
+   * {@code sessionId}, {@code clientInfo} and {@code initialized} flag.
+   * Crucially, this never mints a new session id — otherwise every
+   * per-request {@code _meta.llm} would shred session continuity in the
+   * audit chain.
    */
   public SessionContext withLlm(JSONObject llm) {
-    return new SessionContext(this.sessionId, this.clientInfo, llm);
+    return new SessionContext(this.sessionId, this.clientInfo, llm, this.initialized);
   }
 }

--- a/MCP/src/main/java/org/sikuli/mcp/server/SessionHandle.java
+++ b/MCP/src/main/java/org/sikuli/mcp/server/SessionHandle.java
@@ -3,6 +3,8 @@
  */
 package org.sikuli.mcp.server;
 
+import org.sikuli.mcp.tools.SubstitutionVault;
+
 /**
  * Thin mutable holder around a {@link SessionContext}.
  *
@@ -11,6 +13,11 @@ package org.sikuli.mcp.server;
  * rather than passing the context by value lets the dispatcher mutate
  * state transparently for both stdio (single session) and HTTP (many
  * concurrent sessions owned by a {@link SessionStore}).
+ *
+ * <p>Also owns the per-session {@link SubstitutionVault} used to
+ * detokenise PII/secret arguments the LLM operates on as opaque
+ * tokens. The vault is created fresh with the handle and dies with
+ * it — no cross-session leakage.
  *
  * <p>Access is synchronized because an HTTP transport may expose the same
  * handle to overlapping request threads for the same session id.
@@ -21,6 +28,7 @@ package org.sikuli.mcp.server;
 public final class SessionHandle {
 
   private SessionContext ctx;
+  private final SubstitutionVault vault = new SubstitutionVault();
 
   public SessionHandle() {
     this.ctx = SessionContext.empty();
@@ -36,5 +44,10 @@ public final class SessionHandle {
 
   public synchronized void set(SessionContext next) {
     this.ctx = next;
+  }
+
+  /** Session-scoped PII/secret detokeniser. Never null. */
+  public SubstitutionVault vault() {
+    return vault;
   }
 }

--- a/MCP/src/main/java/org/sikuli/mcp/tools/SubstitutionVault.java
+++ b/MCP/src/main/java/org/sikuli/mcp/tools/SubstitutionVault.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright (c) 2010-2026, sikuli.org, sikulix.com, oculix-org - MIT license
+ */
+package org.sikuli.mcp.tools;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.regex.Pattern;
+
+/**
+ * Session-scoped ephemeral tokenisation vault for PII / secret values
+ * that the LLM must never see in plain form.
+ *
+ * <p>Threat model. Consider a data-driven scenario where a test harness
+ * knows the real value of a form field (an email, IBAN, credit-card
+ * number, one-time password). If the harness passes that value into the
+ * LLM prompt so the agent can "type it into the login form", the value
+ * is logged, cached, and potentially exposed by every part of the LLM
+ * pipeline (context stores, tool-use traces, provider-side logging).
+ * The value should never enter the LLM in the first place.
+ *
+ * <p>The vault flips the exposure model: the harness calls {@link #wrap}
+ * once per real value, gets back an opaque token ({@code info1},
+ * {@code info2}, ...), and only the token is injected into the prompt.
+ * The LLM manipulates tokens. When the LLM asks OculiX to type
+ * {@code info1}, the dispatcher resolves it back to the real value at
+ * the last moment, just before the keystroke.
+ *
+ * <p>Scope. The vault is <b>session-scoped</b> — one instance per
+ * {@link org.sikuli.mcp.server.SessionHandle}. A global vault would
+ * leak values across concurrent HTTP sessions in the same process; a
+ * per-request vault would defeat the purpose. Nothing is ever
+ * persisted to disk: the map lives entirely in the process heap and
+ * dies with the session.
+ *
+ * <p>Journal contract. The journal must log the token, never the
+ * resolved value. {@link #wrap} deduplicates so identical values share
+ * a token — the auditor can still correlate identical secrets across
+ * entries without ever reading them.
+ *
+ * <p>Where the wrap happens. The wrap must be performed by the
+ * component that prepares the LLM context (the data-driven test
+ * harness, the scenario runner). The MCP server is downstream of the
+ * LLM in the request path — it cannot hide from the model a value the
+ * model has already spoken. See the {@code vault/wrap} JSON-RPC method
+ * in {@code McpDispatcher} for the endpoint clients call before
+ * building their prompt.
+ *
+ * <p>Thread-safety: all methods are {@code synchronized}. The
+ * wrap counter is an {@link AtomicInteger} for read-mostly reporting.
+ *
+ * @author Julien Mer (julienmerconsulting)
+ * @author Claude (Anthropic)
+ * @since 4.0.1
+ */
+public final class SubstitutionVault {
+
+  /** Token shape: literal {@code info} followed by one or more digits. */
+  public static final Pattern TOKEN_PATTERN = Pattern.compile("info\\d+");
+
+  private final Map<String, String> tokenToValue = new HashMap<>();
+  private final Map<String, String> valueToToken = new HashMap<>();
+  private final AtomicInteger counter = new AtomicInteger(0);
+
+  /**
+   * Register a real value and return the opaque token that the LLM
+   * will see instead. Idempotent: calling {@code wrap} on a value that
+   * was already wrapped returns the previously-issued token. No
+   * re-issue, no collision.
+   *
+   * @param realValue the value the LLM must never see in plain form
+   * @return the token ({@code info1}, {@code info2}, ...)
+   * @throws NullPointerException if {@code realValue} is {@code null}
+   */
+  public synchronized String wrap(String realValue) {
+    if (realValue == null) {
+      throw new NullPointerException("wrap: realValue must not be null");
+    }
+    String existing = valueToToken.get(realValue);
+    if (existing != null) return existing;
+    String token = "info" + counter.incrementAndGet();
+    tokenToValue.put(token, realValue);
+    valueToToken.put(realValue, token);
+    return token;
+  }
+
+  /**
+   * Resolve a token back to its real value. If the input is not a
+   * registered token (an ordinary {@code "Next"} button label, a
+   * literal filename, whatever), it is returned unchanged. This
+   * matters for the dispatcher's transparent-resolve hook: it walks
+   * every {@code type_text}/{@code find_text}/{@code click_text}
+   * argument and passes each string through {@code resolve}; only
+   * strings that were wrapped are substituted.
+   */
+  public synchronized String resolve(String tokenOrLiteral) {
+    if (tokenOrLiteral == null) return null;
+    String v = tokenToValue.get(tokenOrLiteral);
+    return v == null ? tokenOrLiteral : v;
+  }
+
+  /**
+   * True iff {@code s} looks like a token AND is registered. A string
+   * that merely matches the token pattern but was never wrapped is
+   * treated as literal text.
+   */
+  public synchronized boolean isKnownToken(String s) {
+    return s != null && tokenToValue.containsKey(s);
+  }
+
+  /** Number of distinct values currently tokenised. Read-mostly, for reporting. */
+  public int size() {
+    return counter.get();
+  }
+}

--- a/MCP/src/main/java/org/sikuli/mcp/transport/HttpTransport.java
+++ b/MCP/src/main/java/org/sikuli/mcp/transport/HttpTransport.java
@@ -21,6 +21,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
+import java.util.Set;
 import java.util.UUID;
 
 /**
@@ -90,15 +91,34 @@ public final class HttpTransport implements AutoCloseable {
   private final long maxRequestBytes;
   private final long tokenTtlSeconds;
   private final Runnable onAuditFailure;
+  /**
+   * Allowlist of {@code Origin} header values. A request that carries
+   * an {@code Origin} not in this set is rejected with {@code 403}.
+   * A request without an {@code Origin} header (non-browser clients:
+   * curl, MCP Inspector, native SDK) passes through. Empty set means
+   * the strictest policy — any non-null {@code Origin} is refused.
+   *
+   * <p>Prevents DNS-rebind / cross-origin abuse: a browser page hosted
+   * on {@code evil.com} that resolves the loopback bind and POSTs
+   * {@code initialize} would otherwise mint a bearer and drive the mouse.
+   */
+  private final Set<String> allowedOrigins;
 
   private Undertow server;
 
   public HttpTransport(McpDispatcher dispatcher, SessionStore sessions,
                        TokenIssuer issuer, BearerAuth.StaticToken clientToken,
                        String host, int port) {
+    this(dispatcher, sessions, issuer, clientToken, host, port, Set.of());
+  }
+
+  public HttpTransport(McpDispatcher dispatcher, SessionStore sessions,
+                       TokenIssuer issuer, BearerAuth.StaticToken clientToken,
+                       String host, int port,
+                       Set<String> allowedOrigins) {
     this(dispatcher, sessions, issuer, clientToken, host, port,
         DEFAULT_MAX_REQUEST_BYTES, DEFAULT_TOKEN_TTL_SECONDS,
-        () -> System.exit(2));
+        () -> System.exit(2), allowedOrigins);
   }
 
   public HttpTransport(McpDispatcher dispatcher, SessionStore sessions,
@@ -106,6 +126,16 @@ public final class HttpTransport implements AutoCloseable {
                        String host, int port,
                        long maxRequestBytes, long tokenTtlSeconds,
                        Runnable onAuditFailure) {
+    this(dispatcher, sessions, issuer, clientToken, host, port,
+        maxRequestBytes, tokenTtlSeconds, onAuditFailure, Set.of());
+  }
+
+  public HttpTransport(McpDispatcher dispatcher, SessionStore sessions,
+                       TokenIssuer issuer, BearerAuth.StaticToken clientToken,
+                       String host, int port,
+                       long maxRequestBytes, long tokenTtlSeconds,
+                       Runnable onAuditFailure,
+                       Set<String> allowedOrigins) {
     this.dispatcher = dispatcher;
     this.sessions = sessions;
     this.issuer = issuer;
@@ -115,6 +145,7 @@ public final class HttpTransport implements AutoCloseable {
     this.maxRequestBytes = maxRequestBytes;
     this.tokenTtlSeconds = tokenTtlSeconds;
     this.onAuditFailure = onAuditFailure;
+    this.allowedOrigins = allowedOrigins == null ? Set.of() : Set.copyOf(allowedOrigins);
   }
 
   public synchronized void start() {
@@ -164,6 +195,20 @@ public final class HttpTransport implements AutoCloseable {
     }
     if (ex.isInIoThread()) {
       ex.dispatch(this::handle);
+      return;
+    }
+
+    // Origin allowlist. Absent Origin = non-browser client (curl, MCP
+    // Inspector, native SDK) → pass through. Present Origin must be in
+    // the allowlist, otherwise 403. Empty allowlist means every non-null
+    // Origin is refused — the safest default for a loopback bind.
+    String origin = firstHeader(ex.getRequestHeaders(), "Origin");
+    if (origin != null && !allowedOrigins.contains(origin)) {
+      ex.setStatusCode(StatusCodes.FORBIDDEN);
+      ex.getResponseHeaders().put(new HttpString("Content-Type"), "application/json");
+      ex.getResponseSender().send(
+          "{\"error\":\"origin not allowed\"}",
+          StandardCharsets.UTF_8);
       return;
     }
 

--- a/MCP/src/test/java/org/sikuli/mcp/ArgsRedactorTest.java
+++ b/MCP/src/test/java/org/sikuli/mcp/ArgsRedactorTest.java
@@ -1,0 +1,150 @@
+/*
+ * Copyright (c) 2010-2026, sikuli.org, sikulix.com, oculix-org - MIT license
+ */
+package org.sikuli.mcp;
+
+import org.json.JSONArray;
+import org.json.JSONObject;
+import org.junit.jupiter.api.Test;
+import org.sikuli.mcp.audit.ArgsRedactor;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * @author Julien Mer (julienmerconsulting)
+ * @author Claude (Anthropic)
+ * @since 4.0.1
+ */
+class ArgsRedactorTest {
+
+  @Test
+  void nullInputReturnsNull() {
+    assertNull(ArgsRedactor.redact(null));
+  }
+
+  @Test
+  void nonSensitiveKeysPassThroughUnchanged() {
+    JSONObject in = new JSONObject()
+        .put("reference_path", "/tmp/x.png")
+        .put("similarity", 0.85)
+        .put("timeout_ms", 5000);
+    JSONObject out = ArgsRedactor.redact(in);
+    assertEquals("/tmp/x.png", out.getString("reference_path"));
+    assertEquals(0.85, out.getDouble("similarity"), 1e-9);
+    assertEquals(5000, out.getInt("timeout_ms"));
+  }
+
+  @Test
+  void passwordIsRedactedWithFingerprint() {
+    JSONObject in = new JSONObject().put("password", "s3cret-p@ss");
+    JSONObject out = ArgsRedactor.redact(in);
+    String v = out.getString("password");
+    assertTrue(v.startsWith("***REDACTED"), () -> "unexpected: " + v);
+    assertTrue(v.contains("sha256="), () -> "no fingerprint: " + v);
+    assertFalse(v.contains("s3cret"), "cleartext must not leak");
+  }
+
+  @Test
+  void identicalSecretsProduceIdenticalFingerprints() {
+    JSONObject a = new JSONObject().put("secret", "hunter2");
+    JSONObject b = new JSONObject().put("secret", "hunter2");
+    assertEquals(
+        ArgsRedactor.redact(a).getString("secret"),
+        ArgsRedactor.redact(b).getString("secret"),
+        "auditors must still be able to correlate identical secrets");
+  }
+
+  @Test
+  void differentSecretsProduceDifferentFingerprints() {
+    JSONObject a = new JSONObject().put("secret", "aaa");
+    JSONObject b = new JSONObject().put("secret", "bbb");
+    assertNotEquals(
+        ArgsRedactor.redact(a).getString("secret"),
+        ArgsRedactor.redact(b).getString("secret"));
+  }
+
+  @Test
+  void allSensitivePatternsAreCovered() {
+    String[] sensitiveKeys = {
+        "password", "passwd", "secret",
+        "api_key", "apiKey", "x-api-key",
+        "token", "auth", "authorization",
+        "credential", "credentials",
+        "private_key", "privateKey",
+        "pin", "ssn",
+        "iban", "cvv",
+        "creditCard", "credit_card",
+        "session_id",
+    };
+    for (String key : sensitiveKeys) {
+      JSONObject in = new JSONObject().put(key, "SENSITIVE_VALUE");
+      String out = ArgsRedactor.redact(in).getString(key);
+      assertTrue(out.startsWith("***REDACTED"),
+          () -> "key '" + key + "' was not redacted: " + out);
+      assertFalse(out.contains("SENSITIVE_VALUE"),
+          () -> "cleartext leaked for key '" + key + "'");
+    }
+  }
+
+  @Test
+  void caseInsensitiveMatch() {
+    JSONObject in = new JSONObject()
+        .put("Password", "p1")
+        .put("PASSWORD", "p2")
+        .put("MyApiKey", "k1");
+    JSONObject out = ArgsRedactor.redact(in);
+    assertTrue(out.getString("Password").startsWith("***REDACTED"));
+    assertTrue(out.getString("PASSWORD").startsWith("***REDACTED"));
+    assertTrue(out.getString("MyApiKey").startsWith("***REDACTED"));
+  }
+
+  @Test
+  void nestedObjectsAreRedactedRecursively() {
+    JSONObject in = new JSONObject()
+        .put("form", new JSONObject()
+            .put("username", "alice")
+            .put("password", "s3cret")
+            .put("nested", new JSONObject().put("secret", "deep")));
+    JSONObject out = ArgsRedactor.redact(in);
+    JSONObject form = out.getJSONObject("form");
+    assertEquals("alice", form.getString("username"));
+    assertTrue(form.getString("password").startsWith("***REDACTED"));
+    assertTrue(form.getJSONObject("nested").getString("secret")
+        .startsWith("***REDACTED"));
+  }
+
+  @Test
+  void arraysOfObjectsAreRedactedRecursively() {
+    JSONArray users = new JSONArray()
+        .put(new JSONObject().put("name", "alice").put("token", "t1"))
+        .put(new JSONObject().put("name", "bob").put("token", "t2"));
+    JSONObject in = new JSONObject().put("users", users);
+    JSONObject out = ArgsRedactor.redact(in);
+    JSONArray outUsers = out.getJSONArray("users");
+    assertEquals("alice", outUsers.getJSONObject(0).getString("name"));
+    assertTrue(outUsers.getJSONObject(0).getString("token").startsWith("***REDACTED"));
+    assertTrue(outUsers.getJSONObject(1).getString("token").startsWith("***REDACTED"));
+  }
+
+  @Test
+  void nullValueIsSpelledOut() {
+    JSONObject in = new JSONObject().put("password", JSONObject.NULL);
+    String out = ArgsRedactor.redact(in).getString("password");
+    assertTrue(out.contains("null"), () -> "expected null marker, got: " + out);
+  }
+
+  @Test
+  void emptyValueIsSpelledOut() {
+    JSONObject in = new JSONObject().put("password", "");
+    String out = ArgsRedactor.redact(in).getString("password");
+    assertTrue(out.contains("empty"), () -> "expected empty marker, got: " + out);
+  }
+
+  @Test
+  void originalJsonObjectIsNotMutated() {
+    JSONObject in = new JSONObject().put("password", "s3cret");
+    ArgsRedactor.redact(in);
+    assertEquals("s3cret", in.getString("password"),
+        "input JSON must remain untouched — redaction returns a fresh tree");
+  }
+}

--- a/MCP/src/test/java/org/sikuli/mcp/AuditChainTest.java
+++ b/MCP/src/test/java/org/sikuli/mcp/AuditChainTest.java
@@ -6,11 +6,15 @@ package org.sikuli.mcp;
 import org.json.JSONObject;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
+import org.sikuli.mcp.audit.HighWaterMark;
 import org.sikuli.mcp.audit.JournalVerifier;
 import org.sikuli.mcp.audit.JournalWriter;
 import org.sikuli.mcp.crypto.KeyManager;
 
 import java.nio.file.*;
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.Collectors;
 
 import static org.junit.jupiter.api.Assertions.*;
 /**
@@ -106,6 +110,323 @@ class AuditChainTest {
                     .count();
     }
     assertEquals(2, count, "Rotation should have produced exactly 2 journal files");
+  }
+
+  // ── verifyChain: cross-file + HWM tests ──
+
+  @Test
+  void chainVerifyPassesOnCleanChain(@TempDir Path dir) throws Exception {
+    KeyManager keys = KeyManager.loadOrInit(dir);
+    Path journalDir = dir.resolve("journal");
+    Path anchor = dir.resolve("journal.hwm");
+    HighWaterMark hwm = new HighWaterMark(anchor, keys);
+    try (JournalWriter j = new JournalWriter(journalDir, keys, 100, 60_000, hwm)) {
+      j.appendToolCall("s", null, null, "a", new JSONObject(), "h1");
+      j.rotate("test_rotation", keys.publicKeySha256Hex());
+      j.appendToolCall("s", null, null, "b", new JSONObject(), "h2");
+    }
+
+    JournalVerifier.ChainResult r =
+        JournalVerifier.verifyChain(journalDir, keys.publicKey(), anchor);
+    assertTrue(r.ok(),
+        () -> "Expected OK, got level=" + r.level + " issues=" + r.issues + " warns=" + r.warnings);
+    assertEquals(JournalVerifier.ChainResult.Level.OK, r.level);
+    assertEquals(2, r.filesChecked);
+  }
+
+  @Test
+  void chainVerifyDetectsMissingFileBetweenRotations(@TempDir Path dir) throws Exception {
+    // Suppression of an audit-*.jsonl between two rotations must
+    // surface as a FAIL. The property is proven by hash resolution:
+    // the surviving rotation_begin references a rotation_end that
+    // no longer exists in the map, regardless of filename order.
+    KeyManager keys = KeyManager.loadOrInit(dir);
+    Path journalDir = dir.resolve("journal");
+    Path anchor = dir.resolve("journal.hwm");
+    HighWaterMark hwm = new HighWaterMark(anchor, keys);
+    try (JournalWriter j = new JournalWriter(journalDir, keys, 100, 60_000, hwm)) {
+      j.appendToolCall("s", null, null, "a", new JSONObject(), "h1");
+      j.rotate("r1", keys.publicKeySha256Hex());
+      j.appendToolCall("s", null, null, "b", new JSONObject(), "h2");
+      j.rotate("r2", keys.publicKeySha256Hex());
+      j.appendToolCall("s", null, null, "c", new JSONObject(), "h3");
+    }
+    List<Path> files = listAuditFiles(journalDir);
+    assertEquals(3, files.size());
+
+    // Delete the middle file.
+    Files.delete(files.get(1));
+
+    JournalVerifier.ChainResult r =
+        JournalVerifier.verifyChain(journalDir, keys.publicKey(), null);
+    assertEquals(JournalVerifier.ChainResult.Level.FAIL, r.level);
+    assertTrue(r.issues.stream().anyMatch(iss ->
+        iss.contains("missing file between rotations")
+        || iss.contains("unknown previous_marker_hash")),
+        () -> "Expected missing-file issue, got: " + r.issues);
+  }
+
+  @Test
+  void chainVerifyDetectsTamperedPreviousMarkerHash(@TempDir Path dir) throws Exception {
+    // Modifying the previous_marker_hash in a rotation_begin breaks
+    // the per-file entry_hash first (hash covers extra), but even if
+    // an attacker recomputed the hash and re-signed with a stolen key,
+    // the hash would no longer resolve into endsByHash. We assert the
+    // failure path, not which specific check flags it.
+    KeyManager keys = KeyManager.loadOrInit(dir);
+    Path journalDir = dir.resolve("journal");
+    Path anchor = dir.resolve("journal.hwm");
+    HighWaterMark hwm = new HighWaterMark(anchor, keys);
+    try (JournalWriter j = new JournalWriter(journalDir, keys, 100, 60_000, hwm)) {
+      j.appendToolCall("s", null, null, "a", new JSONObject(), "h1");
+      j.rotate("r1", keys.publicKeySha256Hex());
+      j.appendToolCall("s", null, null, "b", new JSONObject(), "h2");
+    }
+    List<Path> files = listAuditFiles(journalDir);
+    Path secondFile = files.get(1);
+
+    String content = Files.readString(secondFile);
+    // The rotation_begin is on line 1 of the second file. Rewrite its
+    // previous_marker_hash to a bogus value.
+    String tampered = content.replaceFirst(
+        "\"previous_marker_hash\":\"[0-9a-f]+\"",
+        "\"previous_marker_hash\":\"deadbeef\"");
+    assertNotEquals(content, tampered, "regex should have matched");
+    Files.writeString(secondFile, tampered);
+
+    JournalVerifier.ChainResult r =
+        JournalVerifier.verifyChain(journalDir, keys.publicKey(), null);
+    assertEquals(JournalVerifier.ChainResult.Level.FAIL, r.level);
+  }
+
+  @Test
+  void chainVerifyAcceptsFileStartingWithRecoveryGap(@TempDir Path dir) throws Exception {
+    // A file that begins with a signed RECOVERY_GAP is a legitimate
+    // fresh chain — prev_hash == genesis by design of appendRecoveryGap.
+    // The verifier must accept it as a chain start.
+    KeyManager keys = KeyManager.loadOrInit(dir);
+    Path journalDir = dir.resolve("journal");
+    Path anchor = dir.resolve("journal.hwm");
+    HighWaterMark hwm = new HighWaterMark(anchor, keys);
+    try (JournalWriter j = new JournalWriter(journalDir, keys, 100, 60_000, hwm)) {
+      j.appendRecoveryGap("operator_recovery", "2026-07-06T00:00:00Z", "lost");
+      j.appendToolCall("s", null, null, "post_recovery",
+          new JSONObject(), "h1");
+    }
+    JournalVerifier.ChainResult r =
+        JournalVerifier.verifyChain(journalDir, keys.publicKey(), anchor);
+    assertTrue(r.ok(),
+        () -> "Expected OK on recovery journal, got: " + r.issues + " / " + r.warnings);
+  }
+
+  @Test
+  void chainVerifyRejectsFakeTxtBypass(@TempDir Path dir) throws Exception {
+    // The core property of the fix: a plain .txt marker (as the old
+    // cmdRecover used to write) MUST NOT legitimise the deletion of a
+    // journal file. The verifier ignores .txt entirely and reports
+    // FAIL because the surviving rotation_begin doesn't resolve.
+    KeyManager keys = KeyManager.loadOrInit(dir);
+    Path journalDir = dir.resolve("journal");
+    Path anchor = dir.resolve("journal.hwm");
+    HighWaterMark hwm = new HighWaterMark(anchor, keys);
+    try (JournalWriter j = new JournalWriter(journalDir, keys, 100, 60_000, hwm)) {
+      j.appendToolCall("s", null, null, "a", new JSONObject(), "h1");
+      j.rotate("r1", keys.publicKeySha256Hex());
+      j.appendToolCall("s", null, null, "b", new JSONObject(), "h2");
+      j.rotate("r2", keys.publicKeySha256Hex());
+      j.appendToolCall("s", null, null, "c", new JSONObject(), "h3");
+    }
+    List<Path> files = listAuditFiles(journalDir);
+    Files.delete(files.get(1));
+
+    // Attacker drops a legitimate-looking .txt to try to explain the gap.
+    Files.writeString(journalDir.resolve("UNSIGNED_GAP-999.txt"),
+        "Audit chain broken at " + java.time.Instant.now() + ".\n");
+
+    JournalVerifier.ChainResult r =
+        JournalVerifier.verifyChain(journalDir, keys.publicKey(), null);
+    assertEquals(JournalVerifier.ChainResult.Level.FAIL, r.level,
+        "a .txt file must never be treated as a legitimate break");
+  }
+
+  @Test
+  void chainVerifyToleratesFilenameCollisionSuffixes(@TempDir Path dir) throws Exception {
+    // openNewFile suffixes -1, -2 on millisecond collisions, and
+    // lexicographic order (audit-...-000-1.jsonl < audit-...-000.jsonl)
+    // no longer reflects creation order. Chain resolution runs on the
+    // hash chain, not the filename, so the verifier stays clean even
+    // when the lexicographic order lies.
+    KeyManager keys = KeyManager.loadOrInit(dir);
+    Path journalDir = dir.resolve("journal");
+    Path anchor = dir.resolve("journal.hwm");
+    HighWaterMark hwm = new HighWaterMark(anchor, keys);
+    try (JournalWriter j = new JournalWriter(journalDir, keys, 100, 60_000, hwm)) {
+      j.appendToolCall("s", null, null, "a", new JSONObject(), "h1");
+      j.rotate("r1", keys.publicKeySha256Hex());
+      j.appendToolCall("s", null, null, "b", new JSONObject(), "h2");
+    }
+    List<Path> files = listAuditFiles(journalDir);
+    assertEquals(2, files.size());
+
+    // Rename the FIRST file to simulate a suffixed collision so the
+    // lexicographic order places the SECOND file before it. Hash chain
+    // must still verify.
+    Path first = files.get(0);
+    String firstName = first.getFileName().toString();
+    // audit-YYYYMMDD-HHMMSS-SSS.jsonl → audit-YYYYMMDD-HHMMSS-SSS-9.jsonl
+    String suffixed = firstName.substring(0, firstName.length() - ".jsonl".length())
+        + "-9.jsonl";
+    // We keep the anchor pointing at the SECOND file so HWM doesn't complain.
+    Files.move(first, journalDir.resolve(suffixed));
+
+    JournalVerifier.ChainResult r =
+        JournalVerifier.verifyChain(journalDir, keys.publicKey(), null);
+    assertTrue(r.ok(),
+        () -> "Chain resolution must not depend on lexicographic order. Got: "
+              + r.issues + " / " + r.warnings);
+  }
+
+  @Test
+  void chainVerifyDetectsTruncatedTail(@TempDir Path dir) throws Exception {
+    // The property the whole HWM design exists to hold: if an attacker
+    // lops off the last file and does NOT wipe the anchor, verify
+    // catches it. This is the tail-truncation case that neither
+    // prev_hash nor rotation_end/begin can detect on their own.
+    KeyManager keys = KeyManager.loadOrInit(dir);
+    Path journalDir = dir.resolve("journal");
+    Path anchor = dir.resolve("journal.hwm");
+    HighWaterMark hwm = new HighWaterMark(anchor, keys);
+    try (JournalWriter j = new JournalWriter(journalDir, keys, 100, 60_000, hwm)) {
+      j.appendToolCall("s", null, null, "a", new JSONObject(), "h1");
+      j.rotate("r1", keys.publicKeySha256Hex());
+      j.appendToolCall("s", null, null, "b", new JSONObject(), "h2");
+    }
+
+    // Delete the last file. Anchor stays behind — points at the file
+    // we just deleted.
+    List<Path> files = listAuditFiles(journalDir);
+    Files.delete(files.get(files.size() - 1));
+
+    JournalVerifier.ChainResult r =
+        JournalVerifier.verifyChain(journalDir, keys.publicKey(), anchor);
+    assertEquals(JournalVerifier.ChainResult.Level.FAIL, r.level);
+    assertTrue(r.issues.stream().anyMatch(iss ->
+        iss.contains("tail truncation") || iss.contains("last_file")),
+        () -> "Expected tail-truncation issue, got: " + r.issues);
+  }
+
+  @Test
+  void chainVerifyDetectsOrphanFileInjection(@TempDir Path dir) throws Exception {
+    // Pass 4: a file whose first entry has prev_hash != GENESIS and
+    // whose type is not rotation_begin is orphaned. This test
+    // simulates an attacker dropping a valid-looking journal file
+    // in a place where its predecessor doesn't exist.
+    KeyManager keys = KeyManager.loadOrInit(dir);
+    Path journalDir = dir.resolve("journal");
+    Path anchor = dir.resolve("journal.hwm");
+    HighWaterMark hwm = new HighWaterMark(anchor, keys);
+    try (JournalWriter j = new JournalWriter(journalDir, keys, 100, 60_000, hwm)) {
+      j.appendToolCall("s", null, null, "a", new JSONObject(), "h1");
+      j.rotate("r1", keys.publicKeySha256Hex());
+      j.appendToolCall("s", null, null, "b", new JSONObject(), "h2");
+    }
+
+    // Delete the rotation_begin file (second). Then re-parent its
+    // remaining part by removing the rotation_begin from an
+    // otherwise-valid file → orphan.
+    List<Path> files = listAuditFiles(journalDir);
+    Path second = files.get(1);
+    // Strip line 1 (the rotation_begin) — leave just tool_call lines.
+    String content = Files.readString(second);
+    int nl = content.indexOf('\n');
+    if (nl > 0) {
+      Files.writeString(second, content.substring(nl + 1));
+    }
+
+    JournalVerifier.ChainResult r =
+        JournalVerifier.verifyChain(journalDir, keys.publicKey(), null);
+    assertEquals(JournalVerifier.ChainResult.Level.FAIL, r.level,
+        "an orphan file must FAIL");
+    assertTrue(r.issues.stream().anyMatch(iss ->
+        iss.contains("orphan") || iss.contains("genesis")
+        || iss.contains("does not start with rotation_begin")),
+        () -> "Expected orphan issue, got: " + r.issues);
+  }
+
+  @Test
+  void chainVerifyDetectsJournalDirWipeWithHwmIntact(@TempDir Path dir) throws Exception {
+    // The anchor lives OUTSIDE journalDir. Wiping journalDir alone
+    // leaves the anchor behind and the verifier catches the wipe.
+    // This is the wipe-partiel scenario documented as covered.
+    KeyManager keys = KeyManager.loadOrInit(dir);
+    Path journalDir = dir.resolve("journal");
+    Path anchor = dir.resolve("journal.hwm"); // outside journalDir
+    HighWaterMark hwm = new HighWaterMark(anchor, keys);
+    try (JournalWriter j = new JournalWriter(journalDir, keys, 100, 60_000, hwm)) {
+      j.appendToolCall("s", null, null, "a", new JSONObject(), "h1");
+    }
+    assertTrue(Files.exists(anchor), "anchor must have been written outside journalDir");
+
+    // Wipe the journal directory only. Anchor survives.
+    try (var stream = Files.list(journalDir)) {
+      List<Path> toDelete = stream.collect(Collectors.toList());
+      for (Path p : toDelete) Files.delete(p);
+    }
+
+    JournalVerifier.ChainResult r =
+        JournalVerifier.verifyChain(journalDir, keys.publicKey(), anchor);
+    // Level is FAIL when the anchor's last_file cannot be resolved.
+    // For an empty journalDir + present anchor, the anchor's file is
+    // missing → FAIL "tail truncation".
+    assertEquals(JournalVerifier.ChainResult.Level.FAIL, r.level,
+        "wipe of journalDir with anchor intact must be detected");
+  }
+
+  @Test
+  void chainVerifyReportsWarnWhenAnchorLagsQueue(@TempDir Path dir) throws Exception {
+    // HWM update failure is a possible state at runtime: writeLine
+    // reached disk but the follow-up hwm.update crashed (disk full,
+    // permission flip, VM pause). We simulate the crash by rewinding
+    // the anchor to the previous entry after both writes succeeded.
+    // The chain itself is intact; the verifier must WARN, not FAIL.
+    KeyManager keys = KeyManager.loadOrInit(dir);
+    Path journalDir = dir.resolve("journal");
+    Path anchor = dir.resolve("journal.hwm");
+    HighWaterMark hwm = new HighWaterMark(anchor, keys);
+    try (JournalWriter j = new JournalWriter(journalDir, keys, 100, 60_000, hwm)) {
+      j.appendToolCall("s", null, null, "a", new JSONObject(), "h1");
+      j.appendToolCall("s", null, null, "b", new JSONObject(), "h2");
+    }
+    Path file = listAuditFiles(journalDir).get(0);
+
+    // Read entry seq=0 (the first line) so we can rewind the anchor
+    // to point at it as if the update for seq=1 had crashed.
+    JSONObject first;
+    try (var in = Files.newBufferedReader(file)) {
+      first = new JSONObject(in.readLine());
+    }
+    hwm.reset(
+        first.getString("entry_hash"),
+        first.getLong("seq"),
+        file.getFileName().toString(),
+        first.getString("ts_utc"));
+
+    JournalVerifier.ChainResult r =
+        JournalVerifier.verifyChain(journalDir, keys.publicKey(), anchor);
+    assertEquals(JournalVerifier.ChainResult.Level.WARN, r.level,
+        () -> "Expected WARN for HWM lag, got: " + r.level
+              + " issues=" + r.issues + " warns=" + r.warnings);
+    assertTrue(r.warnings.stream().anyMatch(w -> w.contains("lags actual queue")),
+        () -> "Expected lag warning, got: " + r.warnings);
+  }
+
+  private static List<Path> listAuditFiles(Path journalDir) throws Exception {
+    try (var stream = Files.list(journalDir)) {
+      return stream.filter(p -> p.getFileName().toString().startsWith("audit-")
+                             && p.getFileName().toString().endsWith(".jsonl"))
+                   .sorted(Comparator.naturalOrder())
+                   .collect(Collectors.toList());
+    }
   }
 
   private static Path findJournalFile(Path journalDir) throws Exception {

--- a/MCP/src/test/java/org/sikuli/mcp/ClockGuardTest.java
+++ b/MCP/src/test/java/org/sikuli/mcp/ClockGuardTest.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright (c) 2010-2026, sikuli.org, sikulix.com, oculix-org - MIT license
+ */
+package org.sikuli.mcp;
+
+import org.junit.jupiter.api.Test;
+import org.sikuli.mcp.audit.ClockGuard;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.concurrent.atomic.AtomicLong;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * @author Julien Mer (julienmerconsulting)
+ * @author Claude (Anthropic)
+ * @since 4.0.1
+ */
+class ClockGuardTest {
+
+  /** Wall clock advances in lockstep with monotonic → no regression. */
+  @Test
+  void steadyClockDoesNotRegress() {
+    AtomicLong nano = new AtomicLong(0L);
+    MutableClock wall = new MutableClock(Instant.parse("2026-07-06T00:00:00Z"));
+    ClockGuard g = new ClockGuard(wall, nano::get);
+
+    // Advance both by 1 second.
+    nano.set(1_000_000_000L);
+    wall.set(Instant.parse("2026-07-06T00:00:01Z"));
+
+    assertFalse(g.hasRegressed());
+  }
+
+  /** Wall clock jumps backward while monotonic advances → regression. */
+  @Test
+  void wallClockRegressionIsDetected() {
+    AtomicLong nano = new AtomicLong(0L);
+    MutableClock wall = new MutableClock(Instant.parse("2026-07-06T00:00:00Z"));
+    ClockGuard g = new ClockGuard(wall, nano::get);
+
+    // Monotonic advances by 2 seconds, wall clock goes BACK 1 second.
+    nano.set(2_000_000_000L);
+    wall.set(Instant.parse("2026-07-05T23:59:59Z"));
+
+    assertTrue(g.hasRegressed());
+  }
+
+  /** Wall clock stalls while monotonic advances significantly → regression. */
+  @Test
+  void wallClockStallIsDetected() {
+    AtomicLong nano = new AtomicLong(0L);
+    MutableClock wall = new MutableClock(Instant.parse("2026-07-06T00:00:00Z"));
+    ClockGuard g = new ClockGuard(wall, nano::get);
+
+    // Monotonic advances 5 seconds. Wall clock does not move at all.
+    nano.set(5_000_000_000L);
+
+    assertTrue(g.hasRegressed());
+  }
+
+  /** Small jitter under the 50ms tolerance stays quiet. */
+  @Test
+  void smallJitterUnderToleranceDoesNotFireFalseAlarm() {
+    AtomicLong nano = new AtomicLong(0L);
+    MutableClock wall = new MutableClock(Instant.parse("2026-07-06T00:00:00Z"));
+    ClockGuard g = new ClockGuard(wall, nano::get);
+
+    // Monotonic advances 100ms. Wall clock advances 60ms — a 40ms
+    // deficit, within the 50ms tolerance.
+    nano.set(100_000_000L);
+    wall.set(Instant.parse("2026-07-06T00:00:00.060Z"));
+
+    assertFalse(g.hasRegressed(),
+        "40ms jitter should not fire a regression alarm");
+  }
+
+  /** acknowledge resets the reference so subsequent checks compare from now. */
+  @Test
+  void acknowledgeResetsReference() {
+    AtomicLong nano = new AtomicLong(0L);
+    MutableClock wall = new MutableClock(Instant.parse("2026-07-06T00:00:00Z"));
+    ClockGuard g = new ClockGuard(wall, nano::get);
+
+    // Trigger a regression.
+    nano.set(2_000_000_000L);
+    wall.set(Instant.parse("2026-07-05T23:59:58Z"));
+    assertTrue(g.hasRegressed());
+
+    // Acknowledge freezes both refs at "now".
+    g.acknowledge();
+    assertFalse(g.hasRegressed(), "post-acknowledge should be quiet");
+  }
+
+  /** nowIso uses the injected wall clock, not System.currentTimeMillis. */
+  @Test
+  void nowIsoUsesInjectedClock() {
+    MutableClock wall = new MutableClock(Instant.parse("2026-07-06T12:34:56.789Z"));
+    ClockGuard g = new ClockGuard(wall, () -> 0L);
+    String iso = g.nowIso();
+    assertTrue(iso.startsWith("2026-07-06T12:34:56"),
+        () -> "unexpected iso stamp: " + iso);
+    assertTrue(iso.endsWith("Z"));
+  }
+
+  /** Default constructor still works (production callers). */
+  @Test
+  void defaultConstructorWorksAndReadsSystemClock() {
+    ClockGuard g = new ClockGuard();
+    String iso = g.nowIso();
+    assertNotNull(iso);
+    assertTrue(iso.length() >= 20, () -> "ISO too short: " + iso);
+    assertFalse(g.hasRegressed(),
+        "fresh guard on a healthy machine should not report regression");
+  }
+
+  /**
+   * Minimal mutable {@link Clock} — {@link Clock#fixed} is immutable and
+   * would force a rebuild per test step. We keep an instant field and
+   * mutate it directly.
+   */
+  private static final class MutableClock extends Clock {
+    private Instant current;
+    MutableClock(Instant initial) { this.current = initial; }
+    void set(Instant next) { this.current = next; }
+    @Override public Instant instant() { return current; }
+    @Override public ZoneOffset getZone() { return ZoneOffset.UTC; }
+    @Override public Clock withZone(java.time.ZoneId zone) { return this; }
+  }
+}

--- a/MCP/src/test/java/org/sikuli/mcp/HighWaterMarkTest.java
+++ b/MCP/src/test/java/org/sikuli/mcp/HighWaterMarkTest.java
@@ -1,0 +1,246 @@
+/*
+ * Copyright (c) 2010-2026, sikuli.org, sikulix.com, oculix-org - MIT license
+ */
+package org.sikuli.mcp;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.sikuli.mcp.audit.HighWaterMark;
+import org.sikuli.mcp.audit.HighWaterMark.Snapshot;
+import org.sikuli.mcp.crypto.KeyManager;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Unit tests for {@link HighWaterMark}.
+ *
+ * <p>The critical property proven here is that all four business fields
+ * ({@code last_entry_hash}, {@code last_seq}, {@code last_file},
+ * {@code last_ts_utc}) sit under the Ed25519 signature. Tampering any of
+ * them — including a {@code last_file} rename — invalidates the anchor.
+ *
+ * @author Julien Mer (julienmerconsulting)
+ * @author Claude (Anthropic)
+ * @since 4.0.1
+ */
+class HighWaterMarkTest {
+
+  private static final String FILE_A = "audit-20260706-000000-000.jsonl";
+  private static final String FILE_B = "audit-20260706-010000-000.jsonl";
+  private static final String TS_A   = "2026-07-06T00:00:00.000000Z";
+  private static final String TS_B   = "2026-07-06T01:00:00.000000Z";
+  private static final String HASH_A = "abc123def456";
+  private static final String HASH_B = "999888777666";
+
+  @Test
+  void updateThenLoad_roundtripsAllFourFields(@TempDir Path dir) throws Exception {
+    KeyManager keys = KeyManager.loadOrInit(dir);
+    Path anchor = dir.resolve("journal.hwm");
+    HighWaterMark hwm = new HighWaterMark(anchor, keys);
+    hwm.update(HASH_A, 42L, FILE_A, TS_A);
+
+    Snapshot loaded = hwm.load().orElseThrow();
+    assertEquals(HASH_A, loaded.lastEntryHash);
+    assertEquals(42L, loaded.lastSeq);
+    assertEquals(FILE_A, loaded.lastFile);
+    assertEquals(TS_A, loaded.lastTsUtc);
+    assertNotNull(loaded.signature);
+    assertFalse(loaded.signature.isBlank());
+  }
+
+  @Test
+  void verifyValidSignature_returnsTrue(@TempDir Path dir) throws Exception {
+    KeyManager keys = KeyManager.loadOrInit(dir);
+    Path anchor = dir.resolve("journal.hwm");
+    HighWaterMark hwm = new HighWaterMark(anchor, keys);
+    hwm.update(HASH_A, 1L, FILE_A, TS_A);
+
+    Snapshot loaded = hwm.load().orElseThrow();
+    assertTrue(HighWaterMark.verify(loaded, keys.publicKey()));
+  }
+
+  @Test
+  void verifyTamperedSignature_returnsFalse(@TempDir Path dir) throws Exception {
+    KeyManager keys = KeyManager.loadOrInit(dir);
+    Path anchor = dir.resolve("journal.hwm");
+    HighWaterMark hwm = new HighWaterMark(anchor, keys);
+    hwm.update(HASH_A, 1L, FILE_A, TS_A);
+    Snapshot original = hwm.load().orElseThrow();
+
+    // Flip the first two hex chars of the signature.
+    String flippedSig = (original.signature.charAt(0) == '0' ? "1" : "0")
+        + original.signature.substring(1);
+    Snapshot tampered = new Snapshot(
+        original.lastEntryHash, original.lastSeq,
+        original.lastFile, original.lastTsUtc, flippedSig);
+
+    assertFalse(HighWaterMark.verify(tampered, keys.publicKey()));
+  }
+
+  @Test
+  void verifyTamperedLastFile_returnsFalse(@TempDir Path dir) throws Exception {
+    // The property this test locks in: last_file is under the signature.
+    // A rename cannot silently redirect the verifier onto a wrong file.
+    KeyManager keys = KeyManager.loadOrInit(dir);
+    Path anchor = dir.resolve("journal.hwm");
+    HighWaterMark hwm = new HighWaterMark(anchor, keys);
+    hwm.update(HASH_A, 1L, FILE_A, TS_A);
+    Snapshot original = hwm.load().orElseThrow();
+
+    Snapshot renamed = new Snapshot(
+        original.lastEntryHash, original.lastSeq,
+        "attacker-supplied.jsonl",
+        original.lastTsUtc, original.signature);
+
+    assertFalse(HighWaterMark.verify(renamed, keys.publicKey()),
+        "renaming last_file must invalidate the signature");
+  }
+
+  @Test
+  void verifyTamperedLastEntryHash_returnsFalse(@TempDir Path dir) throws Exception {
+    KeyManager keys = KeyManager.loadOrInit(dir);
+    Path anchor = dir.resolve("journal.hwm");
+    HighWaterMark hwm = new HighWaterMark(anchor, keys);
+    hwm.update(HASH_A, 1L, FILE_A, TS_A);
+    Snapshot original = hwm.load().orElseThrow();
+
+    Snapshot tampered = new Snapshot(
+        HASH_B,
+        original.lastSeq, original.lastFile,
+        original.lastTsUtc, original.signature);
+
+    assertFalse(HighWaterMark.verify(tampered, keys.publicKey()));
+  }
+
+  @Test
+  void verifyTamperedLastSeq_returnsFalse(@TempDir Path dir) throws Exception {
+    KeyManager keys = KeyManager.loadOrInit(dir);
+    Path anchor = dir.resolve("journal.hwm");
+    HighWaterMark hwm = new HighWaterMark(anchor, keys);
+    hwm.update(HASH_A, 42L, FILE_A, TS_A);
+    Snapshot original = hwm.load().orElseThrow();
+
+    Snapshot tampered = new Snapshot(
+        original.lastEntryHash, 99L,
+        original.lastFile, original.lastTsUtc, original.signature);
+
+    assertFalse(HighWaterMark.verify(tampered, keys.publicKey()));
+  }
+
+  @Test
+  void verifyTamperedLastTsUtc_returnsFalse(@TempDir Path dir) throws Exception {
+    KeyManager keys = KeyManager.loadOrInit(dir);
+    Path anchor = dir.resolve("journal.hwm");
+    HighWaterMark hwm = new HighWaterMark(anchor, keys);
+    hwm.update(HASH_A, 1L, FILE_A, TS_A);
+    Snapshot original = hwm.load().orElseThrow();
+
+    Snapshot tampered = new Snapshot(
+        original.lastEntryHash, original.lastSeq,
+        original.lastFile,
+        "1970-01-01T00:00:00.000000Z",
+        original.signature);
+
+    assertFalse(HighWaterMark.verify(tampered, keys.publicKey()));
+  }
+
+  @Test
+  void verifyWithForeignPublicKey_returnsFalse(@TempDir Path dir,
+                                               @TempDir Path otherDir) throws Exception {
+    KeyManager keys = KeyManager.loadOrInit(dir);
+    KeyManager foreign = KeyManager.loadOrInit(otherDir);
+    Path anchor = dir.resolve("journal.hwm");
+    HighWaterMark hwm = new HighWaterMark(anchor, keys);
+    hwm.update(HASH_A, 1L, FILE_A, TS_A);
+
+    Snapshot loaded = hwm.load().orElseThrow();
+    assertFalse(HighWaterMark.verify(loaded, foreign.publicKey()),
+        "an unrelated key must not verify a foreign anchor");
+  }
+
+  @Test
+  void loadFromMissingAnchor_returnsEmpty(@TempDir Path dir) throws Exception {
+    KeyManager keys = KeyManager.loadOrInit(dir);
+    Path anchor = dir.resolve("does-not-exist.hwm");
+    HighWaterMark hwm = new HighWaterMark(anchor, keys);
+    Optional<Snapshot> loaded = hwm.load();
+    assertTrue(loaded.isEmpty());
+  }
+
+  @Test
+  void loadFromInvalidJson_throwsIOException(@TempDir Path dir) throws Exception {
+    KeyManager keys = KeyManager.loadOrInit(dir);
+    Path anchor = dir.resolve("journal.hwm");
+    Files.writeString(anchor, "not valid json {{{ ");
+    HighWaterMark hwm = new HighWaterMark(anchor, keys);
+    assertThrows(IOException.class, hwm::load);
+  }
+
+  @Test
+  void loadFromJsonMissingFields_throwsIOException(@TempDir Path dir) throws Exception {
+    KeyManager keys = KeyManager.loadOrInit(dir);
+    Path anchor = dir.resolve("journal.hwm");
+    // Valid JSON, but missing last_seq, last_file, last_ts_utc, signature.
+    Files.writeString(anchor, "{\"last_entry_hash\":\"abc\"}");
+    HighWaterMark hwm = new HighWaterMark(anchor, keys);
+    assertThrows(IOException.class, hwm::load);
+  }
+
+  @Test
+  void resetOverwritesExistingAnchor(@TempDir Path dir) throws Exception {
+    KeyManager keys = KeyManager.loadOrInit(dir);
+    Path anchor = dir.resolve("journal.hwm");
+    HighWaterMark hwm = new HighWaterMark(anchor, keys);
+    hwm.update(HASH_A, 1L, FILE_A, TS_A);
+    hwm.reset(HASH_B, 42L, FILE_B, TS_B);
+
+    Snapshot loaded = hwm.load().orElseThrow();
+    assertEquals(HASH_B, loaded.lastEntryHash);
+    assertEquals(42L, loaded.lastSeq);
+    assertEquals(FILE_B, loaded.lastFile);
+    assertEquals(TS_B, loaded.lastTsUtc);
+  }
+
+  @Test
+  void resetWithNewKey_reSignsAnchorSoOldKeyNoLongerVerifies(@TempDir Path dir,
+                                                             @TempDir Path otherDir) throws Exception {
+    // Simulates the rotate-key flow: the old writer signs the anchor,
+    // then the operator promotes a new key and re-signs. Old signature
+    // is dead, new one holds. This is exactly the invariant cmdRotateKey
+    // relies on so verify does not report a bogus tamper post-rotation.
+    KeyManager oldKeys = KeyManager.loadOrInit(dir);
+    Path anchor = dir.resolve("journal.hwm");
+    HighWaterMark hwmOld = new HighWaterMark(anchor, oldKeys);
+    hwmOld.update(HASH_A, 1L, FILE_A, TS_A);
+
+    KeyManager newKeys = KeyManager.loadOrInit(otherDir);
+    HighWaterMark hwmNew = new HighWaterMark(anchor, newKeys);
+    hwmNew.reset(HASH_A, 1L, FILE_A, TS_A);
+
+    Snapshot loaded = hwmNew.load().orElseThrow();
+    assertFalse(HighWaterMark.verify(loaded, oldKeys.publicKey()),
+        "old key must no longer verify after re-sign");
+    assertTrue(HighWaterMark.verify(loaded, newKeys.publicKey()),
+        "new key must verify the re-signed anchor");
+  }
+
+  @Test
+  void verify_rejectsSnapshotWithMalformedHexSignature(@TempDir Path dir) throws Exception {
+    KeyManager keys = KeyManager.loadOrInit(dir);
+    Snapshot malformed = new Snapshot(HASH_A, 1L, FILE_A, TS_A, "not-hex-at-all");
+    assertFalse(HighWaterMark.verify(malformed, keys.publicKey()));
+  }
+
+  @Test
+  void verify_rejectsNullSnapshotAndNullSignature(@TempDir Path dir) throws Exception {
+    KeyManager keys = KeyManager.loadOrInit(dir);
+    assertFalse(HighWaterMark.verify(null, keys.publicKey()));
+    Snapshot noSig = new Snapshot(HASH_A, 1L, FILE_A, TS_A, null);
+    assertFalse(HighWaterMark.verify(noSig, keys.publicKey()));
+  }
+}

--- a/MCP/src/test/java/org/sikuli/mcp/McpDispatcherTest.java
+++ b/MCP/src/test/java/org/sikuli/mcp/McpDispatcherTest.java
@@ -77,14 +77,90 @@ class McpDispatcherTest {
     ToolRegistry r = new ToolRegistry();
     r.register(new EchoTool());
     McpDispatcher d = mkDispatcher(dir, r, new AutoApproveGate());
+    SessionHandle h = new SessionHandle();
 
-    JSONObject req = new JSONObject()
-        .put("jsonrpc", "2.0").put("id", 2).put("method", "tools/list");
-    JSONObject resp = d.dispatch(req, new SessionHandle());
+    // MCP protocol: initialize must precede tools/list.
+    d.dispatch(new JSONObject()
+        .put("jsonrpc", "2.0").put("id", 1).put("method", "initialize"), h);
+
+    JSONObject resp = d.dispatch(new JSONObject()
+        .put("jsonrpc", "2.0").put("id", 2).put("method", "tools/list"), h);
 
     JSONArray tools = resp.getJSONObject("result").getJSONArray("tools");
     assertEquals(1, tools.length());
     assertEquals("echo", tools.getJSONObject(0).getString("name"));
+  }
+
+  @Test
+  void toolsCallBeforeInitializeIsRejected(@TempDir Path dir) throws Exception {
+    ToolRegistry r = new ToolRegistry();
+    r.register(new EchoTool());
+    McpDispatcher d = mkDispatcher(dir, r, new AutoApproveGate());
+
+    JSONObject req = new JSONObject()
+        .put("jsonrpc", "2.0").put("id", 1).put("method", "tools/call")
+        .put("params", new JSONObject().put("name", "echo"));
+    JSONObject resp = d.dispatch(req, new SessionHandle());
+
+    assertTrue(resp.has("error"), () -> "Expected error, got: " + resp);
+    assertEquals(JsonRpc.INVALID_REQUEST,
+        resp.getJSONObject("error").getInt("code"));
+  }
+
+  @Test
+  void toolsListBeforeInitializeIsRejected(@TempDir Path dir) throws Exception {
+    ToolRegistry r = new ToolRegistry();
+    r.register(new EchoTool());
+    McpDispatcher d = mkDispatcher(dir, r, new AutoApproveGate());
+
+    JSONObject req = new JSONObject()
+        .put("jsonrpc", "2.0").put("id", 1).put("method", "tools/list");
+    JSONObject resp = d.dispatch(req, new SessionHandle());
+
+    assertTrue(resp.has("error"));
+    assertEquals(JsonRpc.INVALID_REQUEST,
+        resp.getJSONObject("error").getInt("code"));
+  }
+
+  @Test
+  void pingBeforeInitializeIsAllowed(@TempDir Path dir) throws Exception {
+    McpDispatcher d = mkDispatcher(dir, new ToolRegistry(), new AutoApproveGate());
+    JSONObject req = new JSONObject()
+        .put("jsonrpc", "2.0").put("id", 1).put("method", "ping");
+    JSONObject resp = d.dispatch(req, new SessionHandle());
+    assertTrue(resp.has("result"), () -> "Ping should be allowed pre-initialize: " + resp);
+  }
+
+  @Test
+  void protocolVersionNegotiation_echoesSupported() {
+    assertEquals(McpDispatcher.PROTOCOL_VERSION,
+        McpDispatcher.negotiateProtocolVersion(McpDispatcher.PROTOCOL_VERSION));
+  }
+
+  @Test
+  void protocolVersionNegotiation_fallsBackOnUnknown() {
+    // Unknown proposal → we respond with our canonical version and log a warn.
+    assertEquals(McpDispatcher.PROTOCOL_VERSION,
+        McpDispatcher.negotiateProtocolVersion("9999-12-31"));
+  }
+
+  @Test
+  void protocolVersionNegotiation_handlesMissingProposal() {
+    assertEquals(McpDispatcher.PROTOCOL_VERSION,
+        McpDispatcher.negotiateProtocolVersion(null));
+    assertEquals(McpDispatcher.PROTOCOL_VERSION,
+        McpDispatcher.negotiateProtocolVersion(""));
+  }
+
+  @Test
+  void serverVersionSourcedDynamically() {
+    // In test mode (no jar), we hit the dev sentinel. In a packaged jar,
+    // pom.properties provides the real Maven version. Both are non-blank
+    // and never the hard-coded 3.0.1 that used to lie.
+    assertNotNull(McpDispatcher.SERVER_VERSION);
+    assertFalse(McpDispatcher.SERVER_VERSION.isBlank());
+    assertNotEquals("3.0.1", McpDispatcher.SERVER_VERSION,
+        "SERVER_VERSION must not be the hard-coded 3.0.1 sentinel any more");
   }
 
   @Test

--- a/MCP/src/test/java/org/sikuli/mcp/McpDispatcherTest.java
+++ b/MCP/src/test/java/org/sikuli/mcp/McpDispatcherTest.java
@@ -268,4 +268,178 @@ class McpDispatcherTest {
     assertEquals(sid1, sid2);
     assertEquals(sid2, sid3);
   }
+
+  // ── SubstitutionVault: vault/wrap + transparent resolve ──
+
+  @Test
+  void vaultWrapReturnsToken(@TempDir Path dir) throws Exception {
+    McpDispatcher d = mkDispatcher(dir, new ToolRegistry(), new AutoApproveGate());
+    SessionHandle h = new SessionHandle();
+    initialize(d, h);
+
+    JSONObject resp = d.dispatch(new JSONObject()
+        .put("jsonrpc", "2.0").put("id", 2)
+        .put("method", "vault/wrap")
+        .put("params", new JSONObject().put("value", "alice@example.com")), h);
+
+    assertEquals("info1", resp.getJSONObject("result").getString("token"));
+  }
+
+  @Test
+  void vaultWrapBeforeInitializeIsRejected(@TempDir Path dir) throws Exception {
+    McpDispatcher d = mkDispatcher(dir, new ToolRegistry(), new AutoApproveGate());
+    JSONObject resp = d.dispatch(new JSONObject()
+        .put("jsonrpc", "2.0").put("id", 1)
+        .put("method", "vault/wrap")
+        .put("params", new JSONObject().put("value", "alice@example.com")),
+        new SessionHandle());
+    assertEquals(JsonRpc.INVALID_REQUEST,
+        resp.getJSONObject("error").getInt("code"));
+  }
+
+  @Test
+  void vaultWrapDedupesIdenticalValues(@TempDir Path dir) throws Exception {
+    McpDispatcher d = mkDispatcher(dir, new ToolRegistry(), new AutoApproveGate());
+    SessionHandle h = new SessionHandle();
+    initialize(d, h);
+
+    String first = d.dispatch(new JSONObject()
+        .put("jsonrpc", "2.0").put("id", 2)
+        .put("method", "vault/wrap")
+        .put("params", new JSONObject().put("value", "same-value")), h)
+        .getJSONObject("result").getString("token");
+    String second = d.dispatch(new JSONObject()
+        .put("jsonrpc", "2.0").put("id", 3)
+        .put("method", "vault/wrap")
+        .put("params", new JSONObject().put("value", "same-value")), h)
+        .getJSONObject("result").getString("token");
+
+    assertEquals(first, second);
+  }
+
+  @Test
+  void toolsCallResolvesTokenIntoRealValueBeforeToolSeesIt(@TempDir Path dir)
+      throws Exception {
+    // The whole point: the tool receives the real value, but the LLM
+    // only ever saw the token. EchoTool echoes its args, so if the
+    // result contains the real value, the resolve did fire.
+    ToolRegistry r = new ToolRegistry();
+    r.register(new EchoTool());
+    McpDispatcher d = mkDispatcher(dir, r, new AutoApproveGate());
+    SessionHandle h = new SessionHandle();
+    initialize(d, h);
+
+    String token = d.dispatch(new JSONObject()
+        .put("jsonrpc", "2.0").put("id", 2)
+        .put("method", "vault/wrap")
+        .put("params", new JSONObject().put("value", "IBAN-FR7612345")), h)
+        .getJSONObject("result").getString("token");
+
+    JSONObject resp = d.dispatch(new JSONObject()
+        .put("jsonrpc", "2.0").put("id", 3)
+        .put("method", "tools/call")
+        .put("params", new JSONObject()
+            .put("name", "echo")
+            .put("arguments", new JSONObject().put("text", token))), h);
+    String echoedResult = resp.getJSONObject("result").toString();
+    assertTrue(echoedResult.contains("IBAN-FR7612345"),
+        () -> "tool must have seen the real value: " + echoedResult);
+    assertFalse(echoedResult.contains(token),
+        () -> "tool must not see the token: " + echoedResult);
+  }
+
+  @Test
+  void toolsCallResolvesTokensNestedInObjectsAndArrays(@TempDir Path dir)
+      throws Exception {
+    ToolRegistry r = new ToolRegistry();
+    r.register(new EchoTool());
+    McpDispatcher d = mkDispatcher(dir, r, new AutoApproveGate());
+    SessionHandle h = new SessionHandle();
+    initialize(d, h);
+
+    String t1 = d.dispatch(new JSONObject().put("jsonrpc", "2.0").put("id", 2)
+        .put("method", "vault/wrap")
+        .put("params", new JSONObject().put("value", "REAL-EMAIL")), h)
+        .getJSONObject("result").getString("token");
+    String t2 = d.dispatch(new JSONObject().put("jsonrpc", "2.0").put("id", 3)
+        .put("method", "vault/wrap")
+        .put("params", new JSONObject().put("value", "REAL-IBAN")), h)
+        .getJSONObject("result").getString("token");
+
+    JSONObject nestedArgs = new JSONObject()
+        .put("user", new JSONObject().put("email", t1))
+        .put("accounts", new JSONArray().put(t2));
+
+    JSONObject resp = d.dispatch(new JSONObject()
+        .put("jsonrpc", "2.0").put("id", 4)
+        .put("method", "tools/call")
+        .put("params", new JSONObject()
+            .put("name", "echo")
+            .put("arguments", nestedArgs)), h);
+    String out = resp.getJSONObject("result").toString();
+    assertTrue(out.contains("REAL-EMAIL"), () -> "nested object resolved: " + out);
+    assertTrue(out.contains("REAL-IBAN"), () -> "array element resolved: " + out);
+    assertFalse(out.contains(t1));
+    assertFalse(out.contains(t2));
+  }
+
+  @Test
+  void toolsCallLeavesUnknownStringsUntouched(@TempDir Path dir) throws Exception {
+    // A tool typing "Suivant" or a raw filename must not be affected
+    // by the resolver, even after some tokens have been registered.
+    ToolRegistry r = new ToolRegistry();
+    r.register(new EchoTool());
+    McpDispatcher d = mkDispatcher(dir, r, new AutoApproveGate());
+    SessionHandle h = new SessionHandle();
+    initialize(d, h);
+    d.dispatch(new JSONObject().put("jsonrpc", "2.0").put("id", 2)
+        .put("method", "vault/wrap")
+        .put("params", new JSONObject().put("value", "secret")), h);
+
+    JSONObject resp = d.dispatch(new JSONObject()
+        .put("jsonrpc", "2.0").put("id", 3)
+        .put("method", "tools/call")
+        .put("params", new JSONObject()
+            .put("name", "echo")
+            .put("arguments", new JSONObject()
+                .put("text", "Suivant")
+                .put("fake_token", "info99"))), h);
+    String out = resp.getJSONObject("result").toString();
+    assertTrue(out.contains("Suivant"));
+    assertTrue(out.contains("info99"),
+        "unregistered token-shaped string must pass through");
+  }
+
+  @Test
+  void vaultIsSessionScopedNotGlobal(@TempDir Path dir) throws Exception {
+    // Two independent SessionHandles must not share wrapped values.
+    McpDispatcher d = mkDispatcher(dir, new ToolRegistry(), new AutoApproveGate());
+    SessionHandle a = new SessionHandle();
+    SessionHandle b = new SessionHandle();
+    initialize(d, a);
+    initialize(d, b);
+
+    String ta = d.dispatch(new JSONObject().put("jsonrpc", "2.0").put("id", 2)
+        .put("method", "vault/wrap")
+        .put("params", new JSONObject().put("value", "session-A-secret")), a)
+        .getJSONObject("result").getString("token");
+    String tb = d.dispatch(new JSONObject().put("jsonrpc", "2.0").put("id", 2)
+        .put("method", "vault/wrap")
+        .put("params", new JSONObject().put("value", "session-B-secret")), b)
+        .getJSONObject("result").getString("token");
+
+    // Both got info1 in their own vault — proof they are separate.
+    assertEquals("info1", ta);
+    assertEquals("info1", tb);
+    // Resolving ta in a's vault returns A's secret; b's vault returns
+    // B's secret. The tokens do not collide because they never live
+    // in the same map.
+    assertNotEquals(a.vault().resolve(ta), b.vault().resolve(tb));
+  }
+
+  private static void initialize(McpDispatcher d, SessionHandle h) {
+    d.dispatch(new JSONObject()
+        .put("jsonrpc", "2.0").put("id", 1)
+        .put("method", "initialize"), h);
+  }
 }

--- a/MCP/src/test/java/org/sikuli/mcp/StartupCheckTest.java
+++ b/MCP/src/test/java/org/sikuli/mcp/StartupCheckTest.java
@@ -1,0 +1,152 @@
+/*
+ * Copyright (c) 2010-2026, sikuli.org, sikulix.com, oculix-org - MIT license
+ */
+package org.sikuli.mcp;
+
+import org.json.JSONObject;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.sikuli.mcp.audit.JournalWriter;
+import org.sikuli.mcp.crypto.KeyManager;
+import org.sikuli.mcp.server.StartupCheck;
+import org.sikuli.mcp.server.StartupCheck.StartupException;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Coverage of the 5 documented startup states plus a "never fall back"
+ * guarantee. Each state should either return a valid {@link KeyManager}
+ * or throw a {@link StartupException} whose message names the recovery
+ * command an operator should run.
+ *
+ * @author Julien Mer (julienmerconsulting)
+ * @author Claude (Anthropic)
+ * @since 4.0.1
+ */
+class StartupCheckTest {
+
+  @Test
+  void state1_noKeysNoHistory_initialisesFreshKeyPair(@TempDir Path oculixDir) throws Exception {
+    Path journalDir = oculixDir.resolve("journal");
+    KeyManager k = StartupCheck.validateAndLoad(oculixDir, journalDir);
+    assertNotNull(k);
+    assertTrue(Files.exists(oculixDir.resolve(KeyManager.PRIVATE_KEY_FILENAME)),
+        "init must persist a private key");
+    assertTrue(Files.exists(oculixDir.resolve(KeyManager.PUBLIC_KEY_FILENAME)),
+        "init must persist a public key");
+  }
+
+  @Test
+  void state2_noKeysButJournalExists_refusesWithRecoverHint(@TempDir Path oculixDir) throws Exception {
+    Path journalDir = oculixDir.resolve("journal");
+    Files.createDirectories(journalDir);
+    // Simulate a leftover audit file with no key pair around.
+    Files.writeString(journalDir.resolve("audit-20260706-000000-000.jsonl"),
+        "{\"stub\":\"orphan\"}\n");
+
+    StartupException ex = assertThrows(StartupException.class,
+        () -> StartupCheck.validateAndLoad(oculixDir, journalDir));
+    assertTrue(ex.getMessage().contains("oculix-mcp recover"),
+        () -> "message must point at recover: " + ex.getMessage());
+  }
+
+  @Test
+  void partialKeyState_onlyPrivateKey_refuses(@TempDir Path oculixDir) throws Exception {
+    Path journalDir = oculixDir.resolve("journal");
+    Files.writeString(oculixDir.resolve(KeyManager.PRIVATE_KEY_FILENAME),
+        "not-a-real-key");
+    // Public key deliberately missing.
+
+    StartupException ex = assertThrows(StartupException.class,
+        () -> StartupCheck.validateAndLoad(oculixDir, journalDir));
+    assertTrue(ex.getMessage().contains("Inconsistent key state"),
+        () -> ex.getMessage());
+  }
+
+  @Test
+  void partialKeyState_onlyPublicKey_refuses(@TempDir Path oculixDir) throws Exception {
+    Path journalDir = oculixDir.resolve("journal");
+    Files.writeString(oculixDir.resolve(KeyManager.PUBLIC_KEY_FILENAME),
+        "not-a-real-key");
+
+    StartupException ex = assertThrows(StartupException.class,
+        () -> StartupCheck.validateAndLoad(oculixDir, journalDir));
+    assertTrue(ex.getMessage().contains("Inconsistent key state"));
+  }
+
+  @Test
+  void state3_corruptedKeyBytes_refusesWithRecoverHint(@TempDir Path oculixDir) throws Exception {
+    Path journalDir = oculixDir.resolve("journal");
+    // Both files present but not real Ed25519 material.
+    Files.writeString(oculixDir.resolve(KeyManager.PRIVATE_KEY_FILENAME),
+        "garbage-not-ed25519");
+    Files.writeString(oculixDir.resolve(KeyManager.PUBLIC_KEY_FILENAME),
+        "garbage-not-ed25519");
+
+    StartupException ex = assertThrows(StartupException.class,
+        () -> StartupCheck.validateAndLoad(oculixDir, journalDir));
+    assertTrue(ex.getMessage().contains("Failed to load")
+        || ex.getMessage().contains("recover"),
+        () -> ex.getMessage());
+  }
+
+  @Test
+  void state4_keyDoesNotVerifyLastEntry_refuses(@TempDir Path oculixDir) throws Exception {
+    Path journalDir = oculixDir.resolve("journal");
+
+    // Init a valid key + a valid journal entry.
+    KeyManager original = KeyManager.generateAndStore(oculixDir);
+    try (JournalWriter j = new JournalWriter(journalDir, original, 100, 60_000)) {
+      j.appendToolCall("s", null, null, "any", new JSONObject(), "h");
+    }
+
+    // Overwrite both key files with a NEW, unrelated pair — as if an
+    // operator swapped keys without going through rotate-key.
+    Path other = oculixDir.resolve("other-key-dir");
+    Files.createDirectories(other);
+    KeyManager foreign = KeyManager.generateAndStore(other);
+    Files.copy(other.resolve(KeyManager.PRIVATE_KEY_FILENAME),
+        oculixDir.resolve(KeyManager.PRIVATE_KEY_FILENAME),
+        java.nio.file.StandardCopyOption.REPLACE_EXISTING);
+    Files.copy(other.resolve(KeyManager.PUBLIC_KEY_FILENAME),
+        oculixDir.resolve(KeyManager.PUBLIC_KEY_FILENAME),
+        java.nio.file.StandardCopyOption.REPLACE_EXISTING);
+
+    StartupException ex = assertThrows(StartupException.class,
+        () -> StartupCheck.validateAndLoad(oculixDir, journalDir));
+    assertTrue(ex.getMessage().contains("does not verify")
+            || ex.getMessage().contains("rotate-key")
+            || ex.getMessage().contains("recover"),
+        () -> "message should name a remedy: " + ex.getMessage());
+  }
+
+  @Test
+  void state5_validKeyAndJournal_startsCleanly(@TempDir Path oculixDir) throws Exception {
+    Path journalDir = oculixDir.resolve("journal");
+    KeyManager original = KeyManager.generateAndStore(oculixDir);
+    try (JournalWriter j = new JournalWriter(journalDir, original, 100, 60_000)) {
+      j.appendToolCall("s", null, null, "any", new JSONObject(), "h");
+    }
+
+    KeyManager loaded = StartupCheck.validateAndLoad(oculixDir, journalDir);
+    assertNotNull(loaded);
+    // Public key fingerprint should match original.
+    assertEquals(original.publicKeySha256Hex(), loaded.publicKeySha256Hex());
+  }
+
+  @Test
+  void neverFallsBackToUnsignedMode(@TempDir Path oculixDir) throws Exception {
+    // The doctrine: any inconsistent state throws, never returns a
+    // dummy KeyManager. Meta-test that verifies the aggregate behaviour
+    // across all failure modes.
+    Path journalDir = oculixDir.resolve("journal");
+    Files.createDirectories(journalDir);
+    Files.writeString(journalDir.resolve("audit-x.jsonl"), "{}\n");
+    // No keys, history exists → REFUSE. Must throw, not return.
+    assertThrows(StartupException.class,
+        () -> StartupCheck.validateAndLoad(oculixDir, journalDir));
+  }
+}

--- a/MCP/src/test/java/org/sikuli/mcp/SubstitutionVaultTest.java
+++ b/MCP/src/test/java/org/sikuli/mcp/SubstitutionVaultTest.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright (c) 2010-2026, sikuli.org, sikulix.com, oculix-org - MIT license
+ */
+package org.sikuli.mcp;
+
+import org.junit.jupiter.api.Test;
+import org.sikuli.mcp.tools.SubstitutionVault;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * @author Julien Mer (julienmerconsulting)
+ * @author Claude (Anthropic)
+ * @since 4.0.1
+ */
+class SubstitutionVaultTest {
+
+  @Test
+  void firstWrapReturnsInfo1() {
+    SubstitutionVault v = new SubstitutionVault();
+    assertEquals("info1", v.wrap("alice@example.com"));
+  }
+
+  @Test
+  void wrapCounterIsMonotonic() {
+    SubstitutionVault v = new SubstitutionVault();
+    assertEquals("info1", v.wrap("alice@example.com"));
+    assertEquals("info2", v.wrap("bob@example.com"));
+    assertEquals("info3", v.wrap("carol@example.com"));
+  }
+
+  @Test
+  void wrappingSameValueTwiceReturnsSameToken() {
+    SubstitutionVault v = new SubstitutionVault();
+    String first = v.wrap("alice@example.com");
+    String second = v.wrap("alice@example.com");
+    assertEquals(first, second, "idempotent wrap");
+    assertEquals(1, v.size(), "no duplicate token allocated");
+  }
+
+  @Test
+  void differentValuesGetDifferentTokens() {
+    SubstitutionVault v = new SubstitutionVault();
+    assertNotEquals(v.wrap("a"), v.wrap("b"));
+  }
+
+  @Test
+  void resolveKnownTokenReturnsRealValue() {
+    SubstitutionVault v = new SubstitutionVault();
+    String t = v.wrap("secret-iban-FR7612345");
+    assertEquals("secret-iban-FR7612345", v.resolve(t));
+  }
+
+  @Test
+  void resolveUnknownStringPassesThroughUnchanged() {
+    // A tool that types "Suivant" or a filename "photo.png" must not
+    // be tampered with by the resolver. Only registered tokens change.
+    SubstitutionVault v = new SubstitutionVault();
+    v.wrap("alice@example.com");
+    assertEquals("Suivant", v.resolve("Suivant"));
+    assertEquals("info99", v.resolve("info99"),
+        "unregistered token-shaped string must pass through");
+    assertEquals("random text", v.resolve("random text"));
+  }
+
+  @Test
+  void resolveNullReturnsNull() {
+    SubstitutionVault v = new SubstitutionVault();
+    assertNull(v.resolve(null));
+  }
+
+  @Test
+  void isKnownTokenDistinguishesRegisteredFromLookalike() {
+    SubstitutionVault v = new SubstitutionVault();
+    String t = v.wrap("alice@example.com");
+    assertTrue(v.isKnownToken(t));
+    assertFalse(v.isKnownToken("info42"),
+        "unregistered token-shaped string is not known");
+    assertFalse(v.isKnownToken(null));
+    assertFalse(v.isKnownToken("Suivant"));
+  }
+
+  @Test
+  void wrapNullThrowsNpe() {
+    SubstitutionVault v = new SubstitutionVault();
+    assertThrows(NullPointerException.class, () -> v.wrap(null));
+  }
+
+  @Test
+  void sizeReflectsWrapCount() {
+    SubstitutionVault v = new SubstitutionVault();
+    assertEquals(0, v.size());
+    v.wrap("a");
+    assertEquals(1, v.size());
+    v.wrap("b");
+    v.wrap("a"); // dedup, no increment
+    assertEquals(2, v.size());
+  }
+
+  @Test
+  void tokenPatternRecognisesEveryWrappedToken() {
+    SubstitutionVault v = new SubstitutionVault();
+    for (int i = 1; i <= 5; i++) {
+      String t = v.wrap("value-" + i);
+      assertTrue(SubstitutionVault.TOKEN_PATTERN.matcher(t).matches(),
+          () -> "token '" + t + "' should match TOKEN_PATTERN");
+    }
+  }
+}

--- a/scripts/VerifyAppLauncher.java
+++ b/scripts/VerifyAppLauncher.java
@@ -1,0 +1,80 @@
+/*
+ * Cross-OS smoke test for OculiX App name resolution.
+ *
+ * Verifies that `new App("<name>").open()` correctly:
+ *   - launches the target app via the OS-native launcher
+ *     ('cmd /c start' on Windows, 'open -a' on Mac, PATH on Linux)
+ *   - returns a valid PID that maps to the running app
+ *   - closes cleanly after the test
+ *
+ * Usage:
+ *   javac -cp API/target/oculixapi-<version>.jar scripts/VerifyAppLauncher.java
+ *   java  -cp API/target/oculixapi-<version>.jar:scripts VerifyAppLauncher [appName]
+ *
+ * Default appName = "firefox" (available cross-OS).
+ * Exit 0 on success, 1 on failure.
+ *
+ * Intended entry point for the .github/workflows/verify-app-launcher.yml
+ * matrix job (ubuntu, macos, windows).
+ */
+
+import org.sikuli.script.App;
+
+public class VerifyAppLauncher {
+
+    private static int rc = 0;
+
+    private static void pass(String msg) {
+        System.out.println("[OK]   " + msg);
+    }
+
+    private static void fail(String msg) {
+        System.err.println("[FAIL] " + msg);
+        rc = 1;
+    }
+
+    public static void main(String[] args) throws Exception {
+        String appName = args.length > 0 ? args[0] : "firefox";
+
+        System.out.println("=== VerifyAppLauncher ===");
+        System.out.println("OS:      " + System.getProperty("os.name"));
+        System.out.println("Java:    " + System.getProperty("java.version"));
+        System.out.println("Target:  " + appName);
+        System.out.println();
+
+        App app = new App(appName);
+        boolean opened = app.open(10);
+
+        if (opened) {
+            pass("App.open(10) returned true");
+            System.out.println("       PID:  " + app.getPID());
+            System.out.println("       name: " + app.getName());
+        } else {
+            fail("App.open(10) returned false — the OS-native launcher did not resolve the name");
+        }
+
+        // Give the app a moment to fully surface before checking isRunning.
+        Thread.sleep(2000);
+
+        if (rc == 0) {
+            if (app.isRunning()) {
+                pass("App.isRunning() true after 2s (PID " + app.getPID() + ")");
+            } else {
+                fail("App.isRunning() false 2s after open — process died or PID lookup grabbed a stale handle");
+            }
+        }
+
+        // Clean up: try to close whether we succeeded or not, so the CI
+        // runner doesn't leak a Firefox process across matrix steps.
+        try {
+            boolean closed = app.close();
+            System.out.println("[cleanup] App.close() returned " + closed);
+        } catch (Exception e) {
+            System.out.println("[cleanup] App.close() threw: " + e.getMessage());
+        }
+
+        System.out.println();
+        System.out.println(rc == 0 ? "=== PASS ===" : "=== FAIL ===");
+        System.exit(rc);
+    }
+}


### PR DESCRIPTION
## Linked issue

Closes #434

## Root cause

The path is case sensitive on Linux, so does not exist if the path is `LIB` as discussed in #398 



## What changed
Changed "LIB" to "Lib"



## How you tested it

Only tested by running Sikulix.jar on Eclipse by selecting `Run as > Java Application`

- OS: Ubuntu
- Java: 17.0.19

## Regressions considered

Because other OS's are case insensitive, should not be a problem.


### Checklist

- [ ] PR scope is **one concern**. No drive-by reformatting / renames / unrelated cleanups.
- [ ] Commit messages are short, imperative, no `feat:`/`fix:`/`chore:` prefixes (we reference tickets in the PR body, not the subject).
- [ ] I built locally (`mvn clean install -DskipTests`) and ran the tests for the modules I touched.
- [ ] If I touched the IDE, I launched it and exercised the feature manually — a compile-green PR that crashes on open wastes everyone's time.
- [ ] If this is AI-assisted, I read and understood every line I'm submitting and can explain why this approach.
- [ ] No new runtime dependency added (or, if so, justified in the issue first).
- [ ] No CI / build / release workflow change (or, if so, agreed in the issue first).


