### PR TITLE
fix(ide): prevent afterThemeChange errors with stale document positions

### DIFF
--- a/IDE/src/main/java/org/sikuli/ide/EditorConsolePane.java
+++ b/IDE/src/main/java/org/sikuli/ide/EditorConsolePane.java
@@ -326,25 +326,29 @@ public class EditorConsolePane extends JPanel implements Runnable, ThemeAware {
 
   @Override
   public void afterThemeChange() {
-    applyThemeColors();
-    // Re-render every line of scrollback under the new palette so existing
-    // logs match the new theme (otherwise they keep the colors they had at
-    // insertion time). Cheap in practice — typical scrollback is < a few
-    // hundred lines.
-    if (textArea != null) {
-      synchronized (textArea) {
-        java.util.List<String> snapshot;
-        synchronized (rawLines) {
-          snapshot = new java.util.ArrayList<>(rawLines);
-        }
-        textArea.setText("");
-        for (String line : snapshot) {
-          appendMsg(htmlize(line));
+    try {
+      applyThemeColors();
+      // Re-render every line of scrollback under the new palette so existing
+      // logs match the new theme (otherwise they keep the colors they had at
+      // insertion time). Cheap in practice — typical scrollback is < a few
+      // hundred lines.
+      if (textArea != null) {
+        synchronized (textArea) {
+          java.util.List<String> snapshot;
+          synchronized (rawLines) {
+            snapshot = new java.util.ArrayList<>(rawLines);
+          }
+          textArea.setText("");
+          for (String line : snapshot) {
+            appendMsg(htmlize(line));
+          }
         }
       }
+      revalidate();
+      repaint();
+    } catch (Exception e) {
+      Debug.logx(-1, "EditorConsolePane: afterThemeChange failed: %s", e.getMessage());
     }
-    revalidate();
-    repaint();
   }
 
   private HTMLEditorKit editorKitWithLineWrap() {

--- a/IDE/src/main/java/org/sikuli/ide/EditorPane.java
+++ b/IDE/src/main/java/org/sikuli/ide/EditorPane.java
@@ -222,6 +222,11 @@ public class EditorPane extends JTextPane implements ThemeAware {
     // remove+reinsert later ones.
     for (int idx = savedThumbOffsets.size() - 1; idx >= 0; idx--) {
       int pos = savedThumbOffsets.get(idx)[0];
+      // Validate position is within document bounds (document may have changed since thumbnails were inserted)
+      if (pos < 0 || pos >= doc.getLength()) {
+        trace("afterThemeChange: skipping stale thumbnail at %d (document length: %d)", pos, doc.getLength());
+        continue;
+      }
       EditorImageButton old = savedThumbButtons.get(idx);
       EditorImageButton fresh = old.cloneForRefresh(this);
       if (fresh == null) continue;


### PR DESCRIPTION
## Summary

Fixes #448 — `EditorPane.afterThemeChange()` threw a `BadLocationException` when toggling Dark/Light theme after script content changed, because cached thumbnail positions (`savedThumbOffsets`) became stale relative to the document.

## Changes

- `EditorPane`: validate thumbnail positions are within document bounds before attempting to swap components; skip stale entries with trace logging instead of throwing.
- `EditorConsolePane`: wrap `afterThemeChange` in try-catch so a scrollback re-rendering error doesn't fail the whole theme toggle.

## Test plan

- [x] Manual: built and ran on macOS 26.6 / Apple M4 Pro (Oculix 4.0.0) — reproduced by editing a script with embedded thumbnails then toggling Dark/Light theme; confirmed no more `IDE: afterThemeChange` errors in the log.
- [ ] CI (compile-API/IDE workflows)
