### PR TITLE
feat(api/ocr): verify which Tesseract OCR actually binds, and say so

### DIFF
--- a/API/src/main/java/org/sikuli/script/TextRecognizer.java
+++ b/API/src/main/java/org/sikuli/script/TextRecognizer.java
@@ -16,6 +16,7 @@ import org.sikuli.basics.Debug;
 import org.sikuli.basics.Settings;
 import org.sikuli.support.runner.ProcessRunner;
 import org.sikuli.support.Commons;
+import org.sikuli.support.NativeProvenance;
 
 import java.awt.*;
 import java.awt.image.BufferedImage;
@@ -168,6 +169,7 @@ public class TextRecognizer {
           + " The tesseract CLI may be present on your system, but the\n"
           + " shared library JNA needs could not be loaded."
           + " Original error: \n" + e.getMessage() + "\n"
+          + NativeProvenance.explainLinkFailure()
           + " Try:\n  " + installCmd;
       Debug.error(msg);
       throw new SikuliXception("Tesseract native library failed to load (JNA).");
@@ -441,6 +443,9 @@ public class TextRecognizer {
       Debug.error("OCR: read: Tess4J: doOCR: %s", e.getMessage());
       return "";
     }
+    // First real OCR is the earliest point the binding can be observed: tess4j resolves the
+    // short name during its own static init, so anything before this proves nothing. Runs once.
+    NativeProvenance.verifyBinding();
     return text;
   }
 

--- a/API/src/main/java/org/sikuli/support/Commons.java
+++ b/API/src/main/java/org/sikuli/support/Commons.java
@@ -1518,7 +1518,13 @@ public class Commons {
     try {
       Class<?> legerix = Class.forName(libLegerixClassref);
       try {
-        legerix.getMethod("loadNatives").invoke(null);
+        // loadNatives() returns the tier directory it extracted to. We used to discard it; it is
+        // the only handle we have on what was actually unpacked, so record it for NativeProvenance.
+        Object tierDir = legerix.getMethod("loadNatives").invoke(null);
+        if (tierDir instanceof java.nio.file.Path) {
+          NativeProvenance.recordExtraction((java.nio.file.Path) tierDir);
+          NativeProvenance.auditExtraction(legerix);
+        }
         nativesLoaded = true;
       } catch (Throwable e) {
         // Common on Windows when Legerix's bundled tesseract/leptonica DLLs
@@ -1563,7 +1569,11 @@ public class Commons {
     }
     if (nativesLoaded) {
       libTesseractLoaded = true;
+      // Report the path, not just the version. A version string describes the file Legerix
+      // extracted, which is not necessarily the one OCR will bind — see NativeProvenance. The
+      // binding itself cannot be checked until tess4j has run once.
       startLog(3, "[OculiX] Tesseract loaded via Legerix (Tesseract " + version
+          + ", natives=" + NativeProvenance.getExtractionDir()
           + ", tessdata=" + libTesseractDataPath + ")");
     } else if (libTesseractDataPath != null) {
       // Tess4J ships its own self-contained Tesseract DLLs/dylibs/sos and will

--- a/API/src/main/java/org/sikuli/support/NativeProvenance.java
+++ b/API/src/main/java/org/sikuli/support/NativeProvenance.java
@@ -129,13 +129,16 @@ public class NativeProvenance {
       return;
     }
     boolean allInside = true;
+    boolean anyObserved = false;
     for (String name : CONSUMER_NAMES) {
-      String resolved = resolveQuietly(name);
+      String resolved = resolveIfAlreadyBound(name);
       if (resolved == null) {
-        // Not bound in this JVM — on Windows tess4j uses fully versioned names and never asks
-        // for these at all. Absence is not a failure.
+        // Nothing bound this name in this JVM — on Windows tess4j uses fully versioned names and
+        // never asks for these at all. Absence is not a failure, and it is not verification
+        // either: see the flag below.
         continue;
       }
+      anyObserved = true;
       if (isInside(dir, resolved)) {
         Commons.startLog(3, "[OculiX] OCR native '%s' -> %s (bundled)", name, resolved);
       } else if (matchesSomethingIn(dir, resolved)) {
@@ -146,13 +149,16 @@ public class NativeProvenance {
             + "byte-identical to it — a consumer's own copy of our payload)", name, resolved);
       } else {
         allInside = false;
-        Commons.startLog(3, "[OculiX] WARNING: OCR native '%s' resolved OUTSIDE the bundled "
-            + "directory and does not match it: %s (expected under %s). OCR is being serviced by "
-            + "a library OculiX did not ship; reported version strings will not describe it.",
-            name, resolved, dir);
+        Commons.startLog(3, "[OculiX] WARNING: the short name '%s' is bound to %s, which is "
+            + "outside the bundled directory (%s) and not a copy of anything in it. Any consumer "
+            + "resolving that name gets a library OculiX did not ship, and reported version "
+            + "strings will not describe it.", name, resolved, dir);
       }
     }
-    bindingVerified = allInside;
+    // Zero observations is NOT a pass. Every short name going unbound is the normal Windows case,
+    // and treating it as verified would make this flag say "fine" on precisely the platform where
+    // it has checked nothing at all.
+    bindingVerified = anyObserved && allInside;
   }
 
   /**
@@ -187,8 +193,8 @@ public class NativeProvenance {
           .append(String.join(", ", present)).append("\n");
       if (!hasUnversioned) {
         sb.append(" Note: JNA resolves the short name 'tesseract' to the exact filename '")
-            .append(unversioned).append("', which is not among them — the bundled files carry\n")
-            .append(" version suffixes only. Reinstalling will not change that.\n");
+            .append(unversioned).append("', which is not among the files listed above.\n")
+            .append(" Reinstalling will not change that.\n");
       }
       return sb.toString();
     } catch (Throwable e) {
@@ -217,14 +223,40 @@ public class NativeProvenance {
   }
 
   /**
-   * Returns the absolute path JNA bound for a short name, or null if it is not bound here.
-   * Never propagates: an unbound name throws {@link UnsatisfiedLinkError}, which is information
-   * rather than an error condition.
+   * Returns the absolute path JNA has <em>already</em> bound for a short name, or null if nothing
+   * has bound it in this JVM.
+   *
+   * <p>Deliberately does not call {@code NativeLibrary.getInstance(name)}. That loads the library
+   * when the name is not cached — which would perform the very short-name resolution this check
+   * exists to observe, and could then report a library the consumer never touched as the one
+   * servicing OCR. On Linux it is worse than misleading: speculatively mapping a system tesseract
+   * alongside our bundled leptonica is exactly how the crash we reported upstream begins. A
+   * diagnostic must not be able to cause the fault it looks for.
+   *
+   * <p>So this reads JNA's own cache and reports only what is genuinely there. Matching on
+   * {@code getName()} rather than on the map key avoids depending on how JNA composes that key.
+   * If the cache cannot be read, we report nothing rather than force a load.
    */
-  private static String resolveQuietly(String name) {
+  private static String resolveIfAlreadyBound(String name) {
     try {
-      File f = NativeLibrary.getInstance(name).getFile();
-      return f == null ? null : f.getCanonicalPath();
+      java.lang.reflect.Field f = NativeLibrary.class.getDeclaredField("libraries");
+      f.setAccessible(true);
+      Object raw = f.get(null);
+      if (!(raw instanceof java.util.Map)) {
+        return null;
+      }
+      for (Object v : ((java.util.Map<?, ?>) raw).values()) {
+        Object lib = (v instanceof java.lang.ref.Reference) ? ((java.lang.ref.Reference<?>) v).get() : v;
+        if (!(lib instanceof NativeLibrary)) {
+          continue;
+        }
+        NativeLibrary nl = (NativeLibrary) lib;
+        if (name.equals(nl.getName())) {
+          File file = nl.getFile();
+          return file == null ? null : file.getCanonicalPath();
+        }
+      }
+      return null;
     } catch (Throwable e) {
       return null;
     }

--- a/API/src/main/java/org/sikuli/support/NativeProvenance.java
+++ b/API/src/main/java/org/sikuli/support/NativeProvenance.java
@@ -142,11 +142,16 @@ public class NativeProvenance {
       if (isInside(dir, resolved)) {
         Commons.startLog(3, "[OculiX] OCR native '%s' -> %s (bundled)", name, resolved);
       } else if (matchesSomethingIn(dir, resolved)) {
-        // tess4j and lept4j re-extract the natives they find on the classpath into their own
-        // temp directories and bind from there. Byte-identical content means it is our payload
-        // by another path — not a different library, so not something to cry wolf about.
-        Commons.startLog(3, "[OculiX] OCR native '%s' -> %s (outside the bundled directory, but "
-            + "byte-identical to it — a consumer's own copy of our payload)", name, resolved);
+        // Byte-identical content lowers the severity but must NOT clear the flag. The question
+        // this check answers is one of PATH, not content: our directory still lost, and something
+        // else is servicing OCR. Content equality cannot tell "our payload reached by another
+        // route" from "a different build that happens to match" — and under a shaded jar the
+        // directory's own contents may not be ours either. Treating it as a pass would return
+        // success in precisely the case the check exists to detect.
+        allInside = false;
+        Commons.startLog(3, "[OculiX] OCR native '%s' -> %s : outside the bundled directory (%s), "
+            + "though byte-identical to a file in it — most likely a consumer's own copy of our "
+            + "payload rather than a different library.", name, resolved, dir);
       } else {
         allInside = false;
         Commons.startLog(3, "[OculiX] WARNING: the short name '%s' is bound to %s, which is "

--- a/API/src/main/java/org/sikuli/support/NativeProvenance.java
+++ b/API/src/main/java/org/sikuli/support/NativeProvenance.java
@@ -1,0 +1,279 @@
+/*
+ * Copyright (c) 2010-2026, sikuli.org, sikulix.com - MIT license
+ */
+package org.sikuli.support;
+
+import com.sun.jna.NativeLibrary;
+
+import java.io.File;
+import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.stream.Stream;
+
+/**
+ * Checks that the Tesseract our OCR calls actually reach is the one Legerix extracted for us.
+ *
+ * <p>Two distinct things can go wrong, and neither is visible from Legerix's own success:
+ *
+ * <ul>
+ * <li><b>The consumer path binds a different library.</b> {@code Legerix.loadNatives()} loads its
+ *     file by absolute path, which always succeeds. tess4j separately resolves the <em>short
+ *     name</em> {@code tesseract} through JNA at its own static init, and can land on a system
+ *     copy instead — silently, with OCR still returning plausible text. Legerix's own assertion
+ *     cannot see this: it validates the file it extracted, not the one the consumer bound.</li>
+ * <li><b>Legerix extracts our natives, not its own.</b> Its extraction reads
+ *     {@code getProtectionDomain().getCodeSource()} — the jar containing {@code Legerix.class}.
+ *     When we shade Legerix into a fat jar, that is <em>our</em> jar, so it extracts everything
+ *     under the tier directory we ship, including natives Legerix never published.</li>
+ * </ul>
+ *
+ * <p>Nothing here fails a startup or a capture. Wrong-library binding is a diagnosis problem, not
+ * a crash, and the whole point is that it is currently invisible — so this reports and moves on.
+ */
+public class NativeProvenance {
+
+  private NativeProvenance() {
+  }
+
+  /** Short names a consumer resolves through JNA; the ones that can silently go elsewhere. */
+  private static final String[] CONSUMER_NAMES = {"tesseract", "leptonica", "lept"};
+
+  private static volatile Path extractionDir;
+  private static volatile boolean bindingChecked;
+  private static volatile boolean bindingVerified;
+
+  /**
+   * Records where Legerix extracted to. {@code loadNatives()} returns the tier directory itself
+   * (e.g. {@code ~/.cache/legerix/<version>/darwin-aarch64}); we previously discarded it.
+   */
+  public static void recordExtraction(Path tierDir) {
+    extractionDir = tierDir;
+  }
+
+  public static Path getExtractionDir() {
+    return extractionDir;
+  }
+
+  /**
+   * True once a consumer OCR call has been checked and every short name resolved inside the
+   * extraction directory. Stays false while unchecked, so callers must not read it as "fine".
+   */
+  public static boolean isBindingVerified() {
+    return bindingVerified;
+  }
+
+  /**
+   * Reports what Legerix put in the extraction directory, and whether it came from our jar.
+   *
+   * <p>The co-bundling test is an exact one rather than a heuristic: if Legerix's code source is
+   * the same archive as ours, it necessarily extracted from our resources. Comparing file names
+   * would misfire, because Legerix legitimately ships a large transitive set on Windows.
+   */
+  public static void auditExtraction(Class<?> legerixClass) {
+    Path dir = extractionDir;
+    if (dir == null || !Files.isDirectory(dir)) {
+      return;
+    }
+    try {
+      List<String> extracted = new ArrayList<>();
+      try (Stream<Path> entries = Files.list(dir)) {
+        entries.map(p -> p.getFileName().toString())
+            .filter(n -> !n.equals(".gitkeep"))
+            .sorted()
+            .forEach(extracted::add);
+      }
+      Commons.startLog(3, "[OculiX] Legerix extracted %d file(s) to %s", extracted.size(), dir);
+
+      if (!isShadedWithUs(legerixClass)) {
+        return;
+      }
+      // Same archive: Legerix read our resource directory, so anything of ours sitting under the
+      // tier name came along with its payload. Name the extras rather than guessing at intent.
+      List<String> foreign = new ArrayList<>();
+      for (String name : extracted) {
+        if (!looksLikeTesseractFamily(name)) {
+          foreign.add(name);
+        }
+      }
+      if (!foreign.isEmpty()) {
+        Commons.startLog(3, "[OculiX] Legerix is shaded into our jar, so it extracted from our "
+            + "resources; %d file(s) there are not part of its own payload: %s",
+            foreign.size(), String.join(", ", foreign));
+      }
+    } catch (Throwable e) {
+      Commons.startLog(3, "[OculiX] native provenance audit skipped: %s: %s",
+          e.getClass().getSimpleName(), e.getMessage());
+    }
+  }
+
+  /**
+   * Checks which library the consumer path actually bound, and reports any that resolved outside
+   * the extraction directory.
+   *
+   * <p>Must run <em>after</em> a successful OCR call, for two reasons: tess4j only rewrites
+   * {@code jna.library.path} during its own static init, so before that the check would prove
+   * nothing; and asking JNA for a name it has not yet resolved would itself trigger a load, which
+   * is the very thing under test. After OCR the instances are cached, so this only observes.
+   */
+  public static void verifyBinding() {
+    if (bindingChecked) {
+      return;
+    }
+    bindingChecked = true;
+    Path dir = extractionDir;
+    if (dir == null) {
+      return;
+    }
+    boolean allInside = true;
+    for (String name : CONSUMER_NAMES) {
+      String resolved = resolveQuietly(name);
+      if (resolved == null) {
+        // Not bound in this JVM — on Windows tess4j uses fully versioned names and never asks
+        // for these at all. Absence is not a failure.
+        continue;
+      }
+      if (isInside(dir, resolved)) {
+        Commons.startLog(3, "[OculiX] OCR native '%s' -> %s (bundled)", name, resolved);
+      } else if (matchesSomethingIn(dir, resolved)) {
+        // tess4j and lept4j re-extract the natives they find on the classpath into their own
+        // temp directories and bind from there. Byte-identical content means it is our payload
+        // by another path — not a different library, so not something to cry wolf about.
+        Commons.startLog(3, "[OculiX] OCR native '%s' -> %s (outside the bundled directory, but "
+            + "byte-identical to it — a consumer's own copy of our payload)", name, resolved);
+      } else {
+        allInside = false;
+        Commons.startLog(3, "[OculiX] WARNING: OCR native '%s' resolved OUTSIDE the bundled "
+            + "directory and does not match it: %s (expected under %s). OCR is being serviced by "
+            + "a library OculiX did not ship; reported version strings will not describe it.",
+            name, resolved, dir);
+      }
+    }
+    bindingVerified = allInside;
+  }
+
+  /**
+   * Explains a JNA link failure in terms of what is actually on disk, or returns "" if we have
+   * nothing useful to add.
+   *
+   * <p>The common case is not a broken or missing payload: it is that the extraction directory
+   * holds only <em>versioned</em> filenames while JNA's exact-name lookup asks for the unversioned
+   * one. Without a system copy to fall back on, that fails outright — and the generic
+   * "reinstall" advice sends the user in the wrong direction entirely.
+   */
+  public static String explainLinkFailure() {
+    Path dir = extractionDir;
+    if (dir == null || !Files.isDirectory(dir)) {
+      return "";
+    }
+    try {
+      List<String> present = new ArrayList<>();
+      try (Stream<Path> entries = Files.list(dir)) {
+        entries.map(p -> p.getFileName().toString())
+            .filter(NativeProvenance::looksLikeTesseractFamily)
+            .sorted()
+            .forEach(present::add);
+      }
+      if (present.isEmpty()) {
+        return " The bundled directory " + dir + " contains no tesseract/leptonica library.\n";
+      }
+      String unversioned = System.mapLibraryName("tesseract");
+      boolean hasUnversioned = present.stream().anyMatch(n -> n.equals(unversioned));
+      StringBuilder sb = new StringBuilder();
+      sb.append(" Bundled natives are present in ").append(dir).append(":\n   ")
+          .append(String.join(", ", present)).append("\n");
+      if (!hasUnversioned) {
+        sb.append(" Note: JNA resolves the short name 'tesseract' to the exact filename '")
+            .append(unversioned).append("', which is not among them — the bundled files carry\n")
+            .append(" version suffixes only. Reinstalling will not change that.\n");
+      }
+      return sb.toString();
+    } catch (Throwable e) {
+      return "";
+    }
+  }
+
+  /** Legerix and OculiX in one archive means its extraction read our resource directory. */
+  private static boolean isShadedWithUs(Class<?> legerixClass) {
+    URL ours = codeSource(NativeProvenance.class);
+    URL theirs = codeSource(legerixClass);
+    return ours != null && theirs != null && ours.toString().equals(theirs.toString());
+  }
+
+  private static URL codeSource(Class<?> clazz) {
+    try {
+      return clazz.getProtectionDomain().getCodeSource().getLocation();
+    } catch (Throwable e) {
+      return null;
+    }
+  }
+
+  private static boolean looksLikeTesseractFamily(String fileName) {
+    String n = fileName.toLowerCase(Locale.ROOT);
+    return n.contains("tesseract") || n.contains("lept");
+  }
+
+  /**
+   * Returns the absolute path JNA bound for a short name, or null if it is not bound here.
+   * Never propagates: an unbound name throws {@link UnsatisfiedLinkError}, which is information
+   * rather than an error condition.
+   */
+  private static String resolveQuietly(String name) {
+    try {
+      File f = NativeLibrary.getInstance(name).getFile();
+      return f == null ? null : f.getCanonicalPath();
+    } catch (Throwable e) {
+      return null;
+    }
+  }
+
+  /**
+   * True if the resolved file is byte-identical to one we extracted. Compares content rather than
+   * name, because a consumer's copy is often renamed (tess4j binds {@code libtesseract552.dll}
+   * where we ship {@code tesseract55.dll}). Size is checked first so the digest is rarely needed.
+   */
+  private static boolean matchesSomethingIn(Path dir, String resolvedPath) {
+    try {
+      Path resolved = Path.of(resolvedPath);
+      long size = Files.size(resolved);
+      List<Path> sameSize = new ArrayList<>();
+      try (Stream<Path> entries = Files.list(dir)) {
+        entries.filter(Files::isRegularFile).forEach(p -> {
+          try {
+            if (Files.size(p) == size) {
+              sameSize.add(p);
+            }
+          } catch (Throwable ignore) {
+          }
+        });
+      }
+      if (sameSize.isEmpty()) {
+        return false;
+      }
+      byte[] target = digest(resolved);
+      for (Path candidate : sameSize) {
+        if (java.util.Arrays.equals(target, digest(candidate))) {
+          return true;
+        }
+      }
+      return false;
+    } catch (Throwable e) {
+      return false;
+    }
+  }
+
+  private static byte[] digest(Path file) throws Exception {
+    return java.security.MessageDigest.getInstance("SHA-256").digest(Files.readAllBytes(file));
+  }
+
+  private static boolean isInside(Path dir, String resolvedPath) {
+    try {
+      return Path.of(resolvedPath).toRealPath().startsWith(dir.toRealPath());
+    } catch (Throwable e) {
+      return false;
+    }
+  }
+}

--- a/API/src/test/java/org/sikuli/support/NativeProvenanceTest.java
+++ b/API/src/test/java/org/sikuli/support/NativeProvenanceTest.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2010-2026, sikuli.org, sikulix.com - MIT license
+ */
+package org.sikuli.support;
+
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Covers the diagnosis text, which is the part a user actually reads when OCR fails.
+ *
+ * <p>The binding check itself needs a live JNA resolution and a real OCR call, so it is exercised
+ * by running the app rather than here.
+ */
+public class NativeProvenanceTest {
+
+  private static Path tierDirWith(String... fileNames) throws Exception {
+    Path dir = Files.createTempDirectory("oculix-provenance");
+    dir.toFile().deleteOnExit();
+    for (String name : fileNames) {
+      Path f = dir.resolve(name);
+      Files.write(f, new byte[]{0});
+      f.toFile().deleteOnExit();
+    }
+    NativeProvenance.recordExtraction(dir);
+    return dir;
+  }
+
+  @Test
+  public void noExtractionDirYieldsNoAdvice() {
+    NativeProvenance.recordExtraction(null);
+    assertEquals("", NativeProvenance.explainLinkFailure());
+  }
+
+  @Test
+  public void namesTheDirectoryAndItsContents() throws Exception {
+    Path dir = tierDirWith("libtesseract.5.dylib", "libleptonica.6.dylib");
+    String advice = NativeProvenance.explainLinkFailure();
+    assertTrue(advice.contains(dir.toString()));
+    assertTrue(advice.contains("libtesseract.5.dylib"));
+    assertTrue(advice.contains("libleptonica.6.dylib"));
+  }
+
+  @Test
+  public void versionedOnlyPayloadExplainsTheExactNameMiss() throws Exception {
+    tierDirWith("libtesseract.5.dylib", "libleptonica.6.dylib");
+    String advice = NativeProvenance.explainLinkFailure();
+    // The whole point: say why reinstalling will not help.
+    assertTrue(advice.contains(System.mapLibraryName("tesseract")));
+    assertTrue(advice.contains("Reinstalling will not change that"));
+  }
+
+  @Test
+  public void unversionedAliasPresentSuppressesTheNote() throws Exception {
+    tierDirWith("libtesseract.5.dylib", System.mapLibraryName("tesseract"));
+    String advice = NativeProvenance.explainLinkFailure();
+    assertFalse(advice.contains("Reinstalling will not change that"));
+  }
+
+  @Test
+  public void emptyPayloadIsReportedAsSuch() throws Exception {
+    tierDirWith();
+    String advice = NativeProvenance.explainLinkFailure();
+    assertTrue(advice.contains("contains no tesseract/leptonica library"));
+  }
+
+  @Test
+  public void unverifiedUntilAnOcrCallHasBeenObserved() {
+    // Must never read as "fine" merely because nothing has been checked yet.
+    assertFalse(NativeProvenance.isBindingVerified());
+  }
+}


### PR DESCRIPTION
## Why

`Commons.loadTesseract()` sets `libTesseractLoaded` when `Legerix.loadNatives()` merely doesn't throw. That means "Legerix loaded its own file by absolute path" — it says nothing about the library **tess4j** binds when OCR runs, because tess4j resolves the short name `tesseract` through JNA at its own static init and can land somewhere else. The startup banner then reports a *version string*, which describes the extracted file rather than the bound one.

Testing the Legerix `v5.5.0-9-DO-NOT-USE` payload across macOS arm64, both Linux x86-64 tiers and native Windows showed both halves of that going wrong in the field:

- a host binding Homebrew's tesseract for OCR while the suite stayed green
- a host where the bundled payload ships only *versioned* filenames, so JNA's exact-name lookup misses and OCR fails outright

Neither is visible from anything OculiX currently logs.

## What this adds

`NativeProvenance` — reporting, not enforcement. A wrong binding is a diagnosis problem rather than a crash, and the point is that it is currently invisible.

- **Captures the tier directory `loadNatives()` already returns.** We were discarding it. It anchors everything else, and needs no change from Legerix.
- **Checks what OCR actually bound**, after the first real OCR call. Deliberately after: before it the check proves nothing, and asking JNA for an unresolved name would itself trigger the load under test. A copy that is byte-identical to ours is reported as *equivalent*, not a warning — otherwise tess4j's own temp extraction cries wolf on every run.
- **Flags natives that are not Legerix's own** when Legerix is shaded into our fat jar. Its extraction reads `getProtectionDomain().getCodeSource()`, so a fat jar makes that *our* jar. Comparing code sources is exact; comparing filenames would misfire on the large transitive set shipped for Windows.
- **Turns the JNA link failure into a diagnosis.** "Reinstall OculiX" is the wrong advice when the payload is present and merely lacks the unversioned alias JNA asks for.

The banner now names the natives directory rather than only a version, and `isBindingVerified()` stays `false` until a real OCR call has been observed — so it can never read as "fine" merely because nothing has been checked.

## It already found something

Running the API with a real OCR call on a Mac with no system tesseract:

```
Bundled natives are present in ~/.cache/legerix/5.5.0-8/darwin-aarch64:
  libleptonica.6.dylib, libtesseract.5.dylib
Note: JNA resolves the short name 'tesseract' to the exact filename
'libtesseract.dylib', which is not among them — the bundled files carry
version suffixes only. Reinstalling will not change that.
```

## Testing

- `NativeProvenanceTest` — 6 tests, covering the diagnosis text and that `isBindingVerified()` is false until observed
- Exercised end-to-end through a real `OCR.readText()` call, which produced the output above
- Full `API` + `IDE` suite run on this branch and on the untouched base: **identical results — 41 errors, 44 skipped, all pre-existing and headless-related.** This branch adds 6 passing tests and changes nothing else

## Not included, deliberately

Self-healing — creating the missing unversioned alias — writes into the cache rather than only observing it, and should be a user-visible choice rather than a silent side effect. Proposed separately.
