### PR TITLE
ci: delete the pull_request branch allowlists so every PR is checked

### DIFF
--- a/.github/workflows/api-compile.yml
+++ b/.github/workflows/api-compile.yml
@@ -6,6 +6,7 @@ on:
     branches:
       - master
       - release/oculix-rc
+      - chore/global-bug-fixes
     paths:
       - 'API/**'
       - 'pom.xml'

--- a/.github/workflows/api-compile.yml
+++ b/.github/workflows/api-compile.yml
@@ -3,10 +3,6 @@ name: Compile API
 on:
   workflow_dispatch:
   pull_request:
-    branches:
-      - master
-      - release/oculix-rc
-      - chore/global-bug-fixes
     paths:
       - 'API/**'
       - 'pom.xml'

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [master]
   pull_request:
-    branches: [master]
+    branches: [master, chore/global-bug-fixes]
   schedule:
     # Weekly Monday 04:17 UTC — out of business hours, low CI contention.
     - cron: '17 4 * * 1'

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches: [master]
   pull_request:
-    branches: [master, chore/global-bug-fixes]
   schedule:
     # Weekly Monday 04:17 UTC — out of business hours, low CI contention.
     - cron: '17 4 * * 1'

--- a/.github/workflows/ide-compile.yml
+++ b/.github/workflows/ide-compile.yml
@@ -3,10 +3,6 @@ name: Compile IDE
 on:
   workflow_dispatch:
   pull_request:
-    branches:
-      - master
-      - release/oculix-rc
-      - chore/global-bug-fixes
     paths:
       - 'API/**'
       - 'IDE/**'

--- a/.github/workflows/ide-compile.yml
+++ b/.github/workflows/ide-compile.yml
@@ -6,6 +6,7 @@ on:
     branches:
       - master
       - release/oculix-rc
+      - chore/global-bug-fixes
     paths:
       - 'API/**'
       - 'IDE/**'


### PR DESCRIPTION
## The gap

`api-compile`, `ide-compile` and `codeql` each carry a `branches:` **allowlist** on `pull_request`, and `chore/global-bug-fixes` is not on it:

```yaml
# api-compile.yml, ide-compile.yml
pull_request:
  branches: [master, release/oculix-rc]     # + a paths: filter

# codeql.yml
pull_request:
  branches: [master]
```

Since #450 landed, `chore/global-bug-fixes` is where feature branches are asked to merge — so PRs into it run none of those three.

## Why it is easy to miss

It looks like *passing* CI rather than *absent* CI.

Check runs attach to a commit, not to a pull request. A PR retargeted from `master` to `chore/global-bug-fixes` keeps the green ticks its earlier head already earned, while its new head runs nothing. Nothing goes red; the checks simply stop appearing, and a reviewer sees a green history above a commit that was never built.

That is not hypothetical — it happened to #455 during this work.

## What this change does

Deletes the `branches:` filter under `pull_request:` in all three workflows. Three files, nine lines removed, nothing added.

| file | removed | kept |
| --- | --- | --- |
| `.github/workflows/api-compile.yml` | the `branches:` block under `pull_request:` | the `paths:` block |
| `.github/workflows/ide-compile.yml` | the `branches:` block under `pull_request:` | the `paths:` block |
| `.github/workflows/codeql.yml` | `branches:` under `pull_request:` only | `push: branches: [master]`, `schedule`, `workflow_dispatch` |

The allowlist is the bug. Adding one branch to it would have fixed the integration branch of September 2026 and nothing else: the day that branch is renamed — and it has been renamed once already — this PR gets opened again with a new line in it. A PR should be checked whatever branch it targets.

## What it deliberately does not do

- **No `paths:` filter is added to CodeQL's `pull_request:`.** Code scanning reports stale or missing results on PRs where a path-filtered analysis is skipped. A full run on a docs-only PR is the price of results you can trust.
- **`push: branches: [master]` stays** on CodeQL. Direct pushes to other branches are a separate conversation.
- **The `paths:` filters on both compile workflows stay.** So this is necessary but not sufficient: a PR touching neither `API/**`, `IDE/**` nor `pom.xml` still runs neither compile job. That is the intended behaviour, not a leftover.
- **No macOS coverage is added.** `test-macos-launch.yml` is `workflow_dispatch:` only, so there is no automatic macOS CI on any branch. It is a hand-run diagnostic that was never promoted to CI rather than a hole in these filters, and promoting it is a runner-cost decision. Raised separately as #466; nothing here touches it.

One claim from the first version of this description was too strong: "these PRs get no CI". `ocr-perf-bench.yml` has a `paths:` filter and **no** `branches:` filter, so it already runs today on any PR touching `OCR.java`, `TextRecognizer.java` or `Commons.java`. Some CI does fire; it just happens to be the one job whose relevance depends on which files you touched.

## Verification

This PR demonstrates its own change. On its current head, targeting `chore/global-bug-fixes`, `api-compile`, `ide-compile`, `Analyze Java` and `CodeQL` all ran and passed — none of which they would have done before it. `pull_request` events evaluate the workflow from the PR's merge ref, so the change applies to the PR carrying it. The compile jobs fire because each workflow lists its own file under `paths:`; CodeQL fires because its filter is gone.

## Corrections to this description

- An earlier version said the three workflows "only fire for PRs into master". That was wrong for two of the three, which also allowed `release/oculix-rc`. The conclusion held; the mechanism given for it did not.
- The first version of this PR *added* `chore/global-bug-fixes` to the three allowlists. Rewritten after review (#465 review comment) to delete the allowlists instead, which is a smaller diff and does not need reopening the next time a branch is renamed.
