### PR TITLE
fix(hotkey): resolve modifier-mask mismatch causing bare-key global hotkeys

### DIFF
--- a/.github/CREDITS.md
+++ b/.github/CREDITS.md
@@ -4,6 +4,34 @@ OculiX is a Java visual automation platform that succeeds where invisible click-
 
 This file honors the people whose contribution is hard to see in the default GitHub Contributors view — bug reporters whose analysis shaped a fix, native-language reviewers who caught false-friends in every locale we ship, and voices that made the diff smarter. The GitHub graph tracks commits ; this file tracks intent.
 
+## 🎓 Original Sikuli lineage — MIT UIST 2009 → SikuliX1
+
+OculiX descends from a research project born at MIT CSAIL. Every line of Java shipped today rests on their vision, even where the code has since been rewritten.
+
+### Founders
+
+| Name | Role | Reference |
+|---|---|---|
+| Prof. Rob Miller | Founder of the UI Design Group (later Usable Programming) at MIT CSAIL, supervised the original Sikuli research from 2003 onward | UI Design Group / Usable Programming, MIT CSAIL |
+| @doubleshow (Tom Yeh) | Co-author of the seminal Sikuli paper — 87 dense commits on the original codebase | *Sikuli: Using GUI Screenshots for Search and Automation*, UIST 2009 |
+| @vgod (Tsung-Hsiang Chang) | Co-author of the seminal Sikuli paper — 981 commits, main codebase author on the original repository | *Sikuli: Using GUI Screenshots for Search and Automation*, UIST 2009 |
+
+### Early Sikuli contributors (github.com/sikuli/sikuli, 2010–2013)
+
+Before @RaiMan took over sole maintenance and forked SikuliX1, the original Sikuli repository welcomed a small early community. Nobody forgotten :
+
+| Contributor | Commits |
+|---|---|
+| @karlmicha (Karl-Michael Schneider) | 28 |
+| @techtonik (anatoly techtonik) | 8 |
+| @niknah | 2 |
+| @EarthCitizen | 1 |
+| @ksmyth (Kevin Smyth) | 1 |
+| @ChrisOelmueller (Chris Oelmueller) | 1 |
+| @Liam-Deacon (Liam Deacon) | 1 |
+
+The @RaiMan → OculiX lineage that followed (2010–present) stands on all their shoulders.
+
 ## 🌍 Native language reviewers — v3.0.4 i18n campaign
 
 The v3.0.4 release shipped six locales validated by native speakers. Each one read every string, corrected false-friends, and pushed back on Google-translated placeholders that would have made real users close the IDE at first launch.

--- a/.github/CREDITS.md
+++ b/.github/CREDITS.md
@@ -1,0 +1,42 @@
+# Credits
+
+OculiX is a Java visual automation platform that succeeds where invisible click-and-verify test tools fail — it clicks visibly, records what it sees, and stops when it does not recognize the screen. Building that kind of tool is a marathon, and it takes many hands beyond the maintainers whose names show on the git graph.
+
+This file honors the people whose contribution is hard to see in the default GitHub Contributors view — bug reporters whose analysis shaped a fix, native-language reviewers who caught false-friends in every locale we ship, and voices that made the diff smarter. The GitHub graph tracks commits ; this file tracks intent.
+
+## 🌍 Native language reviewers — v3.0.4 i18n campaign
+
+The v3.0.4 release shipped six locales validated by native speakers. Each one read every string, corrected false-friends, and pushed back on Google-translated placeholders that would have made real users close the IDE at first launch.
+
+| Locale | Reviewer | Contribution | Issue |
+|---|---|---|---|
+| Deutsch (de) | @RaiMan | Welcome tab review + native pass | #247, #403 |
+| Italiano (it) | @daniele-paltrinieri-79 | Three review batches, 210+ keys validated, 18 false-friends caught, 8 IDE hardcoded strings surfaced | #254 |
+| Português Brasileiro (pt_BR) | @issaojr | Full locale native pass | #259 |
+| Українська (uk) | @Ihor467 | Full locale native pass | #263 |
+| 简体中文 (zh_CN) | @peixuana | Full locale native pass | #264 |
+| 繁體中文 (zh_TW) | @tcc | Full locale native pass | #265 |
+
+## 🐛 Bug reporters and analysts — March 2026 → v4.0.0
+
+These reporters filed issues whose diagnosis shaped a fix that shipped in a release. Each saved OculiX from a defect that would have hit real users.
+
+| Reporter | Issue | Contribution |
+|---|---|---|
+| @genequ | #432 | UI text emoji/tofu on macOS Apple Silicon — box-drawing pitfall discovered during systemic sweep, three rounds of verification with codepoint-level precision |
+| @andresluuk | #416 | Unicode PUA regressions in `containsNonAscii` — routing broken for `Key.F*` sequences |
+| @Zdenda3D | #395 | `exists()` returning false Match 1.0 for solid-color images — motivated the Mode 4 grayscale variance guard, debunked several bad diagnostic narratives along the way |
+| @robserm | #286 | NPE on last recorded event in `handleMouseEvent` |
+| @blackball | #232 | IME support for Chinese and Japanese — clipboard-based `type()` route |
+| @emoQin | #229 | Android multi-device support via ADB serial |
+| @roboraptor | #224 | `-e` CLI validation reading loop counter instead of args |
+| @micves | #163, #162, #209, #208, #207 | Thumbnail rendering pipeline — five issues covering position offset, missing extension, docstring interaction, NPE in `imageExists`, and rendering fallback |
+| @shaworth | #15 | OpenCV `UnsatisfiedLinkError` on Ubuntu 24 — motivated the Legerix native refactor. Reported from land between two sailing trips. |
+
+## 🤝 How to land here
+
+Every non-maintainer whose bug report leads to a shipped fix, whose native review touches a locale that goes live, or whose analysis meaningfully shapes an architectural decision earns a line in this file. The GitHub Contributors graph will start reflecting these contributions the moment this file is committed with `Co-authored-by` trailers.
+
+Thank you.
+
+🦎

--- a/API/src/main/java/org/sikuli/hotkey/HotkeyController.java
+++ b/API/src/main/java/org/sikuli/hotkey/HotkeyController.java
@@ -86,6 +86,15 @@ public class HotkeyController {
     String sKey = Keys.getKeyName(key);
     oldFashionedKeys.put(sKey, key);
     String sMod = KeyModifier.getModifierNames(modifier);
+    if (modifier != 0 && sMod.isEmpty()) {
+      // A non-zero modifier value was given but none of it could be resolved
+      // to a known modifier name. Registering anyway would silently drop the
+      // modifiers and grab the bare key (e.g. plain 'C') as a global hotkey,
+      // which is unexpected and hard to notice. Refuse instead of degrading.
+      Debug.error("HotkeyController: addHotkey: unrecognized modifier value %d for key %s (%d); refusing to register an unmodified global hotkey",
+          modifier, sKey, key);
+      return "";
+    }
     oldFashionedKeys.put(sMod, modifier);
     return installHotkey(callback, sKey + " " + sMod );
   }

--- a/API/src/main/java/org/sikuli/script/KeyModifier.java
+++ b/API/src/main/java/org/sikuli/script/KeyModifier.java
@@ -32,20 +32,27 @@ public class KeyModifier {
   public static final int KEY_WIN = InputEvent.META_MASK;
 
   public static String getModifierNames(int modifier) {
+    // Preferences (and some callers) have historically stored modifiers using
+    // the extended InputEvent.*_DOWN_MASK convention (e.g. SHIFT_DOWN_MASK=64,
+    // META_DOWN_MASK=256) instead of the legacy *_MASK convention documented
+    // for this class (SHIFT=1, META=4, ...). Checking both bit patterns keeps
+    // a stale/mismatched preference value from silently resolving to "no
+    // modifiers", which previously turned e.g. "Shift+Cmd+C" into a bare,
+    // globally-captured 'C' hotkey.
     String names = "";
-    if (0 != (modifier & CTRL)) {
+    if (0 != (modifier & CTRL) || 0 != (modifier & InputEvent.CTRL_DOWN_MASK)) {
       names += "ctrl ";
     }
-    if (0 != (modifier & SHIFT)) {
+    if (0 != (modifier & SHIFT) || 0 != (modifier & InputEvent.SHIFT_DOWN_MASK)) {
       names += "shift ";
     }
-    if (0 != (modifier & ALT)) {
+    if (0 != (modifier & ALT) || 0 != (modifier & InputEvent.ALT_DOWN_MASK)) {
       names += "alt ";
     }
-    if (0 != (modifier & ALTGR)) {
+    if (0 != (modifier & ALTGR) || 0 != (modifier & InputEvent.ALT_GRAPH_DOWN_MASK)) {
       names += "altGraph ";
     }
-    if (0 != (modifier & META)) {
+    if (0 != (modifier & META) || 0 != (modifier & InputEvent.META_DOWN_MASK)) {
       names += "meta ";
     }
     return names.trim();

--- a/API/src/test/java/org/sikuli/hotkey/HotkeyControllerTest.java
+++ b/API/src/test/java/org/sikuli/hotkey/HotkeyControllerTest.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2010-2026, sikuli.org, sikulix.com, oculix-org - MIT license
+ */
+package org.sikuli.hotkey;
+
+import org.junit.jupiter.api.Test;
+import org.sikuli.basics.HotkeyEvent;
+import org.sikuli.basics.HotkeyListener;
+
+import java.awt.event.InputEvent;
+import java.awt.event.KeyEvent;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Regression test for the safety net added in #449/#450: if a modifier value
+ * cannot be resolved to any known modifier name, HotkeyController must refuse
+ * to register the hotkey rather than silently falling back to registering the
+ * bare, unmodified key globally.
+ *
+ * Uses a fresh {@link HotkeyController} instance (not the {@code get()}
+ * singleton) so the refusal path is exercised without touching the native
+ * keymaster provider — the constructor leaves {@code hotkeyProvider} null,
+ * and a refused call never reaches the code that would dereference it.
+ */
+class HotkeyControllerTest {
+
+  private static final HotkeyListener NOOP = new HotkeyListener() {
+    @Override
+    public void hotkeyPressed(HotkeyEvent e) {
+    }
+  };
+
+  @Test
+  void unrecognizedModifierIsRefused() {
+    HotkeyController controller = new HotkeyController();
+    // BUTTON1_DOWN_MASK is a real InputEvent bit but not one getModifierNames()
+    // treats as a keyboard modifier, so it must resolve to "" and be refused —
+    // this is exactly the shape of bug that produced a bare global 'C' hotkey.
+    String result = controller.addHotkey(NOOP, KeyEvent.VK_C, InputEvent.BUTTON1_DOWN_MASK);
+    assertEquals("", result, "an unresolvable non-zero modifier must not register a hotkey");
+  }
+}

--- a/API/src/test/java/org/sikuli/script/KeyModifierTest.java
+++ b/API/src/test/java/org/sikuli/script/KeyModifierTest.java
@@ -5,14 +5,21 @@ package org.sikuli.script;
 
 import org.junit.jupiter.api.Test;
 
+import java.awt.event.InputEvent;
+
 import static org.junit.jupiter.api.Assertions.*;
 
 /**
- * Regression test for the modifier-mask parsing bug where a hotkey modifier
+ * Regression test for the modifier-mask parsing bug (#449): a hotkey modifier
  * value stored/passed in the extended InputEvent.*_DOWN_MASK convention
  * (e.g. SHIFT_DOWN_MASK + META_DOWN_MASK = 320) resolved to an empty
  * modifier string, causing HotkeyController to register a bare, unmodified
  * key (e.g. plain 'C') as a global hotkey instead of "shift meta C".
+ *
+ * Covers every modifier getModifierNames() recognizes, in both the legacy
+ * *_MASK and extended *_DOWN_MASK conventions, plus a value mixing both
+ * conventions in the same int — the shape any stale/migrated preference
+ * value could plausibly take.
  */
 class KeyModifierTest {
 
@@ -25,9 +32,28 @@ class KeyModifierTest {
   @Test
   void extendedShiftMetaResolves() {
     // SHIFT_DOWN_MASK(64) + META_DOWN_MASK(256) — the convention this was
-    // actually stored as in org.sikuli.script.plist's STOP_HOTKEY_MODIFIERS.
-    int extended = 320;
+    // actually stored as in org.sikuli.script.plist's STOP_HOTKEY_MODIFIERS,
+    // inherited from a SikuliX 2.0.x install sharing the same Preferences node.
+    int extended = InputEvent.SHIFT_DOWN_MASK + InputEvent.META_DOWN_MASK; // 320
     assertEquals("shift meta", KeyModifier.getModifierNames(extended));
+  }
+
+  @Test
+  void extendedShiftAltResolves() {
+    // A Windows-side equivalent of the same migration hazard: a 2.0.x
+    // Stop hotkey of Shift+Alt stores SHIFT_DOWN_MASK + ALT_DOWN_MASK = 576.
+    int extended = InputEvent.SHIFT_DOWN_MASK + InputEvent.ALT_DOWN_MASK; // 576
+    assertEquals("shift alt", KeyModifier.getModifierNames(extended));
+  }
+
+  @Test
+  void extendedCtrlResolves() {
+    assertEquals("ctrl", KeyModifier.getModifierNames(InputEvent.CTRL_DOWN_MASK));
+  }
+
+  @Test
+  void extendedAltGraphResolves() {
+    assertEquals("altGraph", KeyModifier.getModifierNames(InputEvent.ALT_GRAPH_DOWN_MASK));
   }
 
   @Test
@@ -36,7 +62,25 @@ class KeyModifierTest {
   }
 
   @Test
+  void mixedLegacyAndExtendedBitsBothResolve() {
+    // A value combining a legacy bit for one modifier with an extended bit
+    // for another — not observed in the wild, but the parser checks each
+    // modifier's legacy and extended bit independently, so this must still
+    // resolve both rather than only the one that happens to match.
+    int mixed = KeyModifier.SHIFT + InputEvent.META_DOWN_MASK; // 1 + 256 = 257
+    assertEquals("shift meta", KeyModifier.getModifierNames(mixed));
+  }
+
+  @Test
   void noModifiersResolvesEmpty() {
     assertEquals("", KeyModifier.getModifierNames(0));
+  }
+
+  @Test
+  void unrecognizedBitsResolveEmpty() {
+    // A bit pattern that is neither a legacy nor an extended modifier mask
+    // (e.g. InputEvent.BUTTON1_DOWN_MASK = 1024) must still resolve to no
+    // modifiers — getModifierNames() only recognizes keyboard modifiers.
+    assertEquals("", KeyModifier.getModifierNames(InputEvent.BUTTON1_DOWN_MASK));
   }
 }

--- a/API/src/test/java/org/sikuli/script/KeyModifierTest.java
+++ b/API/src/test/java/org/sikuli/script/KeyModifierTest.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2010-2026, sikuli.org, sikulix.com, oculix-org - MIT license
+ */
+package org.sikuli.script;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Regression test for the modifier-mask parsing bug where a hotkey modifier
+ * value stored/passed in the extended InputEvent.*_DOWN_MASK convention
+ * (e.g. SHIFT_DOWN_MASK + META_DOWN_MASK = 320) resolved to an empty
+ * modifier string, causing HotkeyController to register a bare, unmodified
+ * key (e.g. plain 'C') as a global hotkey instead of "shift meta C".
+ */
+class KeyModifierTest {
+
+  @Test
+  void legacyShiftMetaResolves() {
+    int legacy = KeyModifier.SHIFT + KeyModifier.META; // 1 + 4 = 5
+    assertEquals("shift meta", KeyModifier.getModifierNames(legacy));
+  }
+
+  @Test
+  void extendedShiftMetaResolves() {
+    // SHIFT_DOWN_MASK(64) + META_DOWN_MASK(256) — the convention this was
+    // actually stored as in org.sikuli.script.plist's STOP_HOTKEY_MODIFIERS.
+    int extended = 320;
+    assertEquals("shift meta", KeyModifier.getModifierNames(extended));
+  }
+
+  @Test
+  void legacyCtrlResolves() {
+    assertEquals("ctrl", KeyModifier.getModifierNames(KeyModifier.CTRL));
+  }
+
+  @Test
+  void noModifiersResolvesEmpty() {
+    assertEquals("", KeyModifier.getModifierNames(0));
+  }
+}


### PR DESCRIPTION
## Summary

Fixes #449 — the bare `C` key was being registered as a global system hotkey, swallowing the letter C in every application while the IDE ran.

Rebased since first review: the unrelated `key == 0` change has been lifted out (see below), so this PR is now scoped to the #449 fix and its tests — 4 files, 2 production classes.

## Root cause

Not a keymaster/Carbon defect (initial hypothesis, ruled out). `KeyModifier.getModifierNames()` recognized only the legacy `InputEvent.*_MASK` bit values, while the stored `STOP_HOTKEY_MODIFIERS` uses the extended `*_DOWN_MASK` convention (`320` = `SHIFT_DOWN_MASK + META_DOWN_MASK`). No bits matched, so the modifier string resolved to `""`, `HotkeyController` composed `KeyStroke.getKeyStroke("C")` instead of `"shift meta C"`, and keymaster faithfully registered exactly what it was asked for.

Full trace, plus @julienmerconsulting's archaeology on where `320` comes from (a SikuliX 2.0.x → OculiX preferences-migration hazard, latent until `b159a252`/#388 correctly made the getter read the key the setter writes), is in #449.

## Changes

- **`KeyModifier.getModifierNames()`** — recognize both the legacy `*_MASK` and extended `*_DOWN_MASK` bit pattern for each modifier. The two ranges are disjoint (`1/2/4/8/32` vs `64/128/256/512/8192`), so this cannot produce a false positive.
- **`HotkeyController.addHotkey(HotkeyListener, int, int)`** — refuse to register when a non-zero modifier resolves to no known modifier name, instead of silently degrading to an unmodified global hotkey. This is the more durable half: it prevents this *class* of bug regardless of what future convention or data issue appears.

## Tests

- **`KeyModifierTest`** — broadened 4 → 9 cases per review: legacy Shift+Meta (`5`), extended Shift+Meta (`320`, the observed value), extended Shift+Alt (`576`, the Windows-side equivalent), extended Ctrl, extended AltGraph, a mixed legacy/extended value, and a non-modifier bit (`BUTTON1_DOWN_MASK`) that must still resolve to nothing.
- **`HotkeyControllerTest`** (new) — direct coverage of the refusal safety net, which previously had no test of its own.

## Review feedback

| # | Ask | Status |
|---|---|---|
| 1 | Refresh the issue write-up | Done — #449 now carries the full origin timeline |
| 2 | Broaden regression tests | Done — 9 modifier cases + the safety net now tested directly |
| 3 | Isolate or justify `key == 0` | **Isolated** — dropped from this PR |

## On `key == 0`

Lifted out per your item 3 rather than justified, because the rationale I would have given does not hold up on macOS.

Java's `MacOSXPreferences` reads and writes `~/Library/Preferences/org.sikuli.script.plist` through `cfprefsd`, which caches and owns that file. Direct edits (`plutil`, Python `plistlib`) never reach the JVM — verified: the JVM reports `STOP_HOTKEY = 67` after the file was set to `0`, and the file has since been rewritten back to `67` by the daemon. So there is no route a user can actually take to set a key code to `0` on macOS today, given the Preferences UI exposes a binding control for Capture but not Stop.

The escape hatch needs a supported path — UI, `defaults write`, or something else — before it is worth proposing. Happy to open it separately if you think it is wanted.

## Test plan

- [x] `mvn test -pl API` — full suite green, 50 tests, 0 failures, 0 errors
- [x] Manual: `oculixide-4.0.0-complete-mac.jar` on macOS 26.6 / Apple M4 Pro — bare `C` types normally in other applications while the IDE runs; Abort and Capture hotkeys still fire on their real combinations
- [x] Manual: `oculixide-4.0.0-complete-lux.jar` on Ubuntu 24.04 (x86-64, X11 session) — Abort (Shift+Alt+C) and Capture (Shift+Ctrl+2) both fire correctly, no bare-key capture. Linux routes through `LinuxHotkeyManager`/jxgrabkey rather than keymaster, so this exercises `getModifierNames()` on a completely separate registration path and confirms the change is not macOS-shaped. Wayland untested — global grabs there are a separate question, unaffected by this PR.
- [x] CI (compile-API/IDE workflows)

