### PR TITLE
feat(api/ocr): offer to repair the missing OCR native alias, on the user's terms

### DIFF
--- a/API/src/main/java/org/sikuli/basics/PreferencesUser.java
+++ b/API/src/main/java/org/sikuli/basics/PreferencesUser.java
@@ -23,6 +23,12 @@ public class PreferencesUser {
   public final static int AUTO_NAMING_TIMESTAMP = 0;
   public final static int AUTO_NAMING_OCR = 1;
   public final static int AUTO_NAMING_OFF = 2;
+  // What to do when the bundled OCR natives lack the unversioned filename JNA looks for.
+  // ASK is the default: this writes into a cache directory we did not create, so it is the
+  // user's call rather than ours to make quietly.
+  public final static int OCR_ALIAS_ASK = 0;
+  public final static int OCR_ALIAS_AUTO = 1;
+  public final static int OCR_ALIAS_NEVER = 2;
   public final static int HORIZONTAL = 0;
   public final static int VERTICAL = 1;
   public final static int UNKNOWN = -1;
@@ -255,6 +261,15 @@ public class PreferencesUser {
 
   public int getAutoNamingMethod() {
     return pref.getInt("AUTO_NAMING", AUTO_NAMING_OCR);
+  }
+
+  // ***** OCR native aliases
+  public void setOcrAliasPolicy(int p) {
+    pref.putInt("OCR_ALIAS_POLICY", p);
+  }
+
+  public int getOcrAliasPolicy() {
+    return pref.getInt("OCR_ALIAS_POLICY", OCR_ALIAS_ASK);
   }
 
   public void setDefaultThumbHeight(int h) {

--- a/API/src/main/java/org/sikuli/script/TextRecognizer.java
+++ b/API/src/main/java/org/sikuli/script/TextRecognizer.java
@@ -16,6 +16,7 @@ import org.sikuli.basics.Debug;
 import org.sikuli.basics.Settings;
 import org.sikuli.support.runner.ProcessRunner;
 import org.sikuli.support.Commons;
+import org.sikuli.support.NativeProvenance;
 
 import java.awt.*;
 import java.awt.image.BufferedImage;
@@ -168,6 +169,7 @@ public class TextRecognizer {
           + " The tesseract CLI may be present on your system, but the\n"
           + " shared library JNA needs could not be loaded."
           + " Original error: \n" + e.getMessage() + "\n"
+          + NativeProvenance.explainLinkFailure()
           + " Try:\n  " + installCmd;
       Debug.error(msg);
       throw new SikuliXception("Tesseract native library failed to load (JNA).");
@@ -441,6 +443,9 @@ public class TextRecognizer {
       Debug.error("OCR: read: Tess4J: doOCR: %s", e.getMessage());
       return "";
     }
+    // First real OCR is the earliest point the binding can be observed: tess4j resolves the
+    // short name during its own static init, so anything before this proves nothing. Runs once.
+    NativeProvenance.verifyBinding();
     return text;
   }
 

--- a/API/src/main/java/org/sikuli/support/Commons.java
+++ b/API/src/main/java/org/sikuli/support/Commons.java
@@ -1518,7 +1518,13 @@ public class Commons {
     try {
       Class<?> legerix = Class.forName(libLegerixClassref);
       try {
-        legerix.getMethod("loadNatives").invoke(null);
+        // loadNatives() returns the tier directory it extracted to. We used to discard it; it is
+        // the only handle we have on what was actually unpacked, so record it for NativeProvenance.
+        Object tierDir = legerix.getMethod("loadNatives").invoke(null);
+        if (tierDir instanceof java.nio.file.Path) {
+          NativeProvenance.recordExtraction((java.nio.file.Path) tierDir);
+          NativeProvenance.auditExtraction(legerix);
+        }
         nativesLoaded = true;
       } catch (Throwable e) {
         // Common on Windows when Legerix's bundled tesseract/leptonica DLLs
@@ -1563,7 +1569,11 @@ public class Commons {
     }
     if (nativesLoaded) {
       libTesseractLoaded = true;
+      // Report the path, not just the version. A version string describes the file Legerix
+      // extracted, which is not necessarily the one OCR will bind — see NativeProvenance. The
+      // binding itself cannot be checked until tess4j has run once.
       startLog(3, "[OculiX] Tesseract loaded via Legerix (Tesseract " + version
+          + ", natives=" + NativeProvenance.getExtractionDir()
           + ", tessdata=" + libTesseractDataPath + ")");
     } else if (libTesseractDataPath != null) {
       // Tess4J ships its own self-contained Tesseract DLLs/dylibs/sos and will

--- a/API/src/main/java/org/sikuli/support/Commons.java
+++ b/API/src/main/java/org/sikuli/support/Commons.java
@@ -1600,15 +1600,20 @@ public class Commons {
    * dialog they cannot answer.
    */
   private static void applyOcrAliasPolicy() {
-    if (NativeProvenance.missingAliases().isEmpty()) {
+    // Capture the directory once and pass it to every call below. Checking and repairing are two
+    // calls, and the field between them is a mutable static that lazy init can re-point — so the
+    // list would be computed for one directory and the links written into another.
+    java.nio.file.Path dir = NativeProvenance.getExtractionDir();
+    if (NativeProvenance.missingAliases(dir).isEmpty()) {
       return;
     }
     int policy = PreferencesUser.get().getOcrAliasPolicy();
     if (policy == PreferencesUser.OCR_ALIAS_AUTO) {
-      NativeProvenance.createAliases();
+      NativeProvenance.createAliases(dir);
     } else if (policy == PreferencesUser.OCR_ALIAS_NEVER) {
       startLog(3, "[OculiX] bundled OCR natives lack the unversioned name JNA looks for; "
-          + "repair is disabled by preference. To do it by hand:\n" + NativeProvenance.manualCommand());
+          + "repair is disabled by preference. To do it by hand:\n"
+          + NativeProvenance.manualCommand(dir));
     }
   }
 

--- a/API/src/main/java/org/sikuli/support/Commons.java
+++ b/API/src/main/java/org/sikuli/support/Commons.java
@@ -11,6 +11,7 @@ import org.opencv.imgcodecs.Imgcodecs;
 import org.opencv.imgproc.Imgproc;
 import org.sikuli.basics.Debug;
 import org.sikuli.basics.HotkeyManager;
+import org.sikuli.basics.PreferencesUser;
 import org.sikuli.basics.Settings;
 import org.sikuli.script.*;
 import org.sikuli.support.devices.HelpDevice;
@@ -1524,6 +1525,7 @@ public class Commons {
         if (tierDir instanceof java.nio.file.Path) {
           NativeProvenance.recordExtraction((java.nio.file.Path) tierDir);
           NativeProvenance.auditExtraction(legerix);
+          applyOcrAliasPolicy();
         }
         nativesLoaded = true;
       } catch (Throwable e) {
@@ -1584,6 +1586,29 @@ public class Commons {
           + "Legerix-bundled tessdata (" + libTesseractDataPath + ")");
     } else {
       startLog(3, "[OculiX] No Tesseract available — OCR will require a system install.");
+    }
+  }
+
+  /**
+   * Acts on the user's stored choice about repairing missing OCR native aliases.
+   *
+   * <p>Re-checked on every startup rather than once at install: the cache is keyed by version, so
+   * an upgrade extracts a fresh directory and any alias made previously is gone. The same reason a
+   * package manager re-points its "latest" link after each build rather than assuming it holds.
+   *
+   * <p>ASK does nothing here — the IDE prompts, and headless callers get the diagnosis without a
+   * dialog they cannot answer.
+   */
+  private static void applyOcrAliasPolicy() {
+    if (NativeProvenance.missingAliases().isEmpty()) {
+      return;
+    }
+    int policy = PreferencesUser.get().getOcrAliasPolicy();
+    if (policy == PreferencesUser.OCR_ALIAS_AUTO) {
+      NativeProvenance.createAliases();
+    } else if (policy == PreferencesUser.OCR_ALIAS_NEVER) {
+      startLog(3, "[OculiX] bundled OCR natives lack the unversioned name JNA looks for; "
+          + "repair is disabled by preference. To do it by hand:\n" + NativeProvenance.manualCommand());
     }
   }
 

--- a/API/src/main/java/org/sikuli/support/NativeProvenance.java
+++ b/API/src/main/java/org/sikuli/support/NativeProvenance.java
@@ -51,7 +51,14 @@ public class NativeProvenance {
    * (e.g. {@code ~/.cache/legerix/<version>/darwin-aarch64}); we previously discarded it.
    */
   public static void recordExtraction(Path tierDir) {
+    Path previous = extractionDir;
     extractionDir = tierDir;
+    if (previous != null && tierDir != null && !previous.equals(tierDir)) {
+      // Worth surfacing: the first touch of Commons from anywhere triggers its static init, which
+      // loads the natives and records the real tier directory — silently replacing whatever a
+      // caller had set. Anything computed against the old value is now stale.
+      Commons.startLog(3, "[OculiX] native extraction dir changed: %s -> %s", previous, tierDir);
+    }
   }
 
   /**
@@ -236,8 +243,21 @@ public class NativeProvenance {
    * </ul>
    */
   public static List<String> missingAliases() {
+    return missingAliases(extractionDir);
+  }
+
+  /**
+   * As {@link #missingAliases()}, for a directory the caller has already captured.
+   *
+   * <p>The explicit parameter is the point. {@code extractionDir} is a mutable static, and the
+   * first touch of {@link Commons} from anywhere triggers its static init, which loads the natives
+   * and records the real tier directory — replacing whatever a caller had set. Reading the field
+   * once per method meant a single logical operation could straddle two directories: the alias
+   * names computed for one, the symlinks written into another. With a filesystem write as the
+   * consequence, that is not a race worth leaving open.
+   */
+  static List<String> missingAliases(Path dir) {
     List<String> missing = new ArrayList<>();
-    Path dir = extractionDir;
     if (dir == null || !Files.isDirectory(dir) || Commons.runningWindows()) {
       return missing;
     }
@@ -274,7 +294,7 @@ public class NativeProvenance {
   /** The command a user who declines can run themselves. Never leave them worse off for saying no. */
   public static String manualCommand() {
     Path dir = extractionDir;
-    List<String> missing = missingAliases();
+    List<String> missing = missingAliases(dir);
     if (dir == null || missing.isEmpty()) {
       return "";
     }
@@ -296,12 +316,14 @@ public class NativeProvenance {
    * nothing.
    */
   public static int createAliases() {
+    // Captured once and threaded through: every name below and every file written must refer to
+    // the same directory, whatever else re-points the field in between.
     Path dir = extractionDir;
     if (dir == null) {
       return 0;
     }
     int made = 0;
-    for (String alias : missingAliases()) {
+    for (String alias : missingAliases(dir)) {
       // A DT_NEEDED-derived alias always names a leptonica; the unversioned ones map by family.
       Path target = targetFor(dir, alias.toLowerCase(Locale.ROOT).contains("lept")
           && !isAliasName(alias.toLowerCase(Locale.ROOT)) ? "lept" : familyOf(alias));

--- a/API/src/main/java/org/sikuli/support/NativeProvenance.java
+++ b/API/src/main/java/org/sikuli/support/NativeProvenance.java
@@ -129,13 +129,16 @@ public class NativeProvenance {
       return;
     }
     boolean allInside = true;
+    boolean anyObserved = false;
     for (String name : CONSUMER_NAMES) {
-      String resolved = resolveQuietly(name);
+      String resolved = resolveIfAlreadyBound(name);
       if (resolved == null) {
-        // Not bound in this JVM — on Windows tess4j uses fully versioned names and never asks
-        // for these at all. Absence is not a failure.
+        // Nothing bound this name in this JVM — on Windows tess4j uses fully versioned names and
+        // never asks for these at all. Absence is not a failure, and it is not verification
+        // either: see the flag below.
         continue;
       }
+      anyObserved = true;
       if (isInside(dir, resolved)) {
         Commons.startLog(3, "[OculiX] OCR native '%s' -> %s (bundled)", name, resolved);
       } else if (matchesSomethingIn(dir, resolved)) {
@@ -146,13 +149,16 @@ public class NativeProvenance {
             + "byte-identical to it — a consumer's own copy of our payload)", name, resolved);
       } else {
         allInside = false;
-        Commons.startLog(3, "[OculiX] WARNING: OCR native '%s' resolved OUTSIDE the bundled "
-            + "directory and does not match it: %s (expected under %s). OCR is being serviced by "
-            + "a library OculiX did not ship; reported version strings will not describe it.",
-            name, resolved, dir);
+        Commons.startLog(3, "[OculiX] WARNING: the short name '%s' is bound to %s, which is "
+            + "outside the bundled directory (%s) and not a copy of anything in it. Any consumer "
+            + "resolving that name gets a library OculiX did not ship, and reported version "
+            + "strings will not describe it.", name, resolved, dir);
       }
     }
-    bindingVerified = allInside;
+    // Zero observations is NOT a pass. Every short name going unbound is the normal Windows case,
+    // and treating it as verified would make this flag say "fine" on precisely the platform where
+    // it has checked nothing at all.
+    bindingVerified = anyObserved && allInside;
   }
 
   /**
@@ -187,8 +193,8 @@ public class NativeProvenance {
           .append(String.join(", ", present)).append("\n");
       if (!hasUnversioned) {
         sb.append(" Note: JNA resolves the short name 'tesseract' to the exact filename '")
-            .append(unversioned).append("', which is not among them — the bundled files carry\n")
-            .append(" version suffixes only. Reinstalling will not change that.\n");
+            .append(unversioned).append("', which is not among the files listed above.\n")
+            .append(" Reinstalling will not change that.\n");
       }
       return sb.toString();
     } catch (Throwable e) {
@@ -217,14 +223,40 @@ public class NativeProvenance {
   }
 
   /**
-   * Returns the absolute path JNA bound for a short name, or null if it is not bound here.
-   * Never propagates: an unbound name throws {@link UnsatisfiedLinkError}, which is information
-   * rather than an error condition.
+   * Returns the absolute path JNA has <em>already</em> bound for a short name, or null if nothing
+   * has bound it in this JVM.
+   *
+   * <p>Deliberately does not call {@code NativeLibrary.getInstance(name)}. That loads the library
+   * when the name is not cached — which would perform the very short-name resolution this check
+   * exists to observe, and could then report a library the consumer never touched as the one
+   * servicing OCR. On Linux it is worse than misleading: speculatively mapping a system tesseract
+   * alongside our bundled leptonica is exactly how the crash we reported upstream begins. A
+   * diagnostic must not be able to cause the fault it looks for.
+   *
+   * <p>So this reads JNA's own cache and reports only what is genuinely there. Matching on
+   * {@code getName()} rather than on the map key avoids depending on how JNA composes that key.
+   * If the cache cannot be read, we report nothing rather than force a load.
    */
-  private static String resolveQuietly(String name) {
+  private static String resolveIfAlreadyBound(String name) {
     try {
-      File f = NativeLibrary.getInstance(name).getFile();
-      return f == null ? null : f.getCanonicalPath();
+      java.lang.reflect.Field f = NativeLibrary.class.getDeclaredField("libraries");
+      f.setAccessible(true);
+      Object raw = f.get(null);
+      if (!(raw instanceof java.util.Map)) {
+        return null;
+      }
+      for (Object v : ((java.util.Map<?, ?>) raw).values()) {
+        Object lib = (v instanceof java.lang.ref.Reference) ? ((java.lang.ref.Reference<?>) v).get() : v;
+        if (!(lib instanceof NativeLibrary)) {
+          continue;
+        }
+        NativeLibrary nl = (NativeLibrary) lib;
+        if (name.equals(nl.getName())) {
+          File file = nl.getFile();
+          return file == null ? null : file.getCanonicalPath();
+        }
+      }
+      return null;
     } catch (Throwable e) {
       return null;
     }

--- a/API/src/main/java/org/sikuli/support/NativeProvenance.java
+++ b/API/src/main/java/org/sikuli/support/NativeProvenance.java
@@ -142,11 +142,16 @@ public class NativeProvenance {
       if (isInside(dir, resolved)) {
         Commons.startLog(3, "[OculiX] OCR native '%s' -> %s (bundled)", name, resolved);
       } else if (matchesSomethingIn(dir, resolved)) {
-        // tess4j and lept4j re-extract the natives they find on the classpath into their own
-        // temp directories and bind from there. Byte-identical content means it is our payload
-        // by another path — not a different library, so not something to cry wolf about.
-        Commons.startLog(3, "[OculiX] OCR native '%s' -> %s (outside the bundled directory, but "
-            + "byte-identical to it — a consumer's own copy of our payload)", name, resolved);
+        // Byte-identical content lowers the severity but must NOT clear the flag. The question
+        // this check answers is one of PATH, not content: our directory still lost, and something
+        // else is servicing OCR. Content equality cannot tell "our payload reached by another
+        // route" from "a different build that happens to match" — and under a shaded jar the
+        // directory's own contents may not be ours either. Treating it as a pass would return
+        // success in precisely the case the check exists to detect.
+        allInside = false;
+        Commons.startLog(3, "[OculiX] OCR native '%s' -> %s : outside the bundled directory (%s), "
+            + "though byte-identical to a file in it — most likely a consumer's own copy of our "
+            + "payload rather than a different library.", name, resolved, dir);
       } else {
         allInside = false;
         Commons.startLog(3, "[OculiX] WARNING: the short name '%s' is bound to %s, which is "

--- a/API/src/main/java/org/sikuli/support/NativeProvenance.java
+++ b/API/src/main/java/org/sikuli/support/NativeProvenance.java
@@ -248,13 +248,23 @@ public class NativeProvenance {
           missing.add(alias);
         }
       }
-      // Evaluated independently of what the loop above found. Gating this on the unversioned
-      // set being incomplete would skip exactly the users who already followed our earlier
-      // three-symlink advice: their unversioned aliases exist, so nothing is "missing", and the
-      // one file that satisfies tesseract's ELF NEEDED never gets created.
-      if (Commons.runningLinux() && targetFor(dir, "lept") != null
-          && !Files.exists(dir.resolve(LINUX_LEPT_SONAME))) {
-        missing.add(LINUX_LEPT_SONAME);
+      // Derived, not assumed. The dynamic linker's requirement is recorded inside the shipped
+      // tesseract and is invisible in a directory listing — no file of that name exists, which is
+      // precisely the defect. Reading DT_NEEDED answers it for whatever tier is actually present,
+      // including the one where the name already matches and no alias is wanted at all.
+      //
+      // Evaluated independently of what the loop above found: gating it on the unversioned set
+      // being incomplete would skip exactly the users who already followed our earlier
+      // three-symlink advice, whose aliases exist so nothing looks "missing".
+      Path tesseract = targetFor(dir, "tesseract");
+      if (tesseract != null) {
+        for (String need : readElfNeeded(tesseract)) {
+          // Only dependencies this directory could satisfy. The rest of tesseract's NEEDED list is
+          // libc, libstdc++ and friends, which are the system's business and not ours to alias.
+          if (need.toLowerCase(Locale.ROOT).contains("lept") && !Files.exists(dir.resolve(need))) {
+            missing.add(need);
+          }
+        }
       }
     } catch (Throwable ignore) {
     }
@@ -271,7 +281,9 @@ public class NativeProvenance {
     StringBuilder sb = new StringBuilder("cd ").append(dir).append(" && \\\n");
     for (int i = 0; i < missing.size(); i++) {
       String alias = missing.get(i);
-      Path target = targetFor(dir, familyOf(alias));
+      // A DT_NEEDED-derived alias always names a leptonica; the unversioned ones map by family.
+      Path target = targetFor(dir, alias.toLowerCase(Locale.ROOT).contains("lept")
+          && !isAliasName(alias.toLowerCase(Locale.ROOT)) ? "lept" : familyOf(alias));
       sb.append("  ln -s ").append(target == null ? "<library>" : target.getFileName())
           .append(' ').append(alias).append(i < missing.size() - 1 ? " && \\\n" : "\n");
     }
@@ -290,7 +302,9 @@ public class NativeProvenance {
     }
     int made = 0;
     for (String alias : missingAliases()) {
-      Path target = targetFor(dir, familyOf(alias));
+      // A DT_NEEDED-derived alias always names a leptonica; the unversioned ones map by family.
+      Path target = targetFor(dir, alias.toLowerCase(Locale.ROOT).contains("lept")
+          && !isAliasName(alias.toLowerCase(Locale.ROOT)) ? "lept" : familyOf(alias));
       if (target == null) {
         continue;
       }
@@ -317,33 +331,136 @@ public class NativeProvenance {
   }
 
   /**
-   * The versioned name tesseract's ELF {@code NEEDED} asks for. Verified on three of the four
-   * Linux tiers; {@code linux-x86-64-legacy} declares {@code libleptonica.so.6} instead, where
-   * this link is simply unused rather than harmful. Assuming a SONAME rather than reading it is
-   * what cost an earlier report a retraction, so it is stated here rather than left implicit.
+   * Reads the {@code DT_NEEDED} entries out of an ELF shared object.
+   *
+   * <p>This exists because a directory listing cannot answer the question. Two independent things
+   * decide which aliases a tier needs: the short names a JNA consumer looks up, which are visible
+   * as filenames; and the dynamic dependency recorded inside the shipped tesseract, which is
+   * <em>not</em> — no file of that name exists, and that absence is the defect. Hardcoding it
+   * happened to be right on three of the four Linux tiers and wrong on the fourth, and assuming a
+   * SONAME rather than reading it is what cost an earlier report a retraction.
+   *
+   * <p>Returns an empty list for anything that is not a 64-bit little-endian ELF, which covers
+   * every tier shipped today and means Mach-O simply yields nothing.
    */
-  private static final String LINUX_LEPT_SONAME = "liblept.so.5";
+  static List<String> readElfNeeded(Path file) {
+    List<String> needed = new ArrayList<>();
+    try {
+      byte[] b = Files.readAllBytes(file);
+      if (b.length < 64 || b[0] != 0x7F || b[1] != 'E' || b[2] != 'L' || b[3] != 'F'
+          || b[4] != 2 || b[5] != 1) {
+        return needed;                       // not 64-bit little-endian ELF
+      }
+      java.nio.ByteBuffer buf = java.nio.ByteBuffer.wrap(b).order(java.nio.ByteOrder.LITTLE_ENDIAN);
+      long phoff = buf.getLong(0x20);
+      int phentsize = buf.getShort(0x36) & 0xFFFF;
+      int phnum = buf.getShort(0x38) & 0xFFFF;
 
-  /** True for any of the unversioned names this class creates, on any platform. */
+      long dynOff = -1;
+      // PT_LOAD segments are what translate a virtual address into a file offset; DT_STRTAB is
+      // recorded as a vaddr, so the mapping has to be built before the string table can be read.
+      List<long[]> loads = new ArrayList<>();
+      for (int i = 0; i < phnum; i++) {
+        long ph = phoff + (long) i * phentsize;
+        int type = buf.getInt((int) ph);
+        long off = buf.getLong((int) ph + 0x08);
+        long vaddr = buf.getLong((int) ph + 0x10);
+        long filesz = buf.getLong((int) ph + 0x20);
+        if (type == 2) {                     // PT_DYNAMIC
+          dynOff = off;
+        } else if (type == 1) {              // PT_LOAD
+          loads.add(new long[]{vaddr, off, filesz});
+        }
+      }
+      if (dynOff < 0) {
+        return needed;
+      }
+      long strtabVaddr = -1;
+      List<Long> neededOffsets = new ArrayList<>();
+      for (long d = dynOff; d + 16 <= b.length; d += 16) {
+        long tag = buf.getLong((int) d);
+        long val = buf.getLong((int) d + 8);
+        if (tag == 0) {                      // DT_NULL
+          break;
+        } else if (tag == 1) {               // DT_NEEDED — val is an index into DT_STRTAB
+          neededOffsets.add(val);
+        } else if (tag == 5) {               // DT_STRTAB
+          strtabVaddr = val;
+        }
+      }
+      if (strtabVaddr < 0) {
+        return needed;
+      }
+      long strtabOff = -1;
+      for (long[] l : loads) {
+        if (strtabVaddr >= l[0] && strtabVaddr < l[0] + l[2]) {
+          strtabOff = l[1] + (strtabVaddr - l[0]);
+          break;
+        }
+      }
+      if (strtabOff < 0) {
+        return needed;
+      }
+      for (long idx : neededOffsets) {
+        int start = (int) (strtabOff + idx);
+        int end = start;
+        while (end < b.length && b[end] != 0) {
+          end++;
+        }
+        if (end > start) {
+          needed.add(new String(b, start, end - start, java.nio.charset.StandardCharsets.UTF_8));
+        }
+      }
+    } catch (Throwable e) {
+      return new ArrayList<>();
+    }
+    return needed;
+  }
+
+  /**
+   * True for any of the unversioned names this class creates. A versioned alias created from
+   * {@code DT_NEEDED} needs no entry here: it is written as a symlink, and the directory scan
+   * already excludes symlinks via {@code NOFOLLOW_LINKS}.
+   */
   private static boolean isAliasName(String lowerName) {
     for (String n : CONSUMER_NAMES) {
       if (lowerName.equals(System.mapLibraryName(n).toLowerCase(Locale.ROOT))) {
         return true;
       }
     }
-    return lowerName.equals(LINUX_LEPT_SONAME);
+    return false;
   }
 
   /**
-   * Restricts alias targets to this platform's object format. A tier never ships both, but a test
-   * fixture or a hand-assembled directory can, and pointing a {@code .so} alias at a Mach-O binary
-   * would produce a link that fails only at load time.
+   * True if the file is a loadable object of this platform's own format.
+   *
+   * <p>Reads the magic bytes rather than matching the extension. Matching {@code .so} looked
+   * equivalent and is not: Linux tiers ship {@code libtesseract.so.5} and {@code libleptonica.so.6},
+   * neither of which <em>ends</em> with {@code .so}, so an extension test excluded every real
+   * candidate and quietly made the whole repair inert on Linux while remaining correct on macOS.
+   * Sniffing the format does what the restriction is actually for, and survives any future naming.
    */
-  private static String platformSuffix() {
-    if (Commons.runningWindows()) {
-      return ".dll";
+  private static boolean isPlatformObject(Path file) {
+    try (java.io.InputStream in = Files.newInputStream(file)) {
+      byte[] m = new byte[4];
+      if (in.read(m) < 4) {
+        return false;
+      }
+      int b0 = m[0] & 0xFF, b1 = m[1] & 0xFF, b2 = m[2] & 0xFF, b3 = m[3] & 0xFF;
+      if (Commons.runningWindows()) {
+        return b0 == 'M' && b1 == 'Z';
+      }
+      if (Commons.runningMac()) {
+        // Mach-O thin (either endianness, 32 or 64 bit) or a fat/universal archive.
+        return (b0 == 0xCF || b0 == 0xCE) && b1 == 0xFA && b2 == 0xED && b3 == 0xFE
+            || b0 == 0xFE && b1 == 0xED && b2 == 0xFA && (b3 == 0xCF || b3 == 0xCE)
+            || b0 == 0xCA && b1 == 0xFE && b2 == 0xBA && b3 == 0xBE
+            || b0 == 0xBE && b1 == 0xBA && b2 == 0xFE && b3 == 0xCA;
+      }
+      return b0 == 0x7F && b1 == 'E' && b2 == 'L' && b3 == 'F';
+    } catch (Throwable e) {
+      return false;
     }
-    return Commons.runningMac() ? ".dylib" : ".so";
   }
 
   private static String familyOf(String alias) {
@@ -364,9 +481,12 @@ public class NativeProvenance {
             // Exclude every name we might create, not just this one: on a tier that already ships
             // unversioned files (darwin does, darwin-aarch64 does not) an alias could otherwise be
             // pointed at another unversioned file, which is the indirection this is meant to stop.
-            return n.contains(want) && !isAliasName(n)
-                && n.endsWith(platformSuffix());
+            return n.contains(want) && !isAliasName(n);
           })
+          .filter(NativeProvenance::isPlatformObject)
+          // Deterministic: Files.list() has no defined order, and a directory with two candidates
+          // would otherwise pick arbitrarily and fail intermittently rather than consistently.
+          .sorted(java.util.Comparator.comparing(pp -> pp.getFileName().toString()))
           .findFirst().orElse(null);
     } catch (Throwable e) {
       return null;

--- a/API/src/main/java/org/sikuli/support/NativeProvenance.java
+++ b/API/src/main/java/org/sikuli/support/NativeProvenance.java
@@ -256,7 +256,7 @@ public class NativeProvenance {
    * names computed for one, the symlinks written into another. With a filesystem write as the
    * consequence, that is not a race worth leaving open.
    */
-  static List<String> missingAliases(Path dir) {
+  public static List<String> missingAliases(Path dir) {
     List<String> missing = new ArrayList<>();
     if (dir == null || !Files.isDirectory(dir) || Commons.runningWindows()) {
       return missing;
@@ -293,7 +293,11 @@ public class NativeProvenance {
 
   /** The command a user who declines can run themselves. Never leave them worse off for saying no. */
   public static String manualCommand() {
-    Path dir = extractionDir;
+    return manualCommand(extractionDir);
+  }
+
+  /** As {@link #manualCommand()}, for a directory the caller has already captured. */
+  public static String manualCommand(Path dir) {
     List<String> missing = missingAliases(dir);
     if (dir == null || missing.isEmpty()) {
       return "";

--- a/API/src/main/java/org/sikuli/support/NativeProvenance.java
+++ b/API/src/main/java/org/sikuli/support/NativeProvenance.java
@@ -316,9 +316,19 @@ public class NativeProvenance {
    * nothing.
    */
   public static int createAliases() {
-    // Captured once and threaded through: every name below and every file written must refer to
-    // the same directory, whatever else re-points the field in between.
-    Path dir = extractionDir;
+    return createAliases(extractionDir);
+  }
+
+  /**
+   * As {@link #createAliases()}, for a directory the caller has already captured.
+   *
+   * <p>Threading the path all the way through is what makes the guarantee real. Reading the static
+   * inside this method still leaves a window between a caller's {@code recordExtraction} and the
+   * call itself, because the first touch of {@link Commons} anywhere triggers its static init and
+   * re-points the field. Demonstrated rather than imagined: a probe recorded a scratch directory,
+   * received the correct alias list for it, and then wrote the alias into the real cache instead.
+   */
+  public static int createAliases(Path dir) {
     if (dir == null) {
       return 0;
     }

--- a/API/src/main/java/org/sikuli/support/NativeProvenance.java
+++ b/API/src/main/java/org/sikuli/support/NativeProvenance.java
@@ -242,14 +242,10 @@ public class NativeProvenance {
    *     lookup this repairs never happens there.</li>
    * </ul>
    */
-  public static List<String> missingAliases() {
-    return missingAliases(extractionDir);
-  }
-
   /**
-   * As {@link #missingAliases()}, for a directory the caller has already captured.
+   * The aliases missing from a directory the caller has captured.
    *
-   * <p>The explicit parameter is the point. {@code extractionDir} is a mutable static, and the
+   * <p>There is deliberately no no-argument form. The explicit parameter is the point: {@code extractionDir} is a mutable static, and the
    * first touch of {@link Commons} from anywhere triggers its static init, which loads the natives
    * and records the real tier directory — replacing whatever a caller had set. Reading the field
    * once per method meant a single logical operation could straddle two directories: the alias
@@ -292,11 +288,12 @@ public class NativeProvenance {
   }
 
   /** The command a user who declines can run themselves. Never leave them worse off for saying no. */
-  public static String manualCommand() {
-    return manualCommand(extractionDir);
-  }
-
-  /** As {@link #manualCommand()}, for a directory the caller has already captured. */
+  /**
+   * The command a user who declines can run themselves. Never leave them worse off for saying no.
+   *
+   * <p>Takes the directory explicitly, like everything else here. See {@link #missingAliases(Path)}
+   * for why there is no convenience form that reads the field for you.
+   */
   public static String manualCommand(Path dir) {
     List<String> missing = missingAliases(dir);
     if (dir == null || missing.isEmpty()) {
@@ -319,12 +316,9 @@ public class NativeProvenance {
    * where links are unavailable. Idempotent — if Legerix ever ships these itself, this does
    * nothing.
    */
-  public static int createAliases() {
-    return createAliases(extractionDir);
-  }
-
   /**
-   * As {@link #createAliases()}, for a directory the caller has already captured.
+   * Creates the missing aliases in a directory the caller has captured, returning how many were
+   * made. Symlinks; falls back to a copy where links are unavailable. Idempotent.
    *
    * <p>Threading the path all the way through is what makes the guarantee real. Reading the static
    * inside this method still leaves a window between a caller's {@code recordExtraction} and the

--- a/API/src/main/java/org/sikuli/support/NativeProvenance.java
+++ b/API/src/main/java/org/sikuli/support/NativeProvenance.java
@@ -54,6 +54,16 @@ public class NativeProvenance {
     extractionDir = tierDir;
   }
 
+  /**
+   * Clears the one-shot latch so a test can exercise {@link #verifyBinding()} more than once.
+   * Package-private and used only by tests — without it the binding flag can only be asserted at
+   * its initial value, which is how a claim about it went untested in the first place.
+   */
+  static void resetForTest() {
+    bindingChecked = false;
+    bindingVerified = false;
+  }
+
   public static Path getExtractionDir() {
     return extractionDir;
   }
@@ -238,7 +248,11 @@ public class NativeProvenance {
           missing.add(alias);
         }
       }
-      if (Commons.runningLinux() && !missing.isEmpty() && targetFor(dir, "lept") != null
+      // Evaluated independently of what the loop above found. Gating this on the unversioned
+      // set being incomplete would skip exactly the users who already followed our earlier
+      // three-symlink advice: their unversioned aliases exist, so nothing is "missing", and the
+      // one file that satisfies tesseract's ELF NEEDED never gets created.
+      if (Commons.runningLinux() && targetFor(dir, "lept") != null
           && !Files.exists(dir.resolve(LINUX_LEPT_SONAME))) {
         missing.add(LINUX_LEPT_SONAME);
       }
@@ -302,7 +316,35 @@ public class NativeProvenance {
     return made;
   }
 
+  /**
+   * The versioned name tesseract's ELF {@code NEEDED} asks for. Verified on three of the four
+   * Linux tiers; {@code linux-x86-64-legacy} declares {@code libleptonica.so.6} instead, where
+   * this link is simply unused rather than harmful. Assuming a SONAME rather than reading it is
+   * what cost an earlier report a retraction, so it is stated here rather than left implicit.
+   */
   private static final String LINUX_LEPT_SONAME = "liblept.so.5";
+
+  /** True for any of the unversioned names this class creates, on any platform. */
+  private static boolean isAliasName(String lowerName) {
+    for (String n : CONSUMER_NAMES) {
+      if (lowerName.equals(System.mapLibraryName(n).toLowerCase(Locale.ROOT))) {
+        return true;
+      }
+    }
+    return lowerName.equals(LINUX_LEPT_SONAME);
+  }
+
+  /**
+   * Restricts alias targets to this platform's object format. A tier never ships both, but a test
+   * fixture or a hand-assembled directory can, and pointing a {@code .so} alias at a Mach-O binary
+   * would produce a link that fails only at load time.
+   */
+  private static String platformSuffix() {
+    if (Commons.runningWindows()) {
+      return ".dll";
+    }
+    return Commons.runningMac() ? ".dylib" : ".so";
+  }
 
   private static String familyOf(String alias) {
     return alias.contains("leptonica") ? "leptonica" : alias.contains("lept") ? "lept" : "tesseract";
@@ -319,8 +361,11 @@ public class NativeProvenance {
           .filter(p -> Files.isRegularFile(p, java.nio.file.LinkOption.NOFOLLOW_LINKS))
           .filter(p -> {
             String n = p.getFileName().toString().toLowerCase(Locale.ROOT);
-            return n.contains(want) && !n.equals(System.mapLibraryName(name))
-                && !n.equals(LINUX_LEPT_SONAME);
+            // Exclude every name we might create, not just this one: on a tier that already ships
+            // unversioned files (darwin does, darwin-aarch64 does not) an alias could otherwise be
+            // pointed at another unversioned file, which is the indirection this is meant to stop.
+            return n.contains(want) && !isAliasName(n)
+                && n.endsWith(platformSuffix());
           })
           .findFirst().orElse(null);
     } catch (Throwable e) {

--- a/API/src/main/java/org/sikuli/support/NativeProvenance.java
+++ b/API/src/main/java/org/sikuli/support/NativeProvenance.java
@@ -207,6 +207,127 @@ public class NativeProvenance {
     }
   }
 
+  /**
+   * The aliases missing from the extraction directory, or empty if nothing is needed.
+   *
+   * <p>Which names are required was measured across macOS, both Linux x86-64 tiers and native
+   * Windows during the Legerix #20 investigation, and the rules are not symmetric:
+   *
+   * <ul>
+   * <li><b>Unversioned only</b> for the JNA short-name lookup. A versioned alias would satisfy
+   *     {@code isVersionedName} and enter JNA's version-pooling fallback, where it competes with
+   *     whatever the distro ships — reintroducing the very bug this fixes.</li>
+   * <li><b>Linux additionally needs versioned {@code liblept.so.5}</b>, because the bundled
+   *     tesseract's ELF {@code NEEDED} is that literal string and no file of that name exists.
+   *     It is safe only <em>alongside</em> the unversioned link, which wins the exact-name pass
+   *     first so the pool is never consulted.</li>
+   * <li><b>Windows needs nothing.</b> tess4j binds fully versioned names it ships itself, so the
+   *     lookup this repairs never happens there.</li>
+   * </ul>
+   */
+  public static List<String> missingAliases() {
+    List<String> missing = new ArrayList<>();
+    Path dir = extractionDir;
+    if (dir == null || !Files.isDirectory(dir) || Commons.runningWindows()) {
+      return missing;
+    }
+    try {
+      for (String name : CONSUMER_NAMES) {
+        String alias = System.mapLibraryName(name);
+        if (!Files.exists(dir.resolve(alias)) && targetFor(dir, name) != null) {
+          missing.add(alias);
+        }
+      }
+      if (Commons.runningLinux() && !missing.isEmpty() && targetFor(dir, "lept") != null
+          && !Files.exists(dir.resolve(LINUX_LEPT_SONAME))) {
+        missing.add(LINUX_LEPT_SONAME);
+      }
+    } catch (Throwable ignore) {
+    }
+    return missing;
+  }
+
+  /** The command a user who declines can run themselves. Never leave them worse off for saying no. */
+  public static String manualCommand() {
+    Path dir = extractionDir;
+    List<String> missing = missingAliases();
+    if (dir == null || missing.isEmpty()) {
+      return "";
+    }
+    StringBuilder sb = new StringBuilder("cd ").append(dir).append(" && \\\n");
+    for (int i = 0; i < missing.size(); i++) {
+      String alias = missing.get(i);
+      Path target = targetFor(dir, familyOf(alias));
+      sb.append("  ln -s ").append(target == null ? "<library>" : target.getFileName())
+          .append(' ').append(alias).append(i < missing.size() - 1 ? " && \\\n" : "\n");
+    }
+    return sb.toString();
+  }
+
+  /**
+   * Creates the missing aliases and returns how many were made. Symlinks; falls back to a copy
+   * where links are unavailable. Idempotent — if Legerix ever ships these itself, this does
+   * nothing.
+   */
+  public static int createAliases() {
+    Path dir = extractionDir;
+    if (dir == null) {
+      return 0;
+    }
+    int made = 0;
+    for (String alias : missingAliases()) {
+      Path target = targetFor(dir, familyOf(alias));
+      if (target == null) {
+        continue;
+      }
+      Path link = dir.resolve(alias);
+      try {
+        try {
+          Files.createSymbolicLink(link, target.getFileName());
+        } catch (UnsupportedOperationException | java.io.IOException linkFailed) {
+          Files.copy(target, link);
+        }
+        made++;
+        Commons.startLog(3, "[OculiX] created OCR native alias %s -> %s", alias,
+            target.getFileName());
+      } catch (Throwable e) {
+        Commons.startLog(3, "[OculiX] could not create OCR native alias %s: %s", alias,
+            e.getMessage());
+      }
+    }
+    if (made > 0) {
+      // The aliases only matter at resolution time, so a later OCR call still needs checking.
+      bindingChecked = false;
+    }
+    return made;
+  }
+
+  private static final String LINUX_LEPT_SONAME = "liblept.so.5";
+
+  private static String familyOf(String alias) {
+    return alias.contains("leptonica") ? "leptonica" : alias.contains("lept") ? "lept" : "tesseract";
+  }
+
+  /** The real library an alias should point at: the versioned file already in the directory. */
+  private static Path targetFor(Path dir, String name) {
+    String want = name.equals("tesseract") ? "tesseract" : "lept";
+    try (Stream<Path> entries = Files.list(dir)) {
+      return entries
+          // NOFOLLOW matters: an alias we made earlier in this same pass is itself a regular file
+          // once resolved, and pointing a later alias at it would build a chain that breaks if the
+          // middle link is removed. Aliases must always target the real versioned library.
+          .filter(p -> Files.isRegularFile(p, java.nio.file.LinkOption.NOFOLLOW_LINKS))
+          .filter(p -> {
+            String n = p.getFileName().toString().toLowerCase(Locale.ROOT);
+            return n.contains(want) && !n.equals(System.mapLibraryName(name))
+                && !n.equals(LINUX_LEPT_SONAME);
+          })
+          .findFirst().orElse(null);
+    } catch (Throwable e) {
+      return null;
+    }
+  }
+
   /** Legerix and OculiX in one archive means its extraction read our resource directory. */
   private static boolean isShadedWithUs(Class<?> legerixClass) {
     URL ours = codeSource(NativeProvenance.class);

--- a/API/src/main/java/org/sikuli/support/NativeProvenance.java
+++ b/API/src/main/java/org/sikuli/support/NativeProvenance.java
@@ -1,0 +1,279 @@
+/*
+ * Copyright (c) 2010-2026, sikuli.org, sikulix.com - MIT license
+ */
+package org.sikuli.support;
+
+import com.sun.jna.NativeLibrary;
+
+import java.io.File;
+import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.stream.Stream;
+
+/**
+ * Checks that the Tesseract our OCR calls actually reach is the one Legerix extracted for us.
+ *
+ * <p>Two distinct things can go wrong, and neither is visible from Legerix's own success:
+ *
+ * <ul>
+ * <li><b>The consumer path binds a different library.</b> {@code Legerix.loadNatives()} loads its
+ *     file by absolute path, which always succeeds. tess4j separately resolves the <em>short
+ *     name</em> {@code tesseract} through JNA at its own static init, and can land on a system
+ *     copy instead — silently, with OCR still returning plausible text. Legerix's own assertion
+ *     cannot see this: it validates the file it extracted, not the one the consumer bound.</li>
+ * <li><b>Legerix extracts our natives, not its own.</b> Its extraction reads
+ *     {@code getProtectionDomain().getCodeSource()} — the jar containing {@code Legerix.class}.
+ *     When we shade Legerix into a fat jar, that is <em>our</em> jar, so it extracts everything
+ *     under the tier directory we ship, including natives Legerix never published.</li>
+ * </ul>
+ *
+ * <p>Nothing here fails a startup or a capture. Wrong-library binding is a diagnosis problem, not
+ * a crash, and the whole point is that it is currently invisible — so this reports and moves on.
+ */
+public class NativeProvenance {
+
+  private NativeProvenance() {
+  }
+
+  /** Short names a consumer resolves through JNA; the ones that can silently go elsewhere. */
+  private static final String[] CONSUMER_NAMES = {"tesseract", "leptonica", "lept"};
+
+  private static volatile Path extractionDir;
+  private static volatile boolean bindingChecked;
+  private static volatile boolean bindingVerified;
+
+  /**
+   * Records where Legerix extracted to. {@code loadNatives()} returns the tier directory itself
+   * (e.g. {@code ~/.cache/legerix/<version>/darwin-aarch64}); we previously discarded it.
+   */
+  public static void recordExtraction(Path tierDir) {
+    extractionDir = tierDir;
+  }
+
+  public static Path getExtractionDir() {
+    return extractionDir;
+  }
+
+  /**
+   * True once a consumer OCR call has been checked and every short name resolved inside the
+   * extraction directory. Stays false while unchecked, so callers must not read it as "fine".
+   */
+  public static boolean isBindingVerified() {
+    return bindingVerified;
+  }
+
+  /**
+   * Reports what Legerix put in the extraction directory, and whether it came from our jar.
+   *
+   * <p>The co-bundling test is an exact one rather than a heuristic: if Legerix's code source is
+   * the same archive as ours, it necessarily extracted from our resources. Comparing file names
+   * would misfire, because Legerix legitimately ships a large transitive set on Windows.
+   */
+  public static void auditExtraction(Class<?> legerixClass) {
+    Path dir = extractionDir;
+    if (dir == null || !Files.isDirectory(dir)) {
+      return;
+    }
+    try {
+      List<String> extracted = new ArrayList<>();
+      try (Stream<Path> entries = Files.list(dir)) {
+        entries.map(p -> p.getFileName().toString())
+            .filter(n -> !n.equals(".gitkeep"))
+            .sorted()
+            .forEach(extracted::add);
+      }
+      Commons.startLog(3, "[OculiX] Legerix extracted %d file(s) to %s", extracted.size(), dir);
+
+      if (!isShadedWithUs(legerixClass)) {
+        return;
+      }
+      // Same archive: Legerix read our resource directory, so anything of ours sitting under the
+      // tier name came along with its payload. Name the extras rather than guessing at intent.
+      List<String> foreign = new ArrayList<>();
+      for (String name : extracted) {
+        if (!looksLikeTesseractFamily(name)) {
+          foreign.add(name);
+        }
+      }
+      if (!foreign.isEmpty()) {
+        Commons.startLog(3, "[OculiX] Legerix is shaded into our jar, so it extracted from our "
+            + "resources; %d file(s) there are not part of its own payload: %s",
+            foreign.size(), String.join(", ", foreign));
+      }
+    } catch (Throwable e) {
+      Commons.startLog(3, "[OculiX] native provenance audit skipped: %s: %s",
+          e.getClass().getSimpleName(), e.getMessage());
+    }
+  }
+
+  /**
+   * Checks which library the consumer path actually bound, and reports any that resolved outside
+   * the extraction directory.
+   *
+   * <p>Must run <em>after</em> a successful OCR call, for two reasons: tess4j only rewrites
+   * {@code jna.library.path} during its own static init, so before that the check would prove
+   * nothing; and asking JNA for a name it has not yet resolved would itself trigger a load, which
+   * is the very thing under test. After OCR the instances are cached, so this only observes.
+   */
+  public static void verifyBinding() {
+    if (bindingChecked) {
+      return;
+    }
+    bindingChecked = true;
+    Path dir = extractionDir;
+    if (dir == null) {
+      return;
+    }
+    boolean allInside = true;
+    for (String name : CONSUMER_NAMES) {
+      String resolved = resolveQuietly(name);
+      if (resolved == null) {
+        // Not bound in this JVM — on Windows tess4j uses fully versioned names and never asks
+        // for these at all. Absence is not a failure.
+        continue;
+      }
+      if (isInside(dir, resolved)) {
+        Commons.startLog(3, "[OculiX] OCR native '%s' -> %s (bundled)", name, resolved);
+      } else if (matchesSomethingIn(dir, resolved)) {
+        // tess4j and lept4j re-extract the natives they find on the classpath into their own
+        // temp directories and bind from there. Byte-identical content means it is our payload
+        // by another path — not a different library, so not something to cry wolf about.
+        Commons.startLog(3, "[OculiX] OCR native '%s' -> %s (outside the bundled directory, but "
+            + "byte-identical to it — a consumer's own copy of our payload)", name, resolved);
+      } else {
+        allInside = false;
+        Commons.startLog(3, "[OculiX] WARNING: OCR native '%s' resolved OUTSIDE the bundled "
+            + "directory and does not match it: %s (expected under %s). OCR is being serviced by "
+            + "a library OculiX did not ship; reported version strings will not describe it.",
+            name, resolved, dir);
+      }
+    }
+    bindingVerified = allInside;
+  }
+
+  /**
+   * Explains a JNA link failure in terms of what is actually on disk, or returns "" if we have
+   * nothing useful to add.
+   *
+   * <p>The common case is not a broken or missing payload: it is that the extraction directory
+   * holds only <em>versioned</em> filenames while JNA's exact-name lookup asks for the unversioned
+   * one. Without a system copy to fall back on, that fails outright — and the generic
+   * "reinstall" advice sends the user in the wrong direction entirely.
+   */
+  public static String explainLinkFailure() {
+    Path dir = extractionDir;
+    if (dir == null || !Files.isDirectory(dir)) {
+      return "";
+    }
+    try {
+      List<String> present = new ArrayList<>();
+      try (Stream<Path> entries = Files.list(dir)) {
+        entries.map(p -> p.getFileName().toString())
+            .filter(NativeProvenance::looksLikeTesseractFamily)
+            .sorted()
+            .forEach(present::add);
+      }
+      if (present.isEmpty()) {
+        return " The bundled directory " + dir + " contains no tesseract/leptonica library.\n";
+      }
+      String unversioned = System.mapLibraryName("tesseract");
+      boolean hasUnversioned = present.stream().anyMatch(n -> n.equals(unversioned));
+      StringBuilder sb = new StringBuilder();
+      sb.append(" Bundled natives are present in ").append(dir).append(":\n   ")
+          .append(String.join(", ", present)).append("\n");
+      if (!hasUnversioned) {
+        sb.append(" Note: JNA resolves the short name 'tesseract' to the exact filename '")
+            .append(unversioned).append("', which is not among them — the bundled files carry\n")
+            .append(" version suffixes only. Reinstalling will not change that.\n");
+      }
+      return sb.toString();
+    } catch (Throwable e) {
+      return "";
+    }
+  }
+
+  /** Legerix and OculiX in one archive means its extraction read our resource directory. */
+  private static boolean isShadedWithUs(Class<?> legerixClass) {
+    URL ours = codeSource(NativeProvenance.class);
+    URL theirs = codeSource(legerixClass);
+    return ours != null && theirs != null && ours.toString().equals(theirs.toString());
+  }
+
+  private static URL codeSource(Class<?> clazz) {
+    try {
+      return clazz.getProtectionDomain().getCodeSource().getLocation();
+    } catch (Throwable e) {
+      return null;
+    }
+  }
+
+  private static boolean looksLikeTesseractFamily(String fileName) {
+    String n = fileName.toLowerCase(Locale.ROOT);
+    return n.contains("tesseract") || n.contains("lept");
+  }
+
+  /**
+   * Returns the absolute path JNA bound for a short name, or null if it is not bound here.
+   * Never propagates: an unbound name throws {@link UnsatisfiedLinkError}, which is information
+   * rather than an error condition.
+   */
+  private static String resolveQuietly(String name) {
+    try {
+      File f = NativeLibrary.getInstance(name).getFile();
+      return f == null ? null : f.getCanonicalPath();
+    } catch (Throwable e) {
+      return null;
+    }
+  }
+
+  /**
+   * True if the resolved file is byte-identical to one we extracted. Compares content rather than
+   * name, because a consumer's copy is often renamed (tess4j binds {@code libtesseract552.dll}
+   * where we ship {@code tesseract55.dll}). Size is checked first so the digest is rarely needed.
+   */
+  private static boolean matchesSomethingIn(Path dir, String resolvedPath) {
+    try {
+      Path resolved = Path.of(resolvedPath);
+      long size = Files.size(resolved);
+      List<Path> sameSize = new ArrayList<>();
+      try (Stream<Path> entries = Files.list(dir)) {
+        entries.filter(Files::isRegularFile).forEach(p -> {
+          try {
+            if (Files.size(p) == size) {
+              sameSize.add(p);
+            }
+          } catch (Throwable ignore) {
+          }
+        });
+      }
+      if (sameSize.isEmpty()) {
+        return false;
+      }
+      byte[] target = digest(resolved);
+      for (Path candidate : sameSize) {
+        if (java.util.Arrays.equals(target, digest(candidate))) {
+          return true;
+        }
+      }
+      return false;
+    } catch (Throwable e) {
+      return false;
+    }
+  }
+
+  private static byte[] digest(Path file) throws Exception {
+    return java.security.MessageDigest.getInstance("SHA-256").digest(Files.readAllBytes(file));
+  }
+
+  private static boolean isInside(Path dir, String resolvedPath) {
+    try {
+      return Path.of(resolvedPath).toRealPath().startsWith(dir.toRealPath());
+    } catch (Throwable e) {
+      return false;
+    }
+  }
+}

--- a/API/src/test/java/org/sikuli/support/NativeProvenanceTest.java
+++ b/API/src/test/java/org/sikuli/support/NativeProvenanceTest.java
@@ -7,10 +7,12 @@ import org.junit.jupiter.api.Test;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeFalse;
 
 /**
  * Covers the diagnosis text, which is the part a user actually reads when OCR fails.
@@ -19,6 +21,11 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * by running the app rather than here.
  */
 public class NativeProvenanceTest {
+
+  /** The repair does not apply on Windows: tess4j binds versioned names it ships itself. */
+  private static void assumeNotWindows() {
+    assumeFalse(System.getProperty("os.name", "").toLowerCase().startsWith("windows"));
+  }
 
   private static Path tierDirWith(String... fileNames) throws Exception {
     Path dir = Files.createTempDirectory("oculix-provenance");
@@ -68,6 +75,57 @@ public class NativeProvenanceTest {
     tierDirWith();
     String advice = NativeProvenance.explainLinkFailure();
     assertTrue(advice.contains("contains no tesseract/leptonica library"));
+  }
+
+  @Test
+  public void versionedOnlyPayloadIsMissingTheUnversionedAliases() throws Exception {
+    assumeNotWindows();
+    tierDirWith("libtesseract.5.dylib", "libleptonica.6.dylib",
+        "libtesseract.so.5", "libleptonica.so.6");
+    List<String> missing = NativeProvenance.missingAliases();
+    assertTrue(missing.contains(System.mapLibraryName("tesseract")));
+    assertTrue(missing.contains(System.mapLibraryName("leptonica")));
+    assertTrue(missing.contains(System.mapLibraryName("lept")));
+    // Never propose a versioned alias for the JNA lookup: it would enter the version-pooling
+    // fallback and compete with whatever the system ships, which is the bug being repaired.
+    assertFalse(missing.contains("libtesseract.so.5"));
+    assertFalse(missing.contains("libleptonica.6.dylib"));
+  }
+
+  @Test
+  public void nothingMissingOnceTheAliasesExist() throws Exception {
+    assumeNotWindows();
+    Path dir = tierDirWith("libtesseract.5.dylib", "libleptonica.6.dylib",
+        "libtesseract.so.5", "libleptonica.so.6");
+    NativeProvenance.createAliases();
+    NativeProvenance.recordExtraction(dir);
+    assertTrue(NativeProvenance.missingAliases().isEmpty());
+  }
+
+  @Test
+  public void aliasesTargetTheRealLibraryNeverAnotherAlias() throws Exception {
+    assumeNotWindows();
+    Path dir = tierDirWith("libtesseract.5.dylib", "libleptonica.6.dylib",
+        "libtesseract.so.5", "libleptonica.so.6");
+    NativeProvenance.createAliases();
+    for (String name : new String[]{"tesseract", "leptonica", "lept"}) {
+      Path alias = dir.resolve(System.mapLibraryName(name));
+      if (Files.isSymbolicLink(alias)) {
+        Path target = dir.resolve(Files.readSymbolicLink(alias));
+        assertFalse(Files.isSymbolicLink(target),
+            "alias " + alias.getFileName() + " chains to another alias");
+      }
+    }
+  }
+
+  @Test
+  public void decliningStillYieldsARunnableCommand() throws Exception {
+    assumeNotWindows();
+    Path dir = tierDirWith("libtesseract.5.dylib", "libleptonica.6.dylib",
+        "libtesseract.so.5", "libleptonica.so.6");
+    String cmd = NativeProvenance.manualCommand();
+    assertTrue(cmd.contains("cd " + dir));
+    assertTrue(cmd.contains("ln -s"));
   }
 
   @Test

--- a/API/src/test/java/org/sikuli/support/NativeProvenanceTest.java
+++ b/API/src/test/java/org/sikuli/support/NativeProvenanceTest.java
@@ -93,8 +93,8 @@ public class NativeProvenanceTest {
   @Test
   public void versionedOnlyPayloadIsMissingTheUnversionedAliases() throws Exception {
     assumeNotWindows();
-    tierDirWith(versionedPayload());
-    List<String> missing = NativeProvenance.missingAliases();
+    Path dir = tierDirWith(versionedPayload());
+    List<String> missing = NativeProvenance.missingAliases(dir);
     assertTrue(missing.contains(System.mapLibraryName("tesseract")));
     assertTrue(missing.contains(System.mapLibraryName("leptonica")));
     assertTrue(missing.contains(System.mapLibraryName("lept")));
@@ -108,9 +108,8 @@ public class NativeProvenanceTest {
   public void nothingMissingOnceTheAliasesExist() throws Exception {
     assumeNotWindows();
     Path dir = tierDirWith(versionedPayload());
-    NativeProvenance.createAliases();
-    NativeProvenance.recordExtraction(dir);
-    assertTrue(NativeProvenance.missingAliases().isEmpty());
+    NativeProvenance.createAliases(dir);
+    assertTrue(NativeProvenance.missingAliases(dir).isEmpty());
   }
 
   @Test
@@ -122,8 +121,7 @@ public class NativeProvenanceTest {
     Path dir = tierDirWith(versionedPayload());
     Files.write(dir.resolve(System.mapLibraryName("leptonica")),
         System.mapLibraryName("x").endsWith(".dylib") ? MACHO_MAGIC : ELF_MAGIC);
-    NativeProvenance.recordExtraction(dir);
-    NativeProvenance.createAliases();
+    NativeProvenance.createAliases(dir);
 
     java.util.List<String> versioned = java.util.Arrays.asList(versionedPayload());
     for (String name : new String[]{"tesseract", "leptonica", "lept"}) {
@@ -145,7 +143,7 @@ public class NativeProvenanceTest {
     // can — and a .so aliased to a Mach-O binary fails only at load time, far from the cause.
     Path dir = tierDirWith("libtesseract.5.dylib", "libtesseract.so.5",
         "libleptonica.6.dylib", "libleptonica.so.6");
-    NativeProvenance.createAliases();
+    NativeProvenance.createAliases(dir);
     String suffix = System.mapLibraryName("x").substring("libx".length());  // ".dylib" / ".so"
     for (String name : new String[]{"tesseract", "leptonica"}) {
       Path alias = dir.resolve(System.mapLibraryName(name));
@@ -162,7 +160,7 @@ public class NativeProvenanceTest {
     assumeNotWindows();
     Path dir = tierDirWith("libtesseract.5.dylib", "libleptonica.6.dylib",
         "libtesseract.so.5", "libleptonica.so.6");
-    String cmd = NativeProvenance.manualCommand();
+    String cmd = NativeProvenance.manualCommand(dir);
     assertTrue(cmd.contains("cd " + dir));
     assertTrue(cmd.contains("ln -s"));
   }

--- a/API/src/test/java/org/sikuli/support/NativeProvenanceTest.java
+++ b/API/src/test/java/org/sikuli/support/NativeProvenanceTest.java
@@ -27,12 +27,18 @@ public class NativeProvenanceTest {
     assumeFalse(System.getProperty("os.name", "").toLowerCase().startsWith("windows"));
   }
 
+  private static final byte[] ELF_MAGIC = {0x7F, 'E', 'L', 'F', 2, 1, 1, 0};
+  private static final byte[] MACHO_MAGIC =
+      {(byte) 0xCF, (byte) 0xFA, (byte) 0xED, (byte) 0xFE, 0, 0, 0, 0};
+
   private static Path tierDirWith(String... fileNames) throws Exception {
     Path dir = Files.createTempDirectory("oculix-provenance");
     dir.toFile().deleteOnExit();
     for (String name : fileNames) {
       Path f = dir.resolve(name);
-      Files.write(f, new byte[]{0});
+      // Real magic bytes: targetFor() now sniffs the object format rather than trusting the
+      // extension, so a fixture of zero bytes would be filtered out and test nothing.
+      Files.write(f, name.endsWith(".dylib") ? MACHO_MAGIC : ELF_MAGIC);
       f.toFile().deleteOnExit();
     }
     NativeProvenance.recordExtraction(dir);
@@ -114,7 +120,8 @@ public class NativeProvenanceTest {
     // version of this test could not have caught an alias pointing at another unversioned file,
     // because its fixture never contained one — the name promised more than the body checked.
     Path dir = tierDirWith(versionedPayload());
-    Files.write(dir.resolve(System.mapLibraryName("leptonica")), new byte[]{0});
+    Files.write(dir.resolve(System.mapLibraryName("leptonica")),
+        System.mapLibraryName("x").endsWith(".dylib") ? MACHO_MAGIC : ELF_MAGIC);
     NativeProvenance.recordExtraction(dir);
     NativeProvenance.createAliases();
 
@@ -158,6 +165,26 @@ public class NativeProvenanceTest {
     String cmd = NativeProvenance.manualCommand();
     assertTrue(cmd.contains("cd " + dir));
     assertTrue(cmd.contains("ln -s"));
+  }
+
+  @Test
+  public void readElfNeededIgnoresAnythingThatIsNotElf() throws Exception {
+    // Safety property: on macOS every file it meets is Mach-O, and on any platform it may be
+    // handed a truncated or unrelated file. It must yield nothing rather than misparse — a wrong
+    // DT_NEEDED would invent an alias, which is worse than deriving none.
+    Path dir = Files.createTempDirectory("oculix-elf");
+    dir.toFile().deleteOnExit();
+    Path machO = dir.resolve("libfake.dylib");
+    Files.write(machO, new byte[]{(byte) 0xCF, (byte) 0xFA, (byte) 0xED, (byte) 0xFE, 0, 0, 0, 0});
+    assertTrue(NativeProvenance.readElfNeeded(machO).isEmpty());
+
+    Path truncated = dir.resolve("libtrunc.so");
+    Files.write(truncated, new byte[]{0x7F, 'E', 'L', 'F', 2, 1});
+    assertTrue(NativeProvenance.readElfNeeded(truncated).isEmpty());
+
+    Path empty = dir.resolve("libempty.so");
+    Files.write(empty, new byte[0]);
+    assertTrue(NativeProvenance.readElfNeeded(empty).isEmpty());
   }
 
   @Test

--- a/API/src/test/java/org/sikuli/support/NativeProvenanceTest.java
+++ b/API/src/test/java/org/sikuli/support/NativeProvenanceTest.java
@@ -188,6 +188,30 @@ public class NativeProvenanceTest {
   }
 
   @Test
+  public void oneCallNeverStraddlesTwoDirectories() throws Exception {
+    assumeNotWindows();
+    // extractionDir is a mutable static that lazy init can re-point underneath a caller. The names
+    // and the writes must therefore come from one captured value: a list computed for directory A
+    // must never be written into directory B, because the consequence is files on disk.
+    Path a = tierDirWith(versionedPayload());
+    Path b = Files.createTempDirectory("oculix-other");
+    b.toFile().deleteOnExit();
+
+    java.util.List<String> forA = NativeProvenance.missingAliases(a);
+    assertFalse(forA.isEmpty(), "fixture should need aliases");
+
+    // Re-point the field, exactly as a lazy static init would, then create.
+    NativeProvenance.recordExtraction(b);
+    NativeProvenance.recordExtraction(a);
+    NativeProvenance.createAliases();
+
+    for (String alias : forA) {
+      assertTrue(Files.exists(a.resolve(alias)), "alias " + alias + " belongs in the recorded dir");
+      assertFalse(Files.exists(b.resolve(alias)), "alias " + alias + " leaked into another dir");
+    }
+  }
+
+  @Test
   public void unverifiedUntilAnOcrCallHasBeenObserved() {
     // Must never read as "fine" merely because nothing has been checked yet.
     NativeProvenance.resetForTest();

--- a/API/src/test/java/org/sikuli/support/NativeProvenanceTest.java
+++ b/API/src/test/java/org/sikuli/support/NativeProvenanceTest.java
@@ -77,11 +77,17 @@ public class NativeProvenanceTest {
     assertTrue(advice.contains("contains no tesseract/leptonica library"));
   }
 
+  /** A real tier ships one object format; a fixture mixing them tests something that cannot occur. */
+  private static String[] versionedPayload() {
+    return System.mapLibraryName("x").endsWith(".dylib")
+        ? new String[]{"libtesseract.5.dylib", "libleptonica.6.dylib"}
+        : new String[]{"libtesseract.so.5", "libleptonica.so.6"};
+  }
+
   @Test
   public void versionedOnlyPayloadIsMissingTheUnversionedAliases() throws Exception {
     assumeNotWindows();
-    tierDirWith("libtesseract.5.dylib", "libleptonica.6.dylib",
-        "libtesseract.so.5", "libleptonica.so.6");
+    tierDirWith(versionedPayload());
     List<String> missing = NativeProvenance.missingAliases();
     assertTrue(missing.contains(System.mapLibraryName("tesseract")));
     assertTrue(missing.contains(System.mapLibraryName("leptonica")));
@@ -95,8 +101,7 @@ public class NativeProvenanceTest {
   @Test
   public void nothingMissingOnceTheAliasesExist() throws Exception {
     assumeNotWindows();
-    Path dir = tierDirWith("libtesseract.5.dylib", "libleptonica.6.dylib",
-        "libtesseract.so.5", "libleptonica.so.6");
+    Path dir = tierDirWith(versionedPayload());
     NativeProvenance.createAliases();
     NativeProvenance.recordExtraction(dir);
     assertTrue(NativeProvenance.missingAliases().isEmpty());
@@ -105,15 +110,42 @@ public class NativeProvenanceTest {
   @Test
   public void aliasesTargetTheRealLibraryNeverAnotherAlias() throws Exception {
     assumeNotWindows();
-    Path dir = tierDirWith("libtesseract.5.dylib", "libleptonica.6.dylib",
-        "libtesseract.so.5", "libleptonica.so.6");
+    // Seed a tier that ALREADY has an unversioned file, as the darwin tier does. The earlier
+    // version of this test could not have caught an alias pointing at another unversioned file,
+    // because its fixture never contained one — the name promised more than the body checked.
+    Path dir = tierDirWith(versionedPayload());
+    Files.write(dir.resolve(System.mapLibraryName("leptonica")), new byte[]{0});
+    NativeProvenance.recordExtraction(dir);
     NativeProvenance.createAliases();
+
+    java.util.List<String> versioned = java.util.Arrays.asList(versionedPayload());
     for (String name : new String[]{"tesseract", "leptonica", "lept"}) {
       Path alias = dir.resolve(System.mapLibraryName(name));
+      if (!Files.isSymbolicLink(alias)) {
+        continue;
+      }
+      String target = Files.readSymbolicLink(alias).getFileName().toString();
+      assertTrue(versioned.contains(target),
+          "alias " + alias.getFileName() + " -> " + target
+              + " : must point at a real versioned library, not " + versioned);
+    }
+  }
+
+  @Test
+  public void aliasTargetsNeverCrossObjectFormats() throws Exception {
+    assumeNotWindows();
+    // A directory holding both formats cannot occur in a shipped tier, but a hand-assembled one
+    // can — and a .so aliased to a Mach-O binary fails only at load time, far from the cause.
+    Path dir = tierDirWith("libtesseract.5.dylib", "libtesseract.so.5",
+        "libleptonica.6.dylib", "libleptonica.so.6");
+    NativeProvenance.createAliases();
+    String suffix = System.mapLibraryName("x").substring("libx".length());  // ".dylib" / ".so"
+    for (String name : new String[]{"tesseract", "leptonica"}) {
+      Path alias = dir.resolve(System.mapLibraryName(name));
       if (Files.isSymbolicLink(alias)) {
-        Path target = dir.resolve(Files.readSymbolicLink(alias));
-        assertFalse(Files.isSymbolicLink(target),
-            "alias " + alias.getFileName() + " chains to another alias");
+        String target = Files.readSymbolicLink(alias).getFileName().toString();
+        assertTrue(target.endsWith(suffix),
+            "alias " + alias.getFileName() + " -> " + target + " crosses object format");
       }
     }
   }
@@ -131,6 +163,19 @@ public class NativeProvenanceTest {
   @Test
   public void unverifiedUntilAnOcrCallHasBeenObserved() {
     // Must never read as "fine" merely because nothing has been checked yet.
+    NativeProvenance.resetForTest();
     assertFalse(NativeProvenance.isBindingVerified());
+  }
+
+  @Test
+  public void zeroObservationsIsNotAPass() throws Exception {
+    // The Windows case: tess4j binds fully versioned names it ships itself, so none of the short
+    // names is ever bound and verifyBinding() observes nothing. Running it must not flip the flag
+    // to true — an earlier version did exactly that, on the one platform it had checked nothing on.
+    NativeProvenance.resetForTest();
+    tierDirWith(versionedPayload());
+    NativeProvenance.verifyBinding();
+    assertFalse(NativeProvenance.isBindingVerified(),
+        "verifyBinding() reported success without observing a single bound name");
   }
 }

--- a/API/src/test/java/org/sikuli/support/NativeProvenanceTest.java
+++ b/API/src/test/java/org/sikuli/support/NativeProvenanceTest.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2010-2026, sikuli.org, sikulix.com - MIT license
+ */
+package org.sikuli.support;
+
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Covers the diagnosis text, which is the part a user actually reads when OCR fails.
+ *
+ * <p>The binding check itself needs a live JNA resolution and a real OCR call, so it is exercised
+ * by running the app rather than here.
+ */
+public class NativeProvenanceTest {
+
+  private static Path tierDirWith(String... fileNames) throws Exception {
+    Path dir = Files.createTempDirectory("oculix-provenance");
+    dir.toFile().deleteOnExit();
+    for (String name : fileNames) {
+      Path f = dir.resolve(name);
+      Files.write(f, new byte[]{0});
+      f.toFile().deleteOnExit();
+    }
+    NativeProvenance.recordExtraction(dir);
+    return dir;
+  }
+
+  @Test
+  public void noExtractionDirYieldsNoAdvice() {
+    NativeProvenance.recordExtraction(null);
+    assertEquals("", NativeProvenance.explainLinkFailure());
+  }
+
+  @Test
+  public void namesTheDirectoryAndItsContents() throws Exception {
+    Path dir = tierDirWith("libtesseract.5.dylib", "libleptonica.6.dylib");
+    String advice = NativeProvenance.explainLinkFailure();
+    assertTrue(advice.contains(dir.toString()));
+    assertTrue(advice.contains("libtesseract.5.dylib"));
+    assertTrue(advice.contains("libleptonica.6.dylib"));
+  }
+
+  @Test
+  public void versionedOnlyPayloadExplainsTheExactNameMiss() throws Exception {
+    tierDirWith("libtesseract.5.dylib", "libleptonica.6.dylib");
+    String advice = NativeProvenance.explainLinkFailure();
+    // The whole point: say why reinstalling will not help.
+    assertTrue(advice.contains(System.mapLibraryName("tesseract")));
+    assertTrue(advice.contains("Reinstalling will not change that"));
+  }
+
+  @Test
+  public void unversionedAliasPresentSuppressesTheNote() throws Exception {
+    tierDirWith("libtesseract.5.dylib", System.mapLibraryName("tesseract"));
+    String advice = NativeProvenance.explainLinkFailure();
+    assertFalse(advice.contains("Reinstalling will not change that"));
+  }
+
+  @Test
+  public void emptyPayloadIsReportedAsSuch() throws Exception {
+    tierDirWith();
+    String advice = NativeProvenance.explainLinkFailure();
+    assertTrue(advice.contains("contains no tesseract/leptonica library"));
+  }
+
+  @Test
+  public void unverifiedUntilAnOcrCallHasBeenObserved() {
+    // Must never read as "fine" merely because nothing has been checked yet.
+    assertFalse(NativeProvenance.isBindingVerified());
+  }
+}

--- a/API/src/test/java/org/sikuli/support/NativeProvenanceTest.java
+++ b/API/src/test/java/org/sikuli/support/NativeProvenanceTest.java
@@ -200,10 +200,10 @@ public class NativeProvenanceTest {
     java.util.List<String> forA = NativeProvenance.missingAliases(a);
     assertFalse(forA.isEmpty(), "fixture should need aliases");
 
-    // Re-point the field, exactly as a lazy static init would, then create.
+    // Re-point the field, exactly as a lazy static init would, then create against the captured
+    // path rather than whatever the field now says.
     NativeProvenance.recordExtraction(b);
-    NativeProvenance.recordExtraction(a);
-    NativeProvenance.createAliases();
+    NativeProvenance.createAliases(a);
 
     for (String alias : forA) {
       assertTrue(Files.exists(a.resolve(alias)), "alias " + alias + " belongs in the recorded dir");

--- a/IDE/src/main/java/org/sikuli/ide/SikulixIDE.java
+++ b/IDE/src/main/java/org/sikuli/ide/SikulixIDE.java
@@ -10,6 +10,7 @@ import org.sikuli.basics.*;
 import org.sikuli.idesupport.IDEDesktopSupport;
 import org.sikuli.idesupport.IDETaskbarSupport;
 import org.sikuli.support.FileManager;
+import org.sikuli.support.NativeProvenance;
 import org.sikuli.support.ide.ExtensionManager;
 import org.sikuli.support.ide.IButton;
 import org.sikuli.support.ide.IDESupport;
@@ -458,6 +459,51 @@ public class SikulixIDE extends JFrame {
     Commons.startLog(3, "IDE ready: on Java %d (%4.1f sec)", Commons.getJavaVersion(), Commons.getSinceStart());
   }
 
+  /**
+   * Offers to add the missing OCR native links, when the user has not already answered.
+   *
+   * <p>The API decides <em>what</em> is needed (see {@code NativeProvenance}); this only asks. Runs
+   * once the window is up rather than during startup, so the first thing a user sees is the IDE
+   * and not a dialog about shared libraries. Silent unless there is something to fix — on a
+   * healthy install this is a directory listing and nothing more.
+   */
+  private static void offerOcrAliasRepair() {
+    try {
+      if (PreferencesUser.get().getOcrAliasPolicy() != PreferencesUser.OCR_ALIAS_ASK
+          || NativeProvenance.missingAliases().isEmpty()) {
+        return;
+      }
+      JCheckBox remember = new JCheckBox(SikuliIDEI18N._I("msgOcrAliasRemember"), true);
+      Object[] message = {SikuliIDEI18N._I("msgOcrAliasExplain"), remember};
+      Object[] options = {
+          SikuliIDEI18N._I("btnOcrAliasRepair"),
+          SikuliIDEI18N._I("btnOcrAliasNotNow"),
+          SikuliIDEI18N._I("btnOcrAliasNever")};
+      int choice = JOptionPane.showOptionDialog(ideWindow, message,
+          SikuliIDEI18N._I("dlgOcrAliasTitle"), JOptionPane.DEFAULT_OPTION,
+          JOptionPane.QUESTION_MESSAGE, null, options, options[0]);
+      if (choice == 0) {
+        // Remembering matters more than the one-off repair: the cache is keyed by version, so the
+        // links are gone again after the next update unless we are allowed to re-add them.
+        if (remember.isSelected()) {
+          PreferencesUser.get().setOcrAliasPolicy(PreferencesUser.OCR_ALIAS_AUTO);
+        }
+        int made = NativeProvenance.createAliases();
+        if (made > 0) {
+          Commons.startLog(3, "[OculiX] %s", SikuliIDEI18N._I("msgOcrAliasDone"));
+        }
+      } else if (choice == 2) {
+        PreferencesUser.get().setOcrAliasPolicy(PreferencesUser.OCR_ALIAS_NEVER);
+        Commons.startLog(3, "[OculiX] %s\n%s", SikuliIDEI18N._I("msgOcrAliasDeclined"),
+            NativeProvenance.manualCommand());
+      }
+      // "Not now" and a closed dialog both leave the preference alone, so the offer returns next
+      // start. Declining once should not be treated as declining forever.
+    } catch (Throwable e) {
+      Commons.startLog(3, "[OculiX] OCR alias offer skipped: %s", e.getMessage());
+    }
+  }
+
   public static void showAfterStart() {
     while (!ideIsReady.get()) {
       Commons.pause(100);
@@ -470,6 +516,7 @@ public class SikulixIDE extends JFrame {
     if (!sikulixIDE.contexts.isEmpty()) {
       sikulixIDE.getActiveContext().focus();
     }
+    offerOcrAliasRepair();
     if (Sikulix.shouldExecuteOnStart) {
       // Mirrors the -r flow at Sikulix.start verbatim — same loadOpenCV +
       // resolveRelativeFiles + runScripts sequence — minus the

--- a/IDE/src/main/java/org/sikuli/ide/SikulixIDE.java
+++ b/IDE/src/main/java/org/sikuli/ide/SikulixIDE.java
@@ -469,8 +469,11 @@ public class SikulixIDE extends JFrame {
    */
   private static void offerOcrAliasRepair() {
     try {
+      // Captured once: a user sits between the check and the repair, which is the longest window
+      // this pattern can have, and the field it would otherwise re-read is mutable static state.
+      java.nio.file.Path tierDir = NativeProvenance.getExtractionDir();
       if (PreferencesUser.get().getOcrAliasPolicy() != PreferencesUser.OCR_ALIAS_ASK
-          || NativeProvenance.missingAliases().isEmpty()) {
+          || NativeProvenance.missingAliases(tierDir).isEmpty()) {
         return;
       }
       JCheckBox remember = new JCheckBox(SikuliIDEI18N._I("msgOcrAliasRemember"), true);
@@ -488,14 +491,14 @@ public class SikulixIDE extends JFrame {
         if (remember.isSelected()) {
           PreferencesUser.get().setOcrAliasPolicy(PreferencesUser.OCR_ALIAS_AUTO);
         }
-        int made = NativeProvenance.createAliases();
+        int made = NativeProvenance.createAliases(tierDir);
         if (made > 0) {
           Commons.startLog(3, "[OculiX] %s", SikuliIDEI18N._I("msgOcrAliasDone"));
         }
       } else if (choice == 2) {
         PreferencesUser.get().setOcrAliasPolicy(PreferencesUser.OCR_ALIAS_NEVER);
         Commons.startLog(3, "[OculiX] %s\n%s", SikuliIDEI18N._I("msgOcrAliasDeclined"),
-            NativeProvenance.manualCommand());
+            NativeProvenance.manualCommand(tierDir));
       }
       // "Not now" and a closed dialog both leave the preference alone, so the offer returns next
       // start. Declining once should not be treated as declining forever.

--- a/IDE/src/main/resources/i18n/IDE_en_US.properties
+++ b/IDE/src/main/resources/i18n/IDE_en_US.properties
@@ -561,3 +561,13 @@ prefMoreTextSearch=allow searching for text
 prefMoreTextOCR=allow OCR
 prefMoreScripter=Activate the new layout (X-1.0) *  (no CommandBar, MessageArea on right side)
 prefMoreLblTitle1=* these prefs need a restart of the IDE - others are active after save (no restart needed)
+
+# OCR native alias repair (offered when the bundled libraries lack the unversioned name JNA looks for)
+dlgOcrAliasTitle=OCR needs a small repair
+msgOcrAliasExplain=<html><p width='420'>The bundled Tesseract libraries are installed, but they carry version numbers in their filenames and OCR looks for the plain name. Until that is bridged, OCR will not run.<br><br>OculiX can add the missing links in its own cache folder. Nothing is downloaded and nothing outside that folder is touched.</p></html>
+msgOcrAliasRemember=Do this automatically after updates
+btnOcrAliasRepair=Add the links
+btnOcrAliasNotNow=Not now
+btnOcrAliasNever=Never
+msgOcrAliasDone=OCR libraries linked — OCR is ready to use.
+msgOcrAliasDeclined=Leaving the OCR libraries as they are. The console shows the commands to do this by hand.


### PR DESCRIPTION
> **Stacked on #463** — contains that commit as well. Merge #463 first; this diff is the second commit only.

## Why

#463 detects that the bundled natives lack the unversioned filename JNA's exact-name lookup asks for. That diagnosis doesn't help a user whose OCR is broken *today*, and the repair is a single symlink.

## The choice is the user's

This writes into a cache directory OculiX did not create, and people hold views about that. So it's a stored three-state preference rather than a silent side effect:

| `OCR_ALIAS_POLICY` | behaviour |
|---|---|
| `ASK` (default) | the IDE prompts once and remembers the answer |
| `AUTO` | re-assert at every startup, silently |
| `NEVER` | never write — but still print the exact `ln -s` command |

`NEVER` printing the command is deliberate: declining should never leave someone worse off than not being asked.

## Why every startup, not once at install

The cache is keyed by version, so an upgrade extracts a fresh directory and any alias made earlier is gone. Same reason a package manager re-points its `latest` link after each build instead of assuming it holds. The check is idempotent and near-free — and if Legerix ever ships these aliases itself, it quietly does nothing.

## Which aliases, and why the rules aren't symmetric

Measured across macOS arm64, both Linux x86-64 tiers and native Windows:

- **Unversioned only** for the JNA lookup. A versioned alias satisfies `isVersionedName`, enters JNA's version-pooling fallback and competes with whatever the distro ships — reintroducing the bug it is meant to fix.
- **Linux additionally needs versioned `liblept.so.5`**, because the bundled tesseract's ELF `NEEDED` is that literal string and no file of that name exists. Safe *only alongside* the unversioned link, which wins the exact-name pass first so the pool is never reached.
- **Windows is excluded.** tess4j binds fully versioned names it ships itself, so the lookup never happens — and NTFS symlinks would need admin or Developer Mode.

Aliases always target the real versioned library, never another alias: the directory scan uses `NOFOLLOW_LINKS`, so a link created earlier in the same pass can't become a later one's target and leave a chain that breaks when the middle link goes.

## Verification — Linux results measured on a Linux host, not inferred here

This was developed on macOS, where `runningLinux()` is false and the Linux path cannot be exercised at all. Every Linux claim below was measured in situ on Ubuntu 24.04 against the shipped `v5.5.0-9` payload, and re-measured on the current head rather than carried forward:

| case | `missingAliases(dir)` |
|---|---|
| `linux-x86-64` as shipped | `[libtesseract.so, libleptonica.so, liblept.so, liblept.so.5]` |
| `linux-x86-64-legacy` | `[libtesseract.so, libleptonica.so, liblept.so]` — correctly no versioned alias |
| non-legacy, three unversioned already present | `[liblept.so.5]` |
| caller pattern, `createAliases(dir)` | 4 links, all in the intended directory |

The third row is the one that matters most: it is the population who followed earlier three-symlink advice, whose aliases exist so nothing looks missing, and who are still one file short of satisfying tesseract's ELF `NEEDED`.

The versioned name is **derived, not assumed** — read from the shipped tesseract's `DT_NEEDED` rather than hardcoded. Hardcoding `liblept.so.5` was right on three of the four Linux tiers and wrong on `linux-x86-64-legacy`, which needs no such alias. The ELF reader was validated against all eight published Linux assets and reproduces a SONAME/NEEDED matrix measured independently on two other hosts, 4 of 4.

The Mach-O branch was exercised against a real Mach-O and a real ELF in one directory: it aliases the former and ignores the latter. **The Windows branch is unexercised** — stated rather than implied.

## Design notes worth reading before the diff

On a Mac with no system tesseract, where OCR previously failed outright:

**Before**
```
Unable to load library 'tesseract':
dlopen(libtesseract.dylib, 0x0009): tried: 'libtesseract.dylib' (no such file) …
```

**After**
```
[OculiX] created OCR native alias libtesseract.dylib -> libtesseract.5.dylib
[OculiX] created OCR native alias libleptonica.dylib -> libleptonica.6.dylib
[OculiX] created OCR native alias liblept.dylib -> libleptonica.6.dylib
[OculiX] OCR native 'tesseract' -> …/darwin-aarch64/libtesseract.5.dylib (bundled)
[OculiX] OCR native 'leptonica' -> …/darwin-aarch64/libleptonica.6.dylib (bundled)
[OculiX] OCR native 'lept'      -> …/darwin-aarch64/libleptonica.6.dylib (bundled)
>>> OCR RESULT = [Hello OculiX]
>>> bindingVerified = true
```

`NativeProvenanceTest` is now 10 tests, including that no versioned alias is ever proposed for the JNA lookup, that aliases never chain, and that declining still yields a runnable command.

## The `ASK` prompt

Included, as a third commit. Shown once the window is up rather than during startup, so the first thing a user meets is the IDE and not a dialog about shared libraries — and silent unless there is something to repair.

> **OCR needs a small repair**
>
> The bundled Tesseract libraries are installed, but they carry version numbers in their filenames and OCR looks for the plain name. Until that is bridged, OCR will not run.
>
> OculiX can add the missing links in its own cache folder. Nothing is downloaded and nothing outside that folder is touched.
>
> ☑ Do this automatically after updates
>
> `[ Never ]  [ Not now ]  [ Add the links ]`

The wording deliberately avoids implementation vocabulary — no symlinks, no JNA, no unversioned filenames. It says what is broken, what OculiX proposes to do, and what it will not touch.

**Not now** leaves the preference untouched so the offer returns next start — declining once is not declining forever. **Never** stores the refusal *and* prints the `ln -s` commands.

Verified end to end on a Mac with the aliases removed and the preference reset to `ASK`: the dialog appears, "Add the links" is the default button, choosing it creates all three aliases targeting the real libraries, and `OCR_ALIAS_POLICY` is stored as `AUTO` because the checkbox was left ticked.


## What review changed, and why the API looks like this

Four rounds of review across three hosts found five defects, of which two would have shipped silently:

- **`targetFor()` filtered by extension** — `endsWith(".so")` matches neither `libtesseract.so.5` nor `libleptonica.so.6`, so the repair was **inert on every Linux tier**, and "nothing missing" is indistinguishable from "already correct". It now sniffs the object format, which is what the restriction was always for.
- **`extractionDir` is mutable static, and the first touch of `Commons` re-points it** via lazy init. Check-then-repair therefore straddled two directories — and that pattern *is* the ASK flow, with a human sitting between the check and the write. Both callers now capture the directory once and pass it everywhere.
- **The no-argument forms are gone.** Whether they misrouted depended on whether something had already initialised `Commons`, which in a shared-fork test suite means it depends on test order — a check that cannot fire, looking like a pass. Making the directory a required argument lets the compiler enforce the property instead of a comment requesting it.

Two smaller ones: byte-identical content outside the extraction directory no longer counts as verified (the question is one of path, not content), and `isBindingVerified()` can no longer return true having observed nothing — previously the normal Windows case.
