### PR TITLE
Fix IDE startup path bug on Linux #434

### DIFF
--- a/IDE/src/main/java/org/sikuli/support/runner/JythonRunner.java
+++ b/IDE/src/main/java/org/sikuli/support/runner/JythonRunner.java
@@ -88,7 +88,7 @@ public class JythonRunner extends AbstractLocalFileScriptRunner {
       jythonSupport = JythonSupport.get();
       jythonSupport.getSysPath();
       if (!Commons.isRunningFromJar()) {
-        jythonSupport.putSysPath(new File(Commons.getMainClassLocation(), "LIB").getAbsolutePath(), 0);
+        jythonSupport.putSysPath(new File(Commons.getMainClassLocation(), "Lib").getAbsolutePath(), 0);
       }
       jythonSupport.addSitePackages();
       jythonSupport.showSysPath();


### PR DESCRIPTION
## Linked issue

Closes #434

## Root cause

The path is case sensitive on Linux, so does not exist if the path is `LIB` as discussed in #398 



## What changed
Changed "LIB" to "Lib"



## How you tested it

Only tested by running Sikulix.jar on Eclipse by selecting `Run as > Java Application`

- OS: Ubuntu
- Java: 17.0.19

## Regressions considered

Because other OS's are case insensitive, should not be a problem.


### Checklist

- [ ] PR scope is **one concern**. No drive-by reformatting / renames / unrelated cleanups.
- [ ] Commit messages are short, imperative, no `feat:`/`fix:`/`chore:` prefixes (we reference tickets in the PR body, not the subject).
- [ ] I built locally (`mvn clean install -DskipTests`) and ran the tests for the modules I touched.
- [ ] If I touched the IDE, I launched it and exercised the feature manually — a compile-green PR that crashes on open wastes everyone's time.
- [ ] If this is AI-assisted, I read and understood every line I'm submitting and can explain why this approach.
- [ ] No new runtime dependency added (or, if so, justified in the issue first).
- [ ] No CI / build / release workflow change (or, if so, agreed in the issue first).


